### PR TITLE
Coral app theme to match the site

### DIFF
--- a/installer/Pipevoice.iss
+++ b/installer/Pipevoice.iss
@@ -4,7 +4,7 @@
 ; Produces installer\Output\Pipevoice-Setup.exe — a per-user install (no admin).
 
 #define AppName "Pipevoice"
-#define AppVersion "2.2.0"
+#define AppVersion "2.3.0"
 #define AppExe "Pipevoice.exe"
 
 [Setup]

--- a/wisprlite/keyprompt.py
+++ b/wisprlite/keyprompt.py
@@ -15,7 +15,7 @@ BG = "#13151d"
 CARD = "#1b1e29"
 FG = "#e5e7eb"
 MUTED = "#94a3b8"
-ACCENT = "#34d399"
+ACCENT = "#e06c75"
 
 PROVIDER = {
     "openai": ("OpenAI", "OPENAI_API_KEY", "https://platform.openai.com/api-keys", "sk-..."),
@@ -138,7 +138,7 @@ def _dialog(cfg) -> None:
               activebackground="#262a3a", activeforeground=FG, relief="flat",
               padx=12, pady=7, font=("Segoe UI", 9)).pack(side="left", padx=(8, 0))
     save_btn = tk.Button(btns, text="Save & start", command=save, bg=ACCENT,
-                         fg="#06281c", activebackground="#2bb588", relief="flat",
+                         fg="#1a0c0d", activebackground="#e8838b", relief="flat",
                          padx=16, pady=7, font=("Segoe UI", 9, "bold"))
     save_btn.pack(side="right")
     entry.bind("<Return>", save)

--- a/wisprlite/overlay.py
+++ b/wisprlite/overlay.py
@@ -22,7 +22,7 @@ WIN_W, WIN_H = 380, 68
 TRANSPARENT = "#010203"  # color key punched out to give rounded corners
 
 ACCENT = {
-    "listening": "#34d399",
+    "listening": "#e06c75",
     "transcribing": "#fbbf24",
     "error": "#f87171",
     "done": "#60a5fa",

--- a/wisprlite/settings.py
+++ b/wisprlite/settings.py
@@ -25,7 +25,7 @@ BG = "#13151d"
 CARD = "#1b1e29"
 FG = "#e5e7eb"
 MUTED = "#94a3b8"
-ACCENT = "#34d399"
+ACCENT = "#e06c75"
 
 
 def _input_devices():
@@ -70,9 +70,9 @@ def main(first_run: bool = False) -> None:
     style.configure("Head.TLabel", background=BG, foreground=ACCENT, font=("Segoe UI", 10, "bold"))
     style.configure("TButton", background=CARD, foreground=FG, padding=6)
     style.map("TButton", background=[("active", "#262a3a")])
-    style.configure("Accent.TButton", background=ACCENT, foreground="#06281c",
+    style.configure("Accent.TButton", background=ACCENT, foreground="#1a0c0d",
                     font=("Segoe UI", 9, "bold"), padding=7)
-    style.map("Accent.TButton", background=[("active", "#2bb588")])
+    style.map("Accent.TButton", background=[("active", "#e8838b")])
     style.configure("TCheckbutton", background=BG, foreground=FG)
     style.map("TCheckbutton", background=[("active", BG)])
     style.configure("TCombobox", fieldbackground=CARD, background=CARD,
@@ -87,7 +87,7 @@ def main(first_run: bool = False) -> None:
     root.option_add("*TCombobox*Listbox.background", CARD)
     root.option_add("*TCombobox*Listbox.foreground", FG)
     root.option_add("*TCombobox*Listbox.selectBackground", ACCENT)
-    root.option_add("*TCombobox*Listbox.selectForeground", "#06281c")
+    root.option_add("*TCombobox*Listbox.selectForeground", "#1a0c0d")
     style.configure("TEntry", fieldbackground=CARD, foreground=FG, insertcolor=FG)
 
     pad = dict(padx=14, pady=5, sticky="w")

--- a/wisprlite/welcome.py
+++ b/wisprlite/welcome.py
@@ -18,7 +18,7 @@ BG = "#13151d"
 CARD = "#1b1e29"
 FG = "#e5e7eb"
 MUTED = "#94a3b8"
-ACCENT = "#34d399"
+ACCENT = "#e06c75"
 
 OPENAI_URL = "https://platform.openai.com/api-keys"
 DEEPGRAM_URL = "https://console.deepgram.com/"
@@ -116,8 +116,8 @@ def show_welcome() -> bool:
     tk.Button(btns, text="I'll set up later", command=later, bg=CARD, fg=FG,
               activebackground="#262a3a", activeforeground=FG, relief="flat",
               padx=16, pady=8, font=("Segoe UI", 9)).pack(side="left")
-    tk.Button(btns, text="Get started   →", command=go, bg=ACCENT, fg="#06281c",
-              activebackground="#2bb588", relief="flat", padx=22, pady=8,
+    tk.Button(btns, text="Get started   →", command=go, bg=ACCENT, fg="#1a0c0d",
+              activebackground="#e8838b", relief="flat", padx=22, pady=8,
               font=("Segoe UI", 10, "bold")).pack(side="right")
 
     root.update_idletasks()


### PR DESCRIPTION
Unifies the app's look with pipevoice.app: swaps the Tk dialogs (key prompt, settings, welcome splash) and the overlay HUD's 'listening' pill from green (#34d399) to the site coral (#e06c75). Accent-button text -> #1a0c0d, hover -> #e8838b. Functional HUD states (transcribing/error/done/idle) unchanged. AppVersion -> 2.3.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)