### PR TITLE
Safer default clipboard hotkey: Right Ctrl + Shift

### DIFF
--- a/installer/Pipevoice.iss
+++ b/installer/Pipevoice.iss
@@ -4,7 +4,7 @@
 ; Produces installer\Output\Pipevoice-Setup.exe — a per-user install (no admin).
 
 #define AppName "Pipevoice"
-#define AppVersion "2.5.0"
+#define AppVersion "2.5.1"
 #define AppExe "Pipevoice.exe"
 
 [Setup]

--- a/wisprlite/config.py
+++ b/wisprlite/config.py
@@ -58,7 +58,7 @@ class Config:
     engine: str = "deepgram"        # openai | deepgram | local
     mode: str = "ptt"               # ptt | toggle
     hotkey: str = "ctrl+\\"          # any key/combo, e.g. "ctrl+alt", "f9"
-    clipboard_hotkey: str = "f8"    # 2nd hotkey: dictate straight to the clipboard (no typing). "" = off
+    clipboard_hotkey: str = "right ctrl+right shift"  # 2nd hotkey -> dictate to clipboard (no typing); safe to hold. "" = off
     output_mode: str = "type"       # type | paste
     language: str = ""              # "" = auto-detect; else ISO code e.g. "en"
     device: str = ""                # mic index or name substring; "" = default

--- a/wisprlitevercel/index.html
+++ b/wisprlitevercel/index.html
@@ -349,8 +349,8 @@
       <div class="mini">
         <div class="bar"><i style="background:#e06c75;width:9px;height:9px;border-radius:50%"></i><i style="background:#e5c07b;width:9px;height:9px;border-radius:50%"></i><i style="background:#98c379;width:9px;height:9px;border-radius:50%"></i><span class="t">two keys</span></div>
         <div class="body mono">
-          <span class="dim">hold</span> <span class="ok">Ctrl + \</span>  <span class="ar">&#8594;</span> types where your cursor is<br/><br/>
-          <span class="dim">hold</span> <span class="ok">F8</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; <span class="ar">&#8594;</span> copies to your clipboard<span class="cur"></span>
+          <span class="dim">hold</span> <span class="ok">Ctrl + \</span> <span class="ar">&#8594;</span> types where your cursor is<br/><br/>
+          <span class="dim">hold</span> <span class="ok">Right Ctrl + Shift</span> <span class="ar">&#8594;</span> copies to your clipboard<span class="cur"></span>
         </div>
       </div>
       <div>
@@ -432,7 +432,7 @@
       <details><summary>Can it handle my accent?</summary>
         <p>Pick your English variant in the tray (British, US, Australian, Indian, New Zealand) and the engine switches to the matching model. For a non-native accent, a stutter, or heavy filler words, add a line of "speech notes" like "native Russian speaker" and the AI cleanup adjusts for it. The engines are trained on a wide range of accents to begin with.</p></details>
       <details><summary>Can I dictate to my clipboard instead of typing?</summary>
-        <p>Yes. A second hotkey (F8 by default) records and copies the result straight to your clipboard without typing into the focused window. Handy for giving feedback while you read one window, then pasting into another.</p></details>
+        <p>Yes. A second hotkey (Right Ctrl + Shift by default, and configurable) records and copies the result straight to your clipboard without typing into the focused window. Handy for giving feedback while you read one window, then pasting into another.</p></details>
       <details><summary>Windows says "unrecognised app" — is it safe?</summary>
         <p>Yes. That SmartScreen warning shows for any app without a paid code-signing certificate. Click <b>More info → Run anyway</b>. It's open source — read every line on <a href="https://github.com/Powleads/PipeVoice">GitHub</a>.</p></details>
       <details><summary>Is my voice uploaded anywhere?</summary>


### PR DESCRIPTION
F8 gets remapped by laptop Fn layers (screenshot, brightness, etc.), so it wasn't a safe universal default. Switched to **Right Ctrl + Shift** — two pure modifiers that never type or trigger anything when held, don't clash with the main Ctrl+\, and aren't OEM-remapped. Site (spotlight + FAQ) updated to match. v2.5.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)