### PR TITLE
Auto-update (v2.8.0): in-app updater + in-place upgrades

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,6 +45,12 @@ jobs:
       - name: Build installer
         run: '& "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" installer\Pipevoice.iss'
 
+      - name: Compute SHA-256
+        shell: pwsh
+        run: |
+          $h = (Get-FileHash installer/Output/Pipevoice-Setup.exe -Algorithm SHA256).Hash.ToLower()
+          [System.IO.File]::WriteAllText("installer/Output/Pipevoice-Setup.exe.sha256", $h)
+
       - name: Upload installer artifact
         uses: actions/upload-artifact@v4
         with:
@@ -55,5 +61,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/v')
         uses: softprops/action-gh-release@v2
         with:
-          files: installer/Output/Pipevoice-Setup.exe
+          files: |
+            installer/Output/Pipevoice-Setup.exe
+            installer/Output/Pipevoice-Setup.exe.sha256
           generate_release_notes: true

--- a/installer/Pipevoice.iss
+++ b/installer/Pipevoice.iss
@@ -4,10 +4,11 @@
 ; Produces installer\Output\Pipevoice-Setup.exe — a per-user install (no admin).
 
 #define AppName "Pipevoice"
-#define AppVersion "2.7.0"
+#define AppVersion "2.8.0"
 #define AppExe "Pipevoice.exe"
 
 [Setup]
+AppId={{41C3C77C-2125-40AF-AE40-5AAC67809491}
 AppName={#AppName}
 AppVersion={#AppVersion}
 AppPublisher=Pipevoice
@@ -20,6 +21,8 @@ OutputBaseFilename={#AppName}-Setup
 Compression=lzma2
 SolidCompression=yes
 WizardStyle=modern
+CloseApplications=yes
+RestartApplications=yes
 SetupIconFile=..\assets\wisprlite.ico
 UninstallDisplayIcon={app}\{#AppExe}
 
@@ -41,7 +44,7 @@ Name: "startup"; Description: "Start {#AppName} automatically when I log in"; Gr
 
 [Run]
 ; The app prompts for the API key on first launch, so just start it.
-Filename: "{app}\{#AppExe}"; Description: "Launch {#AppName}"; Flags: nowait postinstall skipifsilent
+Filename: "{app}\{#AppExe}"; Description: "Launch {#AppName}"; Flags: nowait postinstall
 
 [UninstallDelete]
 Type: filesandordirs; Name: "{userappdata}\{#AppName}"

--- a/wisprlite/__init__.py
+++ b/wisprlite/__init__.py
@@ -1,3 +1,3 @@
 """Pipevoice — push-to-talk voice typing for Windows."""
 
-__version__ = "0.3.0"
+__version__ = "2.8.0"

--- a/wisprlite/app.py
+++ b/wisprlite/app.py
@@ -253,6 +253,33 @@ class App:
             self._fail(f"autostart: {exc}")
         self.tray.update()
 
+    def _notify(self, msg: str) -> None:
+        try:
+            if self.tray is not None and self.tray.icon is not None:
+                self.tray.icon.notify(msg, "Pipevoice")
+                return
+        except Exception:
+            pass
+        print(msg)
+
+    def check_for_updates(self, manual: bool = False) -> None:
+        def work():
+            try:
+                from . import updater
+                info = updater.check()
+                if not info:
+                    if manual:
+                        self._notify("Pipevoice is up to date.")
+                    return
+                self._notify(f"Updating Pipevoice to {info['version']}…")
+                if updater.download_and_run(info):
+                    self.quit()
+                elif manual:
+                    self._notify("Update download failed — try again later.")
+            except Exception as exc:
+                log.warning("update flow failed: %s", exc)
+        threading.Thread(target=work, daemon=True).start()
+
     def quit(self) -> None:
         self._stop.set()
         self.hotkeys.stop()
@@ -363,6 +390,13 @@ class App:
         self.clip_hotkeys.start()
         self._prewarm()
         threading.Thread(target=self._watch_config, daemon=True).start()
+        try:
+            from . import updater
+            updater.cleanup_old()
+        except Exception:
+            pass
+        if self.cfg.auto_update:
+            self.check_for_updates(manual=False)
 
         print("Pipevoice running.")
         print(f"  Engine: {self.cfg.engine}   Mode: {self.cfg.mode}   Hotkey: [{self.cfg.hotkey}]")

--- a/wisprlite/config.py
+++ b/wisprlite/config.py
@@ -67,6 +67,7 @@ class Config:
     local_model_size: str = "base.en"
     overlay: bool = True
     sounds: bool = False
+    auto_update: bool = True         # check GitHub for a newer release on startup and install it
     min_seconds: float = 0.35       # ignore taps shorter than this
     ai_cleanup: bool = True         # polish transcript with an LLM
     cleanup_provider: str = "openai"  # openai | gemini | openrouter | ollama (all OpenAI-compatible)

--- a/wisprlite/settings.py
+++ b/wisprlite/settings.py
@@ -157,6 +157,7 @@ def main(first_run: bool = False) -> None:
     overlay_var = tk.BooleanVar(value=cfg.overlay)
     sounds_var = tk.BooleanVar(value=cfg.sounds)
     autostart_var = tk.BooleanVar(value=autostart.is_enabled())
+    auto_update_var = tk.BooleanVar(value=cfg.auto_update)
 
     def combo(var, options, width=26):
         c = ttk.Combobox(frm, textvariable=var, values=options, state="readonly", width=width)
@@ -282,6 +283,8 @@ def main(first_run: bool = False) -> None:
         row=row, column=0, columnspan=2, sticky="w", padx=14, pady=3); row += 1
     ttk.Checkbutton(frm, text="Start on Windows login", variable=autostart_var).grid(
         row=row, column=0, columnspan=2, sticky="w", padx=14, pady=3); row += 1
+    ttk.Checkbutton(frm, text="Automatic updates (check on startup)", variable=auto_update_var).grid(
+        row=row, column=0, columnspan=2, sticky="w", padx=14, pady=3); row += 1
 
     # --- Buttons ---
     status = ttk.Label(frm, text="", style="Muted.TLabel")
@@ -304,6 +307,7 @@ def main(first_run: bool = False) -> None:
         cfg.local_model_size = local_var.get().strip() or "base.en"
         cfg.overlay = bool(overlay_var.get())
         cfg.sounds = bool(sounds_var.get())
+        cfg.auto_update = bool(auto_update_var.get())
         cfg.ai_cleanup = bool(ai_cleanup_var.get())
         cfg.cleanup_provider = value_for(cleanup_var, CLEANUP_PROVIDERS)
         cfg.cleanup_model = cleanup_model_var.get().strip()

--- a/wisprlite/tray.py
+++ b/wisprlite/tray.py
@@ -97,6 +97,7 @@ class Tray:
             Item("Paused", lambda i, it: app.toggle_pause(),
                  checked=lambda it: app.paused),
             Menu.SEPARATOR,
+            Item("Check for updates…", lambda i, it: app.check_for_updates(manual=True)),
             Item("Quit", lambda i, it: app.quit()),
         )
 

--- a/wisprlite/updater.py
+++ b/wisprlite/updater.py
@@ -1,0 +1,128 @@
+"""Lightweight self-updater.
+
+Checks the GitHub Releases API for a newer Pipevoice-Setup.exe, downloads it,
+verifies its SHA-256, and runs it silently so the existing per-user Inno Setup
+installer upgrades in place (Windows Restart Manager closes + relaunches the
+app). No new dependencies, no server, no admin/UAC (per-user install).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import subprocess
+import urllib.request
+
+from . import __version__, config
+
+log = logging.getLogger("wisprlite")
+
+REPO = "Powleads/PipeVoice"
+API = f"https://api.github.com/repos/{REPO}/releases/latest"
+ASSET = "Pipevoice-Setup.exe"
+_UA = {"User-Agent": "Pipevoice-updater"}
+
+
+def _parse_version(v: str) -> tuple:
+    v = (v or "").lstrip("vV").strip()
+    parts = []
+    for p in v.split("."):
+        digits = "".join(ch for ch in p if ch.isdigit())
+        parts.append(int(digits) if digits else 0)
+    while len(parts) < 3:
+        parts.append(0)
+    return tuple(parts[:3])
+
+
+def check() -> dict | None:
+    """Return {'version','tag','url','sha256'} if a newer release exists, else None."""
+    try:
+        req = urllib.request.Request(API, headers={**_UA, "Accept": "application/vnd.github+json"})
+        with urllib.request.urlopen(req, timeout=10) as r:
+            data = json.load(r)
+    except Exception as exc:
+        log.info("update check failed: %s", exc)
+        return None
+    tag = data.get("tag_name", "")
+    if _parse_version(tag) <= _parse_version(__version__):
+        return None
+    setup_url = sha_url = None
+    for a in data.get("assets", []):
+        name = a.get("name", "")
+        if name == ASSET:
+            setup_url = a.get("browser_download_url")
+        elif name == ASSET + ".sha256":
+            sha_url = a.get("browser_download_url")
+    if not setup_url:
+        return None
+    sha256 = ""
+    if sha_url:
+        try:
+            with urllib.request.urlopen(urllib.request.Request(sha_url, headers=_UA), timeout=10) as r:
+                sha256 = r.read().decode("utf-8", "ignore").split()[0].strip().lower()
+        except Exception:
+            sha256 = ""
+    return {"version": tag.lstrip("vV"), "tag": tag, "url": setup_url, "sha256": sha256}
+
+
+def _sha256(path: str) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest().lower()
+
+
+def download_and_run(info: dict) -> bool:
+    """Download + verify the installer, then spawn it silently. True if launched."""
+    folder = config.config_dir() / "update"
+    try:
+        folder.mkdir(parents=True, exist_ok=True)
+    except Exception:
+        pass
+    dest = str(folder / ASSET)
+    try:
+        req = urllib.request.Request(info["url"], headers=_UA)
+        with urllib.request.urlopen(req, timeout=120) as r, open(dest, "wb") as f:
+            while True:
+                chunk = r.read(65536)
+                if not chunk:
+                    break
+                f.write(chunk)
+    except Exception as exc:
+        log.warning("update download failed: %s", exc)
+        return False
+    # Verify integrity (the app is unsigned, so this is our tamper check).
+    if info.get("sha256"):
+        if _sha256(dest) != info["sha256"]:
+            log.warning("update SHA-256 mismatch; aborting")
+            try:
+                os.remove(dest)
+            except Exception:
+                pass
+            return False
+    # Let the installer (not us) close + replace + relaunch the running exe.
+    try:
+        flags = getattr(subprocess, "DETACHED_PROCESS", 0) | getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
+        subprocess.Popen(
+            [dest, "/VERYSILENT", "/SUPPRESSMSGBOXES", "/NORESTART",
+             "/CLOSEAPPLICATIONS", "/RESTARTAPPLICATIONS"],
+            creationflags=flags,
+            close_fds=True,
+        )
+        return True
+    except Exception as exc:
+        log.warning("could not launch installer: %s", exc)
+        return False
+
+
+def cleanup_old() -> None:
+    """Delete a stale downloaded installer from a previous update."""
+    try:
+        p = config.config_dir() / "update" / ASSET
+        if p.exists():
+            p.unlink()
+    except Exception:
+        pass


### PR DESCRIPTION
Users no longer need to uninstall/reinstall. The app checks GitHub Releases on startup (and via tray **Check for updates…**), downloads the signed-by-SHA installer, and lets Inno swap the running exe in place via Restart Manager.

- `updater.py` — latest-tag check, SHA-256 verify, silent `/CLOSEAPPLICATIONS /RESTARTAPPLICATIONS` install, temp cleanup
- `config.auto_update` (default on) + Settings checkbox + tray item
- installer: stable `AppId` GUID + Close/RestartApplications → true in-place upgrade
- CI publishes `Pipevoice-Setup.exe.sha256`

Tagging `v2.8.0` after merge triggers the first release the updater can pull.