### PR TITLE
First-run Settings window with ready-to-use defaults

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,20 +1,20 @@
 # Copy this file to ".env" and fill in the key(s) for the engine(s) you'll use.
 
-# OpenAI Whisper API (default engine). https://platform.openai.com/api-keys
-OPENAI_API_KEY=sk-...
+# OpenAI key — used by the Whisper engine and "Polish with AI". https://platform.openai.com/api-keys
+OPENAI_API_KEY=
 
 # Deepgram (only needed for the streaming engine). https://console.deepgram.com/
 DEEPGRAM_API_KEY=
 
 # --- Optional first-run defaults (the tray menu overrides these afterward) ---
 # These only seed config.json on the very first launch. Change settings later
-# via the tray icon; they persist to %APPDATA%\WisprLite\config.json.
+# via the tray icon; they persist to %APPDATA%\Pipevoice\config.json.
 
 # Engine: openai | deepgram | local
-WISPRLITE_ENGINE=openai
+WISPRLITE_ENGINE=deepgram
 
 # Push-to-talk key/combo. e.g. "right ctrl", "ctrl+alt", "f9", "scroll lock"
-WISPRLITE_HOTKEY=right ctrl
+WISPRLITE_HOTKEY=ctrl+\
 
 # Mode: ptt (push-to-talk) | toggle
 WISPRLITE_MODE=ptt

--- a/installer/Pipevoice.iss
+++ b/installer/Pipevoice.iss
@@ -4,7 +4,7 @@
 ; Produces installer\Output\Pipevoice-Setup.exe — a per-user install (no admin).
 
 #define AppName "Pipevoice"
-#define AppVersion "0.3.0"
+#define AppVersion "2.1.0"
 #define AppExe "Pipevoice.exe"
 
 [Setup]
@@ -37,7 +37,7 @@ Name: "{group}\Uninstall {#AppName}"; Filename: "{uninstallexe}"
 Name: "{userstartup}\{#AppName}"; Filename: "{app}\{#AppExe}"; Tasks: startup
 
 [Tasks]
-Name: "startup"; Description: "Start {#AppName} automatically when I log in"; GroupDescription: "Startup:"
+Name: "startup"; Description: "Start {#AppName} automatically when I log in"; GroupDescription: "Startup:"; Flags: unchecked
 
 [Run]
 ; The app prompts for the API key on first launch, so just start it.

--- a/wisprlite/app.py
+++ b/wisprlite/app.py
@@ -375,6 +375,15 @@ def _setup_logging() -> None:
 
 def main() -> None:
     _setup_logging()
+    if not config.CONFIG_PATH.exists():
+        # First run: turn on start-at-login and show the settings window
+        # pre-filled with the defaults, so the user confirms engine/hotkey/keys.
+        try:
+            from . import autostart, settings
+            autostart.enable()
+            settings.main(first_run=True)
+        except Exception:
+            log.exception("first-run setup failed")
     log.info("Pipevoice starting (engine=%s)", config.Config.load().engine)
     try:
         App().run()

--- a/wisprlite/config.py
+++ b/wisprlite/config.py
@@ -55,19 +55,19 @@ _load_env()
 
 @dataclass
 class Config:
-    engine: str = "openai"          # openai | deepgram | local
+    engine: str = "deepgram"        # openai | deepgram | local
     mode: str = "ptt"               # ptt | toggle
-    hotkey: str = "right ctrl"      # any key/combo, e.g. "ctrl+alt", "f9"
+    hotkey: str = "ctrl+\\"          # any key/combo, e.g. "ctrl+alt", "f9"
     output_mode: str = "type"       # type | paste
     language: str = ""              # "" = auto-detect; else ISO code e.g. "en"
     device: str = ""                # mic index or name substring; "" = default
     openai_model: str = "whisper-1"
-    deepgram_model: str = "nova-2"
+    deepgram_model: str = "nova-3"
     local_model_size: str = "base.en"
     overlay: bool = True
-    sounds: bool = True
+    sounds: bool = False
     min_seconds: float = 0.35       # ignore taps shorter than this
-    ai_cleanup: bool = False        # polish transcript with an LLM
+    ai_cleanup: bool = True         # polish transcript with an LLM
     cleanup_model: str = "gpt-4o-mini"
     auto_enter: bool = False        # press Enter after typing (hands-free send)
     vocabulary: str = ""            # comma-separated terms to bias recognition

--- a/wisprlite/settings.py
+++ b/wisprlite/settings.py
@@ -42,13 +42,13 @@ def _input_devices():
     return items
 
 
-def main() -> None:
+def main(first_run: bool = False) -> None:
     import tkinter as tk
     from tkinter import ttk
 
     cfg = config.Config.load()
     root = tk.Tk()
-    root.title("Pipevoice settings")
+    root.title("Welcome to Pipevoice" if first_run else "Pipevoice settings")
     root.configure(bg=BG)
     root.resizable(False, False)
     ico = config.asset_path("wisprlite.ico")


### PR DESCRIPTION
On first launch, open the **Settings window pre-filled** with sensible defaults (per James's screenshot) instead of just the API-key prompt.

**Defaults** (config.py dataclass + .env.example seed, kept in sync): Deepgram (streaming), `ctrl+\` push-to-talk, nova-3, Polish-with-AI **on**, sounds **off**, overlay **on**. Empty OpenAI placeholder so the first-run key state is honest.

**First-run flow** (`app.main()`): if no config.json yet → `autostart.enable()` + `settings.main(first_run=True)` (titled *Welcome to Pipevoice*), then start normally.

**Installer**: start-on-login task set to `unchecked` so the app's HKCU-registry autostart is the single source of truth (the checkbox stays accurate); AppVersion → 2.1.0.

Tag **v2.1.0** builds the new `Pipevoice-Setup.exe`. Site download auto-points at `latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)