### PR TITLE
Multi-provider AI cleanup: OpenAI, Gemini (free), OpenRouter, local Ollama

### DIFF
--- a/installer/Pipevoice.iss
+++ b/installer/Pipevoice.iss
@@ -4,7 +4,7 @@
 ; Produces installer\Output\Pipevoice-Setup.exe — a per-user install (no admin).
 
 #define AppName "Pipevoice"
-#define AppVersion "2.6.0"
+#define AppVersion "2.7.0"
 #define AppExe "Pipevoice.exe"
 
 [Setup]

--- a/wisprlite/app.py
+++ b/wisprlite/app.py
@@ -148,12 +148,13 @@ class App:
                 self._set_icon("idle")
                 return
 
-            # AI cleanup ("Flow mode") — needs an OpenAI key; falls back to raw.
-            if self.cfg.ai_cleanup and config.openai_key():
-                self.overlay.set_state("transcribing", "Polishing…")
-                from . import cleanup
+            # AI cleanup ("Flow mode") — OpenAI / Gemini / OpenRouter / local Ollama; falls back to raw.
+            from . import cleanup
 
-                polished = cleanup.clean(text, self.cfg.cleanup_model, self.cfg.language, self.cfg.speech_notes)
+            if self.cfg.ai_cleanup and cleanup.provider_ready(self.cfg.cleanup_provider):
+                self.overlay.set_state("transcribing", "Polishing…")
+                polished = cleanup.clean(text, self.cfg.cleanup_provider, self.cfg.cleanup_model,
+                                         self.cfg.language, self.cfg.speech_notes)
                 if polished:
                     text = polished
 

--- a/wisprlite/cleanup.py
+++ b/wisprlite/cleanup.py
@@ -1,15 +1,19 @@
 """AI cleanup ("Flow mode"): polish a raw dictation transcript with an LLM.
 
-Removes fillers/false starts, fixes grammar, punctuation and obvious
-speech-to-text slips, without changing meaning or following any instructions
-embedded in the speech. Optionally accent-aware (keeps regional spelling and
-fixes accent mis-hears). Needs an OpenAI key. Returns None on any failure so the
-caller can fall back to the raw text.
+Provider-flexible. OpenAI, Google Gemini, OpenRouter, and a local Ollama model
+all speak the OpenAI chat-completions API, so the same client points at any of
+them by swapping base_url / key / model. That means the polish can be free
+(Gemini free tier or OpenRouter free models) or fully local/offline (Ollama).
+
+It removes fillers/false starts, fixes grammar, punctuation and obvious
+speech-to-text slips, and is optionally accent-aware. Returns None on any
+failure so the caller falls back to the raw text.
 """
 
 from __future__ import annotations
 
 import logging
+import os
 from typing import Optional
 
 log = logging.getLogger("wisprlite")
@@ -32,6 +36,16 @@ _ACCENTS = {
     "en-AU": "Australian English",
     "en-IN": "Indian English",
     "en-NZ": "New Zealand English",
+}
+
+# provider -> (base_url, API-key env var, default model). All OpenAI-compatible.
+PROVIDERS = {
+    "openai": (None, "OPENAI_API_KEY", "gpt-4o-mini"),
+    "gemini": ("https://generativelanguage.googleapis.com/v1beta/openai/",
+               "GEMINI_API_KEY", "gemini-2.0-flash"),
+    "openrouter": ("https://openrouter.ai/api/v1",
+                   "OPENROUTER_API_KEY", "google/gemini-2.0-flash-exp:free"),
+    "ollama": ("http://localhost:11434/v1", None, "llama3.2:3b"),
 }
 
 
@@ -61,14 +75,35 @@ def _notes_clause(notes: str) -> str:
             "stutters and repeated words, and remove their filler words.")
 
 
-def clean(text: str, model: str = "gpt-4o-mini", language: str = "", notes: str = "") -> Optional[str]:
+def provider_ready(provider: str) -> bool:
+    """True if the chosen cleanup provider is usable (key present, or local)."""
+    _, key_env, _ = PROVIDERS.get(provider, PROVIDERS["openai"])
+    if key_env is None:
+        return True  # local Ollama needs no key
+    return bool(os.getenv(key_env, "").strip())
+
+
+def clean(text: str, provider: str = "openai", model: str = "",
+          language: str = "", notes: str = "") -> Optional[str]:
     text = (text or "").strip()
     if not text:
         return None
+    base_url, key_env, default_model = PROVIDERS.get(provider, PROVIDERS["openai"])
+    model = (model or "").strip() or default_model
+    if key_env:
+        api_key = os.getenv(key_env, "").strip()
+        if not api_key:
+            log.warning("AI cleanup: no API key for provider %s", provider)
+            return None
+    else:
+        api_key = "ollama"  # local Ollama ignores it, but the client needs something
     try:
         from openai import OpenAI
 
-        client = OpenAI()
+        kwargs = {"api_key": api_key}
+        if base_url:
+            kwargs["base_url"] = base_url
+        client = OpenAI(**kwargs)
         resp = client.chat.completions.create(
             model=model,
             temperature=0,
@@ -80,5 +115,5 @@ def clean(text: str, model: str = "gpt-4o-mini", language: str = "", notes: str 
         out = (resp.choices[0].message.content or "").strip()
         return out or None
     except Exception as exc:
-        log.warning("AI cleanup failed, using raw text: %s", exc)
+        log.warning("AI cleanup failed (%s), using raw text: %s", provider, exc)
         return None

--- a/wisprlite/config.py
+++ b/wisprlite/config.py
@@ -69,7 +69,8 @@ class Config:
     sounds: bool = False
     min_seconds: float = 0.35       # ignore taps shorter than this
     ai_cleanup: bool = True         # polish transcript with an LLM
-    cleanup_model: str = "gpt-4o-mini"
+    cleanup_provider: str = "openai"  # openai | gemini | openrouter | ollama (all OpenAI-compatible)
+    cleanup_model: str = ""           # blank = the provider's default model
     auto_enter: bool = False        # press Enter after typing (hands-free send)
     vocabulary: str = ""            # comma-separated terms to bias recognition
     speech_notes: str = ""          # free text about the user's accent / speech, fed to AI cleanup
@@ -154,6 +155,14 @@ def openai_key() -> str:
 
 def deepgram_key() -> str:
     return os.getenv("DEEPGRAM_API_KEY", "").strip()
+
+
+def gemini_key() -> str:
+    return os.getenv("GEMINI_API_KEY", "").strip()
+
+
+def openrouter_key() -> str:
+    return os.getenv("OPENROUTER_API_KEY", "").strip()
 
 
 def device_arg(cfg: Config):

--- a/wisprlite/settings.py
+++ b/wisprlite/settings.py
@@ -11,13 +11,15 @@ from __future__ import annotations
 
 import threading
 
-from . import autostart, config
+from . import autostart, cleanup, config
 
 ENGINES = [("openai", "OpenAI Whisper  (cloud)"),
            ("deepgram", "Deepgram  (streaming)"),
            ("local", "Local Whisper  (offline)")]
 MODES = [("ptt", "Push-to-talk (hold)"), ("toggle", "Toggle (tap on/off)")]
 OUTPUTS = [("type", "Type keystrokes"), ("paste", "Clipboard + Ctrl+V")]
+CLEANUP_PROVIDERS = [("openai", "OpenAI"), ("gemini", "Google Gemini (free tier)"),
+                     ("openrouter", "OpenRouter (free models)"), ("ollama", "Local — Ollama (offline)")]
 LOCAL_SIZES = ["tiny.en", "base.en", "small.en", "medium.en",
                "tiny", "base", "small", "medium", "large-v3"]
 LANGUAGES = [
@@ -143,7 +145,11 @@ def main(first_run: bool = False) -> None:
     local_var = tk.StringVar(value=cfg.local_model_size)
     oai_key_var = tk.StringVar()
     dg_key_var = tk.StringVar()
+    gem_key_var = tk.StringVar()
+    or_key_var = tk.StringVar()
     ai_cleanup_var = tk.BooleanVar(value=cfg.ai_cleanup)
+    cleanup_var = tk.StringVar(value=dict(CLEANUP_PROVIDERS).get(cfg.cleanup_provider, CLEANUP_PROVIDERS[0][1]))
+    cleanup_model_var = tk.StringVar(value=cfg.cleanup_model)
     auto_enter_var = tk.BooleanVar(value=cfg.auto_enter)
     vocab_var = tk.StringVar(value=cfg.vocabulary)
     fixes_var = tk.StringVar(value=", ".join(f"{k}={v}" for k, v in cfg.replacements.items()))
@@ -241,15 +247,26 @@ def main(first_run: bool = False) -> None:
     label("Deepgram key", "saved" if config.deepgram_key() else "not set")
     e_dg = ttk.Entry(frm, textvariable=dg_key_var, width=29, show="•")
     e_dg.grid(row=row, column=1, padx=6, pady=5, sticky="w"); row += 1
+    label("Gemini key", "saved" if config.gemini_key() else "not set")
+    ttk.Entry(frm, textvariable=gem_key_var, width=29, show="•").grid(row=row, column=1, padx=6, pady=5, sticky="w"); row += 1
+    label("OpenRouter key", "saved" if config.openrouter_key() else "not set")
+    ttk.Entry(frm, textvariable=or_key_var, width=29, show="•").grid(row=row, column=1, padx=6, pady=5, sticky="w"); row += 1
     ttk.Label(frm, text="Leave a key blank to keep the current one.",
               style="Muted.TLabel").grid(row=row, column=0, columnspan=3,
                                           sticky="w", padx=14); row += 1
 
     # --- Transcription ---
     header("Transcription")
-    ttk.Checkbutton(frm, text="Polish with AI (Flow mode — needs OpenAI key)",
+    ttk.Checkbutton(frm, text="Polish with AI (Flow mode — tidies fillers & punctuation)",
                     variable=ai_cleanup_var).grid(row=row, column=0, columnspan=3,
                                                   sticky="w", padx=14, pady=3); row += 1
+    label("Cleanup with"); combo(cleanup_var, [l for _, l in CLEANUP_PROVIDERS], width=24); row += 1
+    label("Cleanup model", "blank = provider default"); entry(cleanup_model_var); row += 1
+
+    def _on_cleanup_provider(*_):
+        prov = value_for(cleanup_var, CLEANUP_PROVIDERS)
+        cleanup_model_var.set(cleanup.PROVIDERS.get(prov, cleanup.PROVIDERS["openai"])[2])
+    cleanup_var.trace_add("write", _on_cleanup_provider)
     ttk.Checkbutton(frm, text="Press Enter after typing (auto-send)",
                     variable=auto_enter_var).grid(row=row, column=0, columnspan=3,
                                                   sticky="w", padx=14, pady=3); row += 1
@@ -288,6 +305,8 @@ def main(first_run: bool = False) -> None:
         cfg.overlay = bool(overlay_var.get())
         cfg.sounds = bool(sounds_var.get())
         cfg.ai_cleanup = bool(ai_cleanup_var.get())
+        cfg.cleanup_provider = value_for(cleanup_var, CLEANUP_PROVIDERS)
+        cfg.cleanup_model = cleanup_model_var.get().strip()
         cfg.auto_enter = bool(auto_enter_var.get())
         cfg.vocabulary = vocab_var.get().strip()
         cfg.speech_notes = speech_notes_var.get().strip()
@@ -304,6 +323,10 @@ def main(first_run: bool = False) -> None:
             config.save_api_key("OPENAI_API_KEY", oai_key_var.get())
         if dg_key_var.get().strip():
             config.save_api_key("DEEPGRAM_API_KEY", dg_key_var.get())
+        if gem_key_var.get().strip():
+            config.save_api_key("GEMINI_API_KEY", gem_key_var.get())
+        if or_key_var.get().strip():
+            config.save_api_key("OPENROUTER_API_KEY", or_key_var.get())
         try:
             if autostart_var.get():
                 autostart.enable()


### PR DESCRIPTION
The 'Polish with AI' pass no longer requires an OpenAI key. All four providers speak the OpenAI chat API, so the same client points at any of them:
- **Google Gemini** (free tier — most people have a Google account)
- **OpenRouter** (free models)
- **Local Ollama** (fully offline, no key, no cost)
- **OpenAI** (default)

Settings gets a 'Cleanup with' dropdown + a cleanup model field + Gemini/OpenRouter key fields. v2.7.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)