### PR TITLE
Speech notes + clipboard hotkey + MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Powleads
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/installer/Pipevoice.iss
+++ b/installer/Pipevoice.iss
@@ -4,7 +4,7 @@
 ; Produces installer\Output\Pipevoice-Setup.exe — a per-user install (no admin).
 
 #define AppName "Pipevoice"
-#define AppVersion "2.4.0"
+#define AppVersion "2.5.0"
 #define AppExe "Pipevoice.exe"
 
 [Setup]

--- a/wisprlite/app.py
+++ b/wisprlite/app.py
@@ -14,7 +14,7 @@ from .audio import Recorder
 from .hotkey import HotkeyManager
 from .overlay import Overlay
 from .tray import Tray
-from .typer import apply_replacements, type_text
+from .typer import apply_replacements, copy_clipboard, type_text
 
 log = logging.getLogger("wisprlite")
 
@@ -35,13 +35,22 @@ class App:
         self.hotkeys = HotkeyManager(
             get_hotkey=lambda: self.cfg.hotkey,
             get_mode=lambda: self.cfg.mode,
-            on_start=self._on_start,
+            on_start=lambda: self._on_start(clipboard=False),
+            on_stop=self._on_stop,
+            is_paused=lambda: self.paused,
+        )
+        # second hotkey: same record flow, but the result goes to the clipboard
+        self.clip_hotkeys = HotkeyManager(
+            get_hotkey=lambda: self.cfg.clipboard_hotkey,
+            get_mode=lambda: self.cfg.mode,
+            on_start=lambda: self._on_start(clipboard=True),
             on_stop=self._on_stop,
             is_paused=lambda: self.paused,
         )
 
         self._engine = None
         self._session = None
+        self._clipboard_only = False
         self._started_at = 0.0
         self._busy = threading.Lock()
         self._stop = threading.Event()
@@ -91,9 +100,10 @@ class App:
         threading.Thread(target=work, daemon=True).start()
 
     # ---- hotkey callbacks (run on the hotkey thread) ----------------------
-    def _on_start(self) -> None:
+    def _on_start(self, clipboard: bool = False) -> None:
         if not self._busy.acquire(blocking=False):
             return  # still finishing the previous utterance
+        self._clipboard_only = clipboard
         try:
             engine = self._get_engine()
             self._session = engine.start_session(on_partial=self.overlay.set_text)
@@ -143,15 +153,19 @@ class App:
                 self.overlay.set_state("transcribing", "Polishing…")
                 from . import cleanup
 
-                polished = cleanup.clean(text, self.cfg.cleanup_model, self.cfg.language)
+                polished = cleanup.clean(text, self.cfg.cleanup_model, self.cfg.language, self.cfg.speech_notes)
                 if polished:
                     text = polished
 
             # user word-fixes, applied last so they always stick
             text = apply_replacements(text, self.cfg.replacements)
 
-            self.overlay.set_state("done", text)
-            type_text(text, self.cfg.output_mode, press_enter=self.cfg.auto_enter)
+            if self._clipboard_only:
+                copy_clipboard(text)
+                self.overlay.set_state("done", "Copied to clipboard")
+            else:
+                self.overlay.set_state("done", text)
+                type_text(text, self.cfg.output_mode, press_enter=self.cfg.auto_enter)
             self._beep(990, 60)
             self._set_icon("idle")
         finally:
@@ -345,6 +359,7 @@ class App:
         self.overlay.start()
         self.tray.start()
         self.hotkeys.start()
+        self.clip_hotkeys.start()
         self._prewarm()
         threading.Thread(target=self._watch_config, daemon=True).start()
 

--- a/wisprlite/cleanup.py
+++ b/wisprlite/cleanup.py
@@ -52,7 +52,16 @@ def _accent_clause(language: str) -> str:
     return ""
 
 
-def clean(text: str, model: str = "gpt-4o-mini", language: str = "") -> Optional[str]:
+def _notes_clause(notes: str) -> str:
+    notes = (notes or "").strip()
+    if not notes:
+        return ""
+    return (f' The speaker describes their own speech as: "{notes}". Take that into '
+            "account — correct likely mis-hearings from their accent, smooth over "
+            "stutters and repeated words, and remove their filler words.")
+
+
+def clean(text: str, model: str = "gpt-4o-mini", language: str = "", notes: str = "") -> Optional[str]:
     text = (text or "").strip()
     if not text:
         return None
@@ -64,7 +73,7 @@ def clean(text: str, model: str = "gpt-4o-mini", language: str = "") -> Optional
             model=model,
             temperature=0,
             messages=[
-                {"role": "system", "content": SYSTEM + _accent_clause(language)},
+                {"role": "system", "content": SYSTEM + _accent_clause(language) + _notes_clause(notes)},
                 {"role": "user", "content": text},
             ],
         )

--- a/wisprlite/config.py
+++ b/wisprlite/config.py
@@ -58,6 +58,7 @@ class Config:
     engine: str = "deepgram"        # openai | deepgram | local
     mode: str = "ptt"               # ptt | toggle
     hotkey: str = "ctrl+\\"          # any key/combo, e.g. "ctrl+alt", "f9"
+    clipboard_hotkey: str = "f8"    # 2nd hotkey: dictate straight to the clipboard (no typing). "" = off
     output_mode: str = "type"       # type | paste
     language: str = ""              # "" = auto-detect; else ISO code e.g. "en"
     device: str = ""                # mic index or name substring; "" = default
@@ -71,6 +72,7 @@ class Config:
     cleanup_model: str = "gpt-4o-mini"
     auto_enter: bool = False        # press Enter after typing (hands-free send)
     vocabulary: str = ""            # comma-separated terms to bias recognition
+    speech_notes: str = ""          # free text about the user's accent / speech, fed to AI cleanup
     replacements: dict = field(default_factory=dict)  # {wrong: right} post-fixes
 
     @classmethod

--- a/wisprlite/settings.py
+++ b/wisprlite/settings.py
@@ -123,6 +123,7 @@ def main(first_run: bool = False) -> None:
     mode_var = tk.StringVar(value=dict(MODES).get(cfg.mode, MODES[0][1]))
     output_var = tk.StringVar(value=dict(OUTPUTS).get(cfg.output_mode, OUTPUTS[0][1]))
     hotkey_var = tk.StringVar(value=cfg.hotkey)
+    clip_hotkey_var = tk.StringVar(value=cfg.clipboard_hotkey)
     lang_var = tk.StringVar(value=dict(LANGUAGES).get(cfg.language, LANGUAGES[0][1]))
     devices = _input_devices()
     dev_label = next((lbl for lbl, val in devices if val == cfg.device), devices[0][0])
@@ -136,6 +137,7 @@ def main(first_run: bool = False) -> None:
     auto_enter_var = tk.BooleanVar(value=cfg.auto_enter)
     vocab_var = tk.StringVar(value=cfg.vocabulary)
     fixes_var = tk.StringVar(value=", ".join(f"{k}={v}" for k, v in cfg.replacements.items()))
+    speech_notes_var = tk.StringVar(value=cfg.speech_notes)
     overlay_var = tk.BooleanVar(value=cfg.overlay)
     sounds_var = tk.BooleanVar(value=cfg.sounds)
     autostart_var = tk.BooleanVar(value=autostart.is_enabled())
@@ -184,6 +186,7 @@ def main(first_run: bool = False) -> None:
 
     cap_btn.config(command=capture)
     row += 1
+    label("Clipboard hotkey", "hold to dictate to the clipboard"); entry(clip_hotkey_var, width=20); row += 1
 
     # --- Audio ---
     header("Audio")
@@ -218,6 +221,7 @@ def main(first_run: bool = False) -> None:
                                                   sticky="w", padx=14, pady=3); row += 1
     label("Vocabulary", "names/jargon, comma-sep"); entry(vocab_var); row += 1
     label("Word fixes", "wrong=right, comma-sep"); entry(fixes_var); row += 1
+    label("Speech notes", "accent / stutter / fillers — guides AI cleanup"); entry(speech_notes_var); row += 1
 
     # --- Toggles ---
     header("Behaviour")
@@ -241,6 +245,7 @@ def main(first_run: bool = False) -> None:
         cfg.mode = value_for(mode_var, MODES)
         cfg.output_mode = value_for(output_var, OUTPUTS)
         cfg.hotkey = hotkey_var.get().strip() or "right ctrl"
+        cfg.clipboard_hotkey = clip_hotkey_var.get().strip()
         cfg.language = value_for(lang_var, LANGUAGES)
         cfg.device = dict((lbl, val) for lbl, val in devices).get(device_var.get(), "")
         cfg.openai_model = oai_var.get().strip() or "whisper-1"
@@ -251,6 +256,7 @@ def main(first_run: bool = False) -> None:
         cfg.ai_cleanup = bool(ai_cleanup_var.get())
         cfg.auto_enter = bool(auto_enter_var.get())
         cfg.vocabulary = vocab_var.get().strip()
+        cfg.speech_notes = speech_notes_var.get().strip()
         fixes = {}
         for part in fixes_var.get().split(","):
             if "=" in part:

--- a/wisprlite/typer.py
+++ b/wisprlite/typer.py
@@ -54,3 +54,16 @@ def type_text(text: str, mode: str = "type", press_enter: bool = False) -> None:
     if press_enter:
         time.sleep(0.05)
         keyboard.send("enter")
+
+
+def copy_clipboard(text: str) -> bool:
+    """Copy text to the clipboard without typing or pasting it. True on success."""
+    if not text:
+        return False
+    try:
+        import pyperclip
+
+        pyperclip.copy(text)
+        return True
+    except Exception:
+        return False


### PR DESCRIPTION
- **Speech notes**: free-text Settings field (accent / stutter / fillers) fed to the AI cleanup — covers non-native accents (e.g. Russian-accented English) the engines have no model for.
- **Clipboard hotkey**: a 2nd hotkey (default F8) that records and copies straight to the clipboard (no typing into the focused window) — dictate while looking at another window, paste later. Configurable; blank = off.
- **MIT LICENSE** (repo had none — HN's first question).
- AppVersion -> 2.5.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)