### PR TITLE
Key prompt: stop nagging every launch (v2.9.1)

### DIFF
--- a/installer/Pipevoice.iss
+++ b/installer/Pipevoice.iss
@@ -4,7 +4,7 @@
 ; Produces installer\Output\Pipevoice-Setup.exe — a per-user install (no admin).
 
 #define AppName "Pipevoice"
-#define AppVersion "2.9.0"
+#define AppVersion "2.9.1"
 #define AppExe "Pipevoice.exe"
 
 [Setup]

--- a/wisprlite/__init__.py
+++ b/wisprlite/__init__.py
@@ -1,3 +1,3 @@
 """Pipevoice — push-to-talk voice typing for Windows."""
 
-__version__ = "2.9.0"
+__version__ = "2.9.1"

--- a/wisprlite/config.py
+++ b/wisprlite/config.py
@@ -76,6 +76,7 @@ class Config:
     vocabulary: str = ""            # comma-separated terms to bias recognition
     speech_notes: str = ""          # free text about the user's accent / speech, fed to AI cleanup
     replacements: dict = field(default_factory=dict)  # {wrong: right} post-fixes
+    key_prompt_skipped_for: str = ""  # engine the user dismissed the key prompt for (stops re-nagging)
 
     @classmethod
     def load(cls) -> "Config":

--- a/wisprlite/keyprompt.py
+++ b/wisprlite/keyprompt.py
@@ -34,6 +34,10 @@ def has_key(engine: str) -> bool:
 def ensure_api_key(cfg) -> None:
     if has_key(cfg.engine) or cfg.engine not in PROVIDER:
         return
+    # Don't nag every launch: if the user already dismissed the prompt for this
+    # engine, stay quiet until they pick a different engine (or add a key).
+    if getattr(cfg, "key_prompt_skipped_for", "") == cfg.engine:
+        return
     try:
         _dialog(cfg)
     except Exception:
@@ -122,6 +126,7 @@ def _dialog(cfg) -> None:
 
     def use_offline():
         cfg.engine = "local"
+        cfg.key_prompt_skipped_for = ""
         try:
             cfg.save()
         except Exception:
@@ -129,6 +134,12 @@ def _dialog(cfg) -> None:
         root.destroy()
 
     def skip():
+        # Remember the skip so we don't re-prompt for this engine every launch.
+        cfg.key_prompt_skipped_for = cfg.engine
+        try:
+            cfg.save()
+        except Exception:
+            pass
         root.destroy()
 
     tk.Button(btns, text="Skip for now", command=skip, bg=CARD, fg=FG,


### PR DESCRIPTION
The cloud-engine key prompt reappeared on every startup, and **Skip for now** didn't stick. Now it records the dismissal per engine (`key_prompt_skipped_for`) and stays quiet until you switch engines or add a key. **Use offline** clears the flag. Fixes the repeated pop-up seen on 2.9.0.