### PR TITLE
Add /privacy policy page

### DIFF
--- a/wisprlitevercel/index.html
+++ b/wisprlitevercel/index.html
@@ -455,7 +455,7 @@
   <footer>
     <div class="foot-row">
       <span>Pipevoice — free, private voice typing for Windows.</span>
-      <span><a href="https://github.com/Powleads/PipeVoice">github.com/Powleads/PipeVoice ↗</a></span>
+      <span><a href="/privacy">Privacy</a> &nbsp;·&nbsp; <a href="https://github.com/Powleads/PipeVoice">github.com/Powleads/PipeVoice ↗</a></span>
     </div>
     <div class="made">
       Built by the team behind <a class="se" href="https://engine.signalsprint.io">SignalEngine</a> — agentic AI outbound for founders &amp; agencies.

--- a/wisprlitevercel/privacy.html
+++ b/wisprlitevercel/privacy.html
@@ -1,0 +1,248 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Privacy Policy — Pipevoice</title>
+<meta name="description" content="How Pipevoice handles your data. Local-first, no telemetry, no developer backend. Cloud transcription uses your own API key and goes only to the provider you choose." />
+<link rel="canonical" href="https://pipevoice.app/privacy" />
+<meta name="robots" content="index,follow" />
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='14' fill='%231b1e24'/%3E%3Crect x='26' y='15' width='12' height='23' rx='6' fill='%23e06c75'/%3E%3Cpath d='M21 32a11 11 0 0 0 22 0' stroke='%23e06c75' stroke-width='3' fill='none'/%3E%3Cline x1='32' y1='43' x2='32' y2='50' stroke='%23e06c75' stroke-width='3'/%3E%3Cline x1='24' y1='50' x2='40' y2='50' stroke='%23e06c75' stroke-width='3'/%3E%3C/svg%3E" />
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700;800&family=Geist+Mono:wght@400;500&display=swap" rel="stylesheet" />
+<style>
+  :root{
+    --canvas:#282c34; --deep:#131313; --card:#1b1e24; --popover:#20242c;
+    --border:rgba(53,90,102,.55); --border-soft:rgba(53,90,102,.28);
+    --accent:#e06c75; --accent-soft:rgba(224,108,117,.12); --accent-line:rgba(224,108,117,.55);
+    --glow:0 0 22px rgba(224,108,117,.32);
+    --good:#98c379; --warn:#e5c07b;
+    --text:#e6e8eb; --muted:#9aa1ad; --r:10px;
+    --mono:"Geist Mono",ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{scroll-behavior:smooth;overflow-x:hidden}
+  body{background:var(--canvas);color:var(--text);
+    font-family:"Geist",system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;
+    line-height:1.6;-webkit-font-smoothing:antialiased;overflow-x:hidden}
+  a{color:inherit;text-decoration:none}
+  .wrap{max-width:1080px;margin:0 auto;padding:0 24px}
+  .mono{font-family:var(--mono)}
+
+  nav{position:relative;z-index:2;display:flex;align-items:center;justify-content:space-between;padding:20px 0;
+    border-bottom:1px solid var(--border-soft)}
+  .logo{display:flex;align-items:center;gap:10px;font-weight:700;font-size:18px;letter-spacing:-.01em}
+  .logo svg{width:30px;height:30px}
+  .nav-links{display:flex;gap:26px;align-items:center;color:var(--muted);font-size:14.5px}
+  .nav-links a:hover{color:var(--text)}
+  .nav-links .gh{color:var(--text)}
+
+  /* legal prose */
+  .legal{max-width:760px;margin:0 auto;padding:54px 24px 16px}
+  .legal h1{font-size:clamp(32px,5vw,46px);letter-spacing:-.025em;font-weight:800;line-height:1.05}
+  .legal .updated{color:var(--muted);font-family:var(--mono);font-size:13px;margin:14px 0 8px}
+  .legal .intro{color:var(--text);font-size:17px;margin:18px 0 6px}
+  .legal h2{font-size:clamp(22px,3vw,27px);font-weight:800;letter-spacing:-.015em;
+    margin:42px 0 6px;padding-top:24px;border-top:1px solid var(--border-soft)}
+  .legal h3{font-size:17px;font-weight:600;margin:26px 0 6px;color:var(--text)}
+  .legal p{color:var(--muted);margin:11px 0;font-size:15.5px}
+  .legal ul{color:var(--muted);margin:11px 0;padding-left:22px}
+  .legal li{margin:8px 0;font-size:15.5px}
+  .legal li::marker{color:var(--accent-line)}
+  .legal strong{color:var(--text);font-weight:600}
+  .legal code{font-family:var(--mono);font-size:12.5px;background:var(--popover);
+    border:1px solid var(--border-soft);border-radius:6px;padding:1px 6px;color:var(--text);white-space:nowrap}
+  .legal a{color:var(--accent)}
+  .legal a:hover{text-decoration:underline}
+  .tldr{background:var(--card);border:1px solid var(--accent-line);border-radius:14px;
+    padding:22px 24px;margin:26px 0 8px;box-shadow:var(--glow)}
+  .tldr ul{margin:0;padding-left:20px}
+  .tldr li{color:var(--muted)}
+
+  footer{border-top:1px solid var(--border-soft);margin-top:40px;padding:34px 0 40px;color:var(--muted);font-size:13.5px;font-family:var(--mono)}
+  .foot-row{display:flex;justify-content:space-between;flex-wrap:wrap;gap:10px}
+  footer a:hover{color:var(--accent)}
+  .made{margin-top:20px;padding-top:18px;border-top:1px solid var(--border-soft)}
+  .made a{color:var(--text)} .made a:hover{color:var(--accent)}
+  .made .se{color:var(--accent)}
+</style>
+</head>
+<body>
+<div class="wrap">
+  <nav>
+    <a class="logo" href="/">
+      <svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+        <rect width="64" height="64" rx="14" fill="#1b1e24" stroke="rgba(53,90,102,.55)"/>
+        <rect x="26" y="15" width="12" height="23" rx="6" fill="#e06c75"/>
+        <path d="M21 32a11 11 0 0 0 22 0" stroke="#e06c75" stroke-width="3" fill="none" stroke-linecap="round"/>
+        <line x1="32" y1="43" x2="32" y2="50" stroke="#e06c75" stroke-width="3" stroke-linecap="round"/>
+        <line x1="24" y1="50" x2="40" y2="50" stroke="#e06c75" stroke-width="3" stroke-linecap="round"/>
+      </svg>
+      Pipevoice
+    </a>
+    <div class="nav-links">
+      <a href="/">Home</a>
+      <a class="gh" href="https://github.com/Powleads/PipeVoice">GitHub ↗</a>
+    </div>
+  </nav>
+
+  <main class="legal">
+    <h1>Privacy Policy</h1>
+    <p class="updated">Last updated: 20 June 2026</p>
+    <p class="intro">Pipevoice is a free, open-source, push-to-talk voice-typing app for Windows. This policy explains exactly what happens to your data when you use the app and the website at pipevoice.app. The short version: Pipevoice is local-first, the desktop app talks to no server of ours, and we receive none of your data from the app.</p>
+
+    <div class="tldr">
+      <ul>
+        <li>The Pipevoice desktop app has <strong>no analytics, no telemetry, no tracking, no crash reporting, and no developer-operated backend</strong>. We do not collect, see, or receive any of your audio, transcripts, settings, or API keys from the app.</li>
+        <li>Your microphone audio and transcribed text are kept <strong>in memory only</strong>, for one utterance at a time, and are never written to disk by the app.</li>
+        <li>If you choose a cloud transcription or AI cleanup engine, your audio or text goes to <strong>the provider you picked, using your own API key</strong>. It does not pass through any server we control.</li>
+        <li>If you use the fully local engines (Local Whisper, Ollama), <strong>nothing leaves your PC at all</strong>.</li>
+        <li>The website is different: if you submit your email there, it reaches our email provider (Resend) through a serverless function we operate, and the site loads fonts from Google's CDN. Details below.</li>
+        <li>We never sell your data. There are no ads.</li>
+      </ul>
+    </div>
+
+    <h2>Who This Covers</h2>
+    <p>This policy covers two things:</p>
+    <ul>
+      <li>The Pipevoice desktop app for Windows.</li>
+      <li>The website at pipevoice.app.</li>
+    </ul>
+    <p>They are described separately below because they behave differently. The desktop app contacts no server of ours. The website does run one serverless function we operate, for the optional email signup.</p>
+
+    <h2>The Desktop App</h2>
+
+    <h3>What the app does with your audio</h3>
+    <p>When you hold the hotkey, Pipevoice captures microphone audio (16 kHz mono PCM) only while the key is held. That audio is used for one purpose: turning your speech into text. Where it goes depends entirely on the engine you choose:</p>
+    <ul>
+      <li><strong>Local Whisper (faster-whisper), fully offline.</strong> The audio never leaves your PC. The first time you ever use this engine, faster-whisper downloads the model file (about 150 MB) from Hugging Face. After that, transcription is fully on-device.</li>
+      <li><strong>OpenAI engine.</strong> The recorded WAV audio is uploaded to OpenAI's transcription API (<code>api.openai.com</code>) using your own <code>OPENAI_API_KEY</code>.</li>
+      <li><strong>Deepgram engine.</strong> The audio is streamed over a websocket to Deepgram (<code>api.deepgram.com</code>) using your own <code>DEEPGRAM_API_KEY</code>.</li>
+    </ul>
+    <p>The engine is your choice. Cloud engines send your audio only to the provider you selected and supplied a key for. If a cloud engine fails (for example, no internet), the app may retry the same audio once with Local Whisper, which stays on your device.</p>
+    <p>Your audio is never persisted by the app. Audio frames live only in memory for the length of a single utterance and are discarded after transcription. They are never written to disk. What happens to audio after it reaches OpenAI or Deepgram is governed by those providers' own policies, not by us.</p>
+
+    <h3>What the app does with your transcribed text</h3>
+    <p>Once your speech is transcribed, the text is typed into whatever window has focus on your PC (via keystrokes or paste), or copied to the Windows clipboard when you use the clipboard hotkey.</p>
+    <p>If you turn on AI cleanup ("Flow mode"), the transcript is additionally sent to the cleanup provider you chose, using your own key, so it can be polished:</p>
+    <ul>
+      <li><strong>OpenAI</strong> (<code>api.openai.com</code>)</li>
+      <li><strong>Google Gemini</strong> (<code>generativelanguage.googleapis.com</code>)</li>
+      <li><strong>OpenRouter</strong> (<code>openrouter.ai</code>)</li>
+      <li><strong>Ollama</strong> (a local model at <code>localhost:11434</code>, which stays on your device)</li>
+    </ul>
+    <p>The provider is your choice. If you use Ollama, the text never leaves your PC. Transcribed text is not saved to any history file. It is held in memory only. The only place text-related information might touch disk is the local log file (below), and even then only as error messages on failure, never the contents of your transcripts.</p>
+
+    <h3>Your API keys</h3>
+    <p>To use a cloud engine, you supply your own API key for that provider (<code>OPENAI_API_KEY</code>, <code>DEEPGRAM_API_KEY</code>, <code>GEMINI_API_KEY</code>, or <code>OPENROUTER_API_KEY</code>). These keys authenticate your own account to the provider you chose.</p>
+    <ul>
+      <li>Keys are stored locally only, in plaintext, in <code>%APPDATA%\Pipevoice\.env</code>.</li>
+      <li>Keys are sent only to the matching provider, as the credential on your API requests. They are never sent anywhere else, and never to any first-party or developer server, because there is none.</li>
+      <li>Keys are deliberately never written to <code>config.json</code>. The app keeps a strict split between secret and non-secret data.</li>
+      <li>Keys stay on disk until you change or delete them.</li>
+    </ul>
+
+    <h3>Your settings and other local data</h3>
+    <p>Pipevoice stores your preferences locally so it can remember how you like it to work. All of this lives in your per-user folder, <code>%APPDATA%\Pipevoice\</code>. None of it is transmitted to us.</p>
+    <ul>
+      <li><strong>Settings</strong> (<code>config.json</code>): engine choice, hotkeys, language, microphone device, model names, overlay/sounds/auto-update/AI-cleanup/auto-enter toggles, and output mode.</li>
+      <li><strong>Vocabulary and word-replacement fixes</strong> (in <code>config.json</code>): your custom terms and "wrong = right" pairs. The vocabulary text is also sent to the transcription provider you already chose, as a recognition hint, to help it recognize names and jargon. Your replacement pairs are applied locally only.</li>
+      <li><strong>Speech notes</strong> (in <code>config.json</code>): your free-text description of your accent, stutter, or fillers. This is embedded into the AI cleanup prompt sent to your chosen cleanup provider, but only when AI cleanup is enabled and actually runs.</li>
+    </ul>
+    <p>Other items in that folder: <code>pipevoice.log</code> (an app log plus error traces, but no transcript bodies), a temporary installer downloaded during auto-update (deleted on the next start), and a generated launcher file. Autostart, if enabled, is a single registry value under <code>HKCU\...\Run</code> named "Pipevoice". Your microphone audio and transcripts are never stored in this folder, or anywhere on disk.</p>
+
+    <h3>Running on your machine</h3>
+    <p>To make sure only one copy of Pipevoice runs at a time, the app binds a local socket on your own machine (<code>127.0.0.1:49517</code>). This is entirely local, transmits no data, and never leaves your PC.</p>
+
+    <h3>The update check</h3>
+    <p>When the app starts (if auto-update is on) or when you check manually, Pipevoice asks GitHub whether a newer version exists. This is the only network request the app makes on its own, without you choosing a cloud engine.</p>
+    <ul>
+      <li>It is an unauthenticated <code>GET</code> to the GitHub Releases API (<code>api.github.com</code>).</li>
+      <li>It sends no user data: no settings, no identifiers, no query parameters. The only thing it includes is a fixed User-Agent string, "Pipevoice-updater".</li>
+      <li>Your installed version is compared against the latest release tag locally, on your machine.</li>
+      <li>If an update is available and you proceed, the app downloads the installer and its checksum from github.com, and verifies the installer with SHA-256 before running it.</li>
+      <li>You can turn this off with the auto-update setting.</li>
+    </ul>
+
+    <h3>Browser "Get a key" links</h3>
+    <p>When you click a "Get a key" link in the welcome or key-entry dialogs, the app simply opens the provider's signup page (such as platform.openai.com or console.deepgram.com) in your default browser. This is user-initiated, and the app itself sends no data. Once the page is open, that provider's own privacy policy applies.</p>
+
+    <h3>Third parties the app may contact</h3>
+    <p>Depending on the engines you choose, the app may contact:</p>
+    <ul>
+      <li><strong>OpenAI</strong> (<code>api.openai.com</code>): transcription and/or AI cleanup, with your own key, only if you select it.</li>
+      <li><strong>Deepgram</strong> (<code>api.deepgram.com</code>): streaming transcription, with your own key, only if you select it.</li>
+      <li><strong>Google Gemini</strong> (<code>generativelanguage.googleapis.com</code>): AI cleanup only, with your own key, only if you select it.</li>
+      <li><strong>OpenRouter</strong> (<code>openrouter.ai</code>): AI cleanup only, with your own key, only if you select it.</li>
+      <li><strong>Ollama</strong> (<code>localhost:11434</code>): local AI cleanup, on your device, nothing leaves the machine.</li>
+      <li><strong>GitHub</strong> (<code>api.github.com</code> and <code>github.com</code>): update checks and installer downloads, with no user data sent.</li>
+      <li><strong>Hugging Face</strong>: only on first-ever use of the Local Whisper engine, to download the model file.</li>
+    </ul>
+    <p>We are not one of these third parties, and we do not receive copies of anything sent to them. Each provider handles your data under its own privacy policy.</p>
+
+    <h3>What the app explicitly does NOT do</h3>
+    <ul>
+      <li>No analytics, no telemetry, no tracking, no crash reporting.</li>
+      <li>No first-party or developer-operated backend server. The developers receive zero user data from the app.</li>
+      <li>No storing of your audio or transcripts on disk.</li>
+      <li>No transmitting of your settings, vocabulary, speech notes, or API keys to us.</li>
+    </ul>
+
+    <h2>The Website (pipevoice.app)</h2>
+    <p>The website is separate from the desktop app and behaves differently. Unlike the app, the website does contact a couple of outside services, and it runs one serverless function we operate.</p>
+
+    <h3>Email signup</h3>
+    <p>If you enter your email address, we use it to send build and product update notifications and to offer early access to a future paid "Pro" tier.</p>
+    <ul>
+      <li>Your email is sent first to our own serverless function (hosted on Vercel), which then forwards it to <strong>Resend</strong> (<code>api.resend.com</code>), our email provider, where it is stored in a Resend audience. Only your email address is forwarded to Resend.</li>
+      <li>There is an optional "Role" dropdown. Your role is used server-side for one thing only: deciding whether to also add your email to a second, segmented audience in Resend. The role value itself is not sent to Resend and is not stored anywhere.</li>
+      <li>A hidden anti-spam field is used to catch bots. If it is filled in, the submission is silently dropped. Its value is never stored or sent anywhere.</li>
+    </ul>
+    <p>Signing up is optional. After you click Download, a small modal appears offering to capture your email, but the app download proceeds either way, and you can choose "No thanks, just downloading." Your email is stored in Resend indefinitely until you unsubscribe or are removed. You can unsubscribe at any time, and you can contact us to have your email deleted.</p>
+
+    <h3>Google Fonts</h3>
+    <p>The website loads its fonts (Geist and Geist Mono) from Google's CDN (fonts.googleapis.com and fonts.gstatic.com). Because your browser fetches these directly from Google, Google receives standard request information, including your IP address, on each page load. We do not control Google's handling of that data. It is covered by Google's own privacy policy.</p>
+
+    <h3>Hosting and outbound links</h3>
+    <ul>
+      <li>The site and its signup function are hosted on <strong>Vercel</strong>.</li>
+      <li>The website links out to <strong>GitHub</strong> (source code and the app download) and to <strong>SignalEngine</strong> (a footer link). These are plain links and downloads. We do not send your data to them.</li>
+    </ul>
+
+    <h3>Cookies and tracking on the website</h3>
+    <p>The website sets no cookies and uses no localStorage, sessionStorage, or IndexedDB. There are no analytics, no tag managers, no tracking pixels, and no third-party tracker scripts. The only outside services the site uses are Google Fonts (for fonts) and Resend (for the optional email signup), both named above.</p>
+
+    <h2>Your Rights and How to Delete Your Data</h2>
+    <ul>
+      <li><strong>App data.</strong> Everything the app stores lives on your own PC in <code>%APPDATA%\Pipevoice\</code>. You can delete any of it (settings, vocabulary, speech notes, your <code>.env</code> with your API keys, the log file) at any time, or uninstall the app to remove it. We hold no copy, so there is nothing for us to delete on your behalf.</li>
+      <li><strong>Your email on our list.</strong> You can unsubscribe at any time using the link in any email we send. To have your email address deleted entirely from Resend, contact us using the details below and we will remove it.</li>
+      <li><strong>Data sent to providers.</strong> Audio and text you send to OpenAI, Deepgram, Google Gemini, or OpenRouter using your own key are governed by those providers' own policies and your own account with them. Requests to access or delete that data should be directed to the provider.</li>
+    </ul>
+
+    <h2>Selling and Sharing Data</h2>
+    <p>We never sell your data, and we do not share it for advertising. We do not have your app data to sell. The only place we forward any personal information is your email address to Resend, solely to operate the mailing list you chose to join. There are no ads in the app or on the website.</p>
+
+    <h2>Children</h2>
+    <p>Pipevoice is a general-purpose tool and is not directed at children. We do not knowingly collect personal information from children.</p>
+
+    <h2>Changes to This Policy</h2>
+    <p>We may update this policy from time to time. When we do, we will change the "Last updated" date at the top. Please check back occasionally.</p>
+
+    <h2>Contact</h2>
+    <p>Questions about this policy, or want your email removed from our list? Email us at <a href="mailto:james@powleads.com">james@powleads.com</a>.</p>
+  </main>
+
+  <footer>
+    <div class="foot-row">
+      <span>Pipevoice — free, private voice typing for Windows.</span>
+      <span><a href="/">Home</a> &nbsp;·&nbsp; <a href="https://github.com/Powleads/PipeVoice">github.com/Powleads/PipeVoice ↗</a></span>
+    </div>
+    <div class="made">
+      Built by the team behind <a class="se" href="https://engine.signalsprint.io">SignalEngine</a> — agentic AI outbound for founders &amp; agencies.
+      <a href="https://engine.signalsprint.io">Take a look ↗</a>
+    </div>
+  </footer>
+</div>
+</body>
+</html>


### PR DESCRIPTION
Adds an accurate, code-audited privacy policy at **https://pipevoice.app/privacy** (cleanUrls serves privacy.html), themed to match the site, plus a footer link.

Covers: local-first app with no telemetry/backend, cloud engines using the user's own key, the GitHub update check, the website Resend email capture, and Google Fonts CDN. Gives the SignPath / Azure signing applications a Privacy Policy URL to cite.