### PR TITLE
Admin dashboard (/admin): downloads, subscribers, cookieless analytics

### DIFF
--- a/wisprlitevercel/admin.html
+++ b/wisprlitevercel/admin.html
@@ -1,0 +1,236 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Pipevoice — Admin</title>
+<meta name="robots" content="noindex, nofollow" />
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='14' fill='%231b1e24'/%3E%3Crect x='26' y='15' width='12' height='23' rx='6' fill='%23e06c75'/%3E%3Cpath d='M21 32a11 11 0 0 0 22 0' stroke='%23e06c75' stroke-width='3' fill='none'/%3E%3C/svg%3E" />
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700;800&family=Geist+Mono:wght@400;500&display=swap" rel="stylesheet" />
+<style>
+  :root{
+    --canvas:#282c34; --deep:#131313; --card:#1b1e24; --popover:#20242c;
+    --border:rgba(53,90,102,.55); --border-soft:rgba(53,90,102,.28);
+    --accent:#e06c75; --accent-soft:rgba(224,108,117,.12); --accent-line:rgba(224,108,117,.55);
+    --glow:0 0 22px rgba(224,108,117,.32); --good:#98c379; --warn:#e5c07b;
+    --text:#e6e8eb; --muted:#9aa1ad; --r:10px; --mono:"Geist Mono",ui-monospace,Menlo,Consolas,monospace;
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  body{background:var(--canvas);color:var(--text);font-family:"Geist",system-ui,"Segoe UI",sans-serif;
+    line-height:1.55;-webkit-font-smoothing:antialiased;min-height:100vh}
+  a{color:var(--accent);text-decoration:none} a:hover{text-decoration:underline}
+  .wrap{max-width:980px;margin:0 auto;padding:30px 22px 60px}
+  .mono{font-family:var(--mono)}
+
+  /* login */
+  .gate{min-height:100vh;display:flex;align-items:center;justify-content:center;padding:24px}
+  .gate .box{background:var(--card);border:1px solid var(--border);border-radius:16px;padding:34px 30px;max-width:380px;width:100%;box-shadow:0 24px 70px rgba(0,0,0,.5)}
+  .gate h1{font-size:22px;letter-spacing:-.02em} .gate h1 .c{color:var(--accent)}
+  .gate p{color:var(--muted);font-size:13.5px;margin:8px 0 18px}
+  input[type=password]{width:100%;background:var(--deep);border:1px solid var(--border);border-radius:var(--r);
+    color:var(--text);padding:13px 15px;font-size:15px;font-family:var(--mono)}
+  input:focus{outline:none;border-color:var(--accent-line);box-shadow:0 0 0 3px var(--accent-soft)}
+  .btn{display:inline-flex;align-items:center;gap:8px;border-radius:var(--r);font-weight:600;cursor:pointer;
+    border:1px solid transparent;font-size:14.5px;font-family:inherit;padding:12px 20px;margin-top:14px}
+  .btn-primary{background:var(--accent);color:#1a0c0d;box-shadow:var(--glow);width:100%;justify-content:center}
+  .btn-primary:hover{filter:brightness(1.06)}
+  .btn-ghost{border-color:var(--border);color:var(--text);padding:8px 14px;font-size:13px;margin:0}
+  .btn-ghost:hover{border-color:var(--accent-line);background:var(--accent-soft)}
+  .err{color:var(--accent);font-size:13px;margin-top:12px;min-height:1px}
+
+  /* dashboard */
+  header.top{display:flex;align-items:center;justify-content:space-between;gap:12px;flex-wrap:wrap;
+    padding-bottom:18px;border-bottom:1px solid var(--border-soft);margin-bottom:24px}
+  header.top h1{font-size:20px;letter-spacing:-.02em} header.top h1 .c{color:var(--accent)}
+  header.top .meta{color:var(--muted);font-size:12px;font-family:var(--mono)}
+  .toolbar{display:flex;gap:8px;align-items:center}
+
+  .kpis{display:grid;grid-template-columns:repeat(4,1fr);gap:14px;margin-bottom:14px}
+  @media(max-width:720px){.kpis{grid-template-columns:repeat(2,1fr)}}
+  .kpi{background:var(--card);border:1px solid var(--border-soft);border-radius:14px;padding:20px}
+  .kpi .lab{color:var(--muted);font-size:12px;font-family:var(--mono);text-transform:uppercase;letter-spacing:.08em}
+  .kpi .num{font-size:34px;font-weight:800;letter-spacing:-.03em;margin-top:8px;line-height:1}
+  .kpi .sub{color:var(--muted);font-size:12.5px;margin-top:6px}
+  .kpi.accent .num{color:var(--accent)}
+
+  .panel{background:var(--card);border:1px solid var(--border-soft);border-radius:14px;padding:22px;margin-top:14px}
+  .panel h2{font-size:15px;letter-spacing:-.01em;margin-bottom:4px}
+  .panel .h2sub{color:var(--muted);font-size:12.5px;margin-bottom:16px;font-family:var(--mono)}
+  table{width:100%;border-collapse:collapse;font-size:14px}
+  th,td{text-align:left;padding:10px 12px;border-bottom:1px solid var(--border-soft)}
+  th{color:var(--muted);font-size:12px;font-weight:600;text-transform:uppercase;letter-spacing:.05em}
+  td.n{text-align:right;font-family:var(--mono)} tr:last-child td{border-bottom:none}
+  .tag{font-family:var(--mono);color:var(--text)}
+  .badge{font-family:var(--mono);font-size:10.5px;color:var(--good);border:1px solid rgba(152,195,121,.4);
+    background:rgba(152,195,121,.08);border-radius:999px;padding:1px 7px;margin-left:8px;text-transform:uppercase;letter-spacing:.04em}
+
+  /* bar chart */
+  .chart{display:flex;align-items:flex-end;gap:8px;height:140px;margin-top:6px}
+  .chart .col{flex:1;display:flex;flex-direction:column;align-items:center;gap:7px;height:100%;justify-content:flex-end}
+  .chart .bar{width:100%;max-width:46px;background:var(--accent-soft);border:1px solid var(--accent-line);
+    border-radius:6px 6px 0 0;min-height:3px;position:relative}
+  .chart .bar .v{position:absolute;top:-19px;left:0;right:0;text-align:center;font-size:11px;font-family:var(--mono);color:var(--text)}
+  .chart .d{font-size:10.5px;color:var(--muted);font-family:var(--mono)}
+  .note{color:var(--muted);font-size:12.5px;font-family:var(--mono);background:var(--popover);
+    border:1px solid var(--border-soft);border-radius:var(--r);padding:12px 14px}
+  .two{display:grid;grid-template-columns:1fr 1fr;gap:14px}
+  @media(max-width:720px){.two{grid-template-columns:1fr}}
+  .pe{color:var(--accent)}
+</style>
+</head>
+<body>
+<div id="gate" class="gate">
+  <div class="box">
+    <h1>Pipe<span class="c">voice</span> admin</h1>
+    <p>Enter the admin password.</p>
+    <form id="login">
+      <input id="token" type="password" placeholder="admin password" autocomplete="current-password" autofocus />
+      <button class="btn btn-primary" type="submit">Open dashboard</button>
+      <p class="err" id="loginErr"></p>
+    </form>
+  </div>
+</div>
+
+<div id="app" class="wrap" style="display:none">
+  <header class="top">
+    <h1>Pipe<span class="c">voice</span> admin</h1>
+    <div class="toolbar">
+      <span class="meta" id="genAt"></span>
+      <button class="btn btn-ghost" id="refresh">Refresh</button>
+      <button class="btn btn-ghost" id="logout">Log out</button>
+    </div>
+  </header>
+  <div id="content"></div>
+</div>
+
+<script>
+(function () {
+  var KEY = "pv_admin_token";
+  var gate = document.getElementById("gate");
+  var app = document.getElementById("app");
+  var content = document.getElementById("content");
+
+  function esc(s){ return String(s == null ? "" : s).replace(/[&<>"]/g, function(c){
+    return {"&":"&amp;","<":"&lt;",">":"&gt;","\"":"&quot;"}[c]; }); }
+  function num(n){ return (n == null ? "—" : Number(n).toLocaleString()); }
+  function fmtDate(s){ try { return new Date(s).toLocaleDateString(undefined,{month:"short",day:"numeric",year:"numeric"}); } catch(e){ return s; } }
+  function dayLabel(s){ try { return new Date(s+"T00:00:00").toLocaleDateString(undefined,{month:"short",day:"numeric"}); } catch(e){ return s; } }
+
+  async function load(token) {
+    var r = await fetch("/api/admin", { headers: { "x-admin-token": token } });
+    if (r.status === 401) throw new Error("Wrong password.");
+    if (r.status === 503) throw new Error("ADMIN_TOKEN is not set in Vercel env yet.");
+    if (!r.ok) throw new Error("Server error (" + r.status + ").");
+    return r.json();
+  }
+
+  function kpiRow(d) {
+    var subs = d.subscribers || {}, vis = d.visitors || {}, dl = d.downloads || {};
+    return '<div class="kpis">' +
+      kpi("Total downloads", dl.error ? "—" : num(dl.total), dl.latest ? ("latest " + esc(dl.latest)) : "GitHub Releases", true) +
+      kpi("Subscribers", subs.configured === false ? "—" : (subs.error ? "—" : num(subs.total)), subs.icp != null ? (num(subs.icp) + " in ICP segment") : "Resend list", false) +
+      kpi("Unique visitors", vis.configured ? num(vis.uniqueAll) : "—", vis.configured ? "all time (cookieless)" : "not configured", false) +
+      kpi("Page views", vis.configured ? num(vis.totalViews) : "—", vis.configured ? "all time" : "add Upstash keys", false) +
+      '</div>';
+  }
+  function kpi(lab, n, sub, accent){
+    return '<div class="kpi'+(accent?" accent":"")+'"><div class="lab">'+esc(lab)+'</div>'+
+      '<div class="num">'+n+'</div><div class="sub">'+esc(sub)+'</div></div>';
+  }
+
+  function downloadsPanel(dl){
+    if (dl.error) return panel("Downloads", "GitHub Releases", '<div class="note">Could not load: '+esc(dl.error)+'</div>');
+    var rows = (dl.byVersion||[]).map(function(v){
+      return '<tr><td class="tag">'+esc(v.tag)+(v.latest?'<span class="badge">latest</span>':'')+'</td>'+
+        '<td>'+(v.publishedAt?fmtDate(v.publishedAt):"—")+'</td>'+
+        '<td class="n">'+num(v.downloads)+'</td></tr>';
+    }).join("");
+    if (!rows) rows = '<tr><td colspan="3" class="note" style="border:none">No releases yet.</td></tr>';
+    return panel("Downloads by version", "installer downloads from GitHub Releases",
+      '<table><thead><tr><th>Version</th><th>Released</th><th class="n">Downloads</th></tr></thead><tbody>'+rows+'</tbody></table>');
+  }
+
+  function visitorsPanel(vis){
+    if (vis.configured === false)
+      return panel("Visitors", "first-party, cookieless",
+        '<div class="note">Visitor analytics is off. Create a free Upstash Redis database and add <span class="pe">UPSTASH_REDIS_REST_URL</span> and <span class="pe">UPSTASH_REDIS_REST_TOKEN</span> to the Vercel project, then redeploy.</div>');
+    if (vis.error) return panel("Visitors", "first-party, cookieless", '<div class="note">Could not load: '+esc(vis.error)+'</div>');
+
+    var days = vis.last7 || [];
+    var max = Math.max(1, Math.max.apply(null, days.map(function(d){return d.views;})));
+    var bars = days.map(function(d){
+      var h = Math.round((d.views/max)*100);
+      return '<div class="col"><div class="bar" style="height:'+h+'%"><span class="v">'+(d.views||0)+'</span></div><span class="d">'+dayLabel(d.date)+'</span></div>';
+    }).join("");
+
+    var paths = (vis.topPaths||[]).map(function(p){
+      return '<tr><td class="tag">'+esc(p.path)+'</td><td class="n">'+num(p.views)+'</td></tr>'; }).join("")
+      || '<tr><td colspan="2" class="note" style="border:none">No views yet.</td></tr>';
+    var refs = (vis.topRefs||[]).map(function(p){
+      return '<tr><td class="tag">'+esc(p.host)+'</td><td class="n">'+num(p.views)+'</td></tr>'; }).join("")
+      || '<tr><td colspan="2" class="note" style="border:none">No external referrers yet.</td></tr>';
+
+    return panel("Page views — last 7 days", "views per day · cookieless, no IP stored",
+      '<div class="chart">'+bars+'</div>' +
+      '<div class="two" style="margin-top:22px">' +
+        '<div><h2 style="font-size:13px;margin-bottom:10px">Top pages</h2><table><tbody>'+paths+'</tbody></table></div>' +
+        '<div><h2 style="font-size:13px;margin-bottom:10px">Top referrers</h2><table><tbody>'+refs+'</tbody></table></div>' +
+      '</div>');
+  }
+
+  function subscribersPanel(subs){
+    if (subs.configured === false)
+      return panel("Subscribers", "Resend", '<div class="note">Resend env not set (RESEND_API_KEY / RESEND_AUDIENCE_ID).</div>');
+    if (subs.error) return panel("Subscribers", "Resend", '<div class="note">Could not load: '+esc(subs.error)+'</div>');
+    return panel("Subscribers", "Resend mailing list",
+      '<table><tbody>' +
+      '<tr><td>Total list</td><td class="n">'+num(subs.total)+'</td></tr>' +
+      (subs.icp!=null ? '<tr><td>Founder / agency / sales (ICP)</td><td class="n">'+num(subs.icp)+'</td></tr>' : '') +
+      '</tbody></table>');
+  }
+
+  function panel(title, sub, inner){
+    return '<div class="panel"><h2>'+esc(title)+'</h2><div class="h2sub">'+esc(sub)+'</div>'+inner+'</div>';
+  }
+
+  function render(d){
+    document.getElementById("genAt").textContent = d.generatedAt ? ("updated " + new Date(d.generatedAt).toLocaleString()) : "";
+    content.innerHTML = kpiRow(d) + downloadsPanel(d.downloads||{}) + visitorsPanel(d.visitors||{}) + subscribersPanel(d.subscribers||{});
+  }
+
+  async function show(token){
+    try{
+      var d = await load(token);
+      sessionStorage.setItem(KEY, token);
+      gate.style.display = "none";
+      app.style.display = "block";
+      render(d);
+    }catch(e){
+      sessionStorage.removeItem(KEY);
+      gate.style.display = "flex";
+      app.style.display = "none";
+      document.getElementById("loginErr").textContent = e.message || "Failed to load.";
+    }
+  }
+
+  document.getElementById("login").addEventListener("submit", function(e){
+    e.preventDefault();
+    document.getElementById("loginErr").textContent = "";
+    var t = document.getElementById("token").value.trim();
+    if (t) show(t);
+  });
+  document.getElementById("refresh").addEventListener("click", function(){
+    var t = sessionStorage.getItem(KEY); if (t) show(t);
+  });
+  document.getElementById("logout").addEventListener("click", function(){
+    sessionStorage.removeItem(KEY); location.reload();
+  });
+
+  var saved = sessionStorage.getItem(KEY);
+  if (saved) show(saved);
+})();
+</script>
+</body>
+</html>

--- a/wisprlitevercel/api/admin.js
+++ b/wisprlitevercel/api/admin.js
@@ -1,0 +1,142 @@
+// Vercel serverless function: GET /api/admin
+// Returns dashboard stats for admin.html. Gated by ADMIN_TOKEN (sent as the
+// `x-admin-token` header, or `Authorization: Bearer <token>`).
+//
+// Required env:
+//   ADMIN_TOKEN              the dashboard password (if unset, the API is disabled)
+// For subscriber counts:
+//   RESEND_API_KEY, RESEND_AUDIENCE_ID, [RESEND_ICP_AUDIENCE_ID]
+// For visitor counts:
+//   UPSTASH_REDIS_REST_URL, UPSTASH_REDIS_REST_TOKEN
+// Optional:
+//   GITHUB_TOKEN            raises the GitHub API rate limit (public repo works without)
+
+import crypto from "node:crypto";
+
+const REPO = "Powleads/PipeVoice";
+const ASSET = "Pipevoice-Setup.exe";
+
+export default async function handler(req, res) {
+  res.setHeader("Cache-Control", "no-store");
+  if (req.method !== "GET") return res.status(405).json({ error: "method_not_allowed" });
+
+  const expected = process.env.ADMIN_TOKEN;
+  if (!expected) return res.status(503).json({ error: "admin_not_configured" });
+  const given = String(
+    req.headers["x-admin-token"] || (req.headers.authorization || "").replace(/^Bearer\s+/i, "")
+  );
+  if (!tokenOk(given, expected)) return res.status(401).json({ error: "unauthorized" });
+
+  const [downloads, subscribers, visitors] = await Promise.all([
+    getDownloads().catch((e) => ({ error: String(e && e.message || e) })),
+    getSubscribers().catch((e) => ({ error: String(e && e.message || e) })),
+    getVisitors().catch((e) => ({ error: String(e && e.message || e) })),
+  ]);
+  return res.status(200).json({ generatedAt: new Date().toISOString(), downloads, subscribers, visitors });
+}
+
+function tokenOk(a, b) {
+  const ba = Buffer.from(String(a));
+  const bb = Buffer.from(String(b));
+  if (ba.length !== bb.length) return false;
+  try {
+    return crypto.timingSafeEqual(ba, bb);
+  } catch {
+    return false;
+  }
+}
+
+async function getDownloads() {
+  const headers = { "User-Agent": "pipevoice-admin", Accept: "application/vnd.github+json" };
+  if (process.env.GITHUB_TOKEN) headers.Authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
+  const r = await fetch(`https://api.github.com/repos/${REPO}/releases?per_page=100`, { headers });
+  if (!r.ok) throw new Error(`github ${r.status}`);
+  const releases = await r.json();
+  let total = 0;
+  const byVersion = [];
+  for (const rel of releases) {
+    const asset = (rel.assets || []).find((a) => a.name === ASSET);
+    const count = asset ? asset.download_count : 0;
+    total += count;
+    byVersion.push({
+      tag: rel.tag_name,
+      downloads: count,
+      publishedAt: rel.published_at,
+      latest: false,
+    });
+  }
+  if (byVersion.length) byVersion[0].latest = true; // GitHub returns releases newest-first
+  return { total, latest: byVersion[0] ? byVersion[0].tag : null, byVersion };
+}
+
+async function getSubscribers() {
+  const key = process.env.RESEND_API_KEY;
+  const master = process.env.RESEND_AUDIENCE_ID;
+  const icp = process.env.RESEND_ICP_AUDIENCE_ID;
+  if (!key || !master) return { configured: false };
+  const count = async (id) => {
+    if (!id) return null;
+    const r = await fetch(`https://api.resend.com/audiences/${id}/contacts`, {
+      headers: { Authorization: `Bearer ${key}` },
+    });
+    if (!r.ok) throw new Error(`resend ${r.status}`);
+    const j = await r.json();
+    const list = Array.isArray(j.data) ? j.data : [];
+    return list.filter((c) => !c.unsubscribed).length;
+  };
+  return { configured: true, total: await count(master), icp: await count(icp) };
+}
+
+async function getVisitors() {
+  const url = process.env.UPSTASH_REDIS_REST_URL;
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+  if (!url || !token) return { configured: false };
+
+  const days = [];
+  for (let i = 6; i >= 0; i--) {
+    days.push(new Date(Date.now() - i * 86400000).toISOString().slice(0, 10));
+  }
+  const cmds = [
+    ["GET", "pv:total"],
+    ["PFCOUNT", "uv:all"],
+    ["HGETALL", "pv:paths"],
+    ["HGETALL", "pv:refs"],
+  ];
+  for (const d of days) {
+    cmds.push(["GET", `pv:day:${d}`]);
+    cmds.push(["PFCOUNT", `uv:day:${d}`]);
+  }
+  const r = await fetch(`${url}/pipeline`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+    body: JSON.stringify(cmds),
+  });
+  if (!r.ok) throw new Error(`upstash ${r.status}`);
+  const out = await r.json();
+  const val = (i) => (out[i] && typeof out[i] === "object" && "result" in out[i] ? out[i].result : out[i]);
+
+  const totalViews = Number(val(0) || 0);
+  const uniqueAll = Number(val(1) || 0);
+  const topPaths = pairs(val(2)).sort((a, b) => b[1] - a[1]).slice(0, 12).map(([path, views]) => ({ path, views }));
+  const topRefs = pairs(val(3)).sort((a, b) => b[1] - a[1]).slice(0, 12).map(([host, views]) => ({ host, views }));
+
+  const last7 = [];
+  let idx = 4;
+  for (const d of days) {
+    const views = Number(val(idx++) || 0);
+    const uniques = Number(val(idx++) || 0);
+    last7.push({ date: d, views, uniques });
+  }
+  return { configured: true, totalViews, uniqueAll, last7, topPaths, topRefs };
+}
+
+function pairs(h) {
+  if (!h) return [];
+  if (Array.isArray(h)) {
+    const out = [];
+    for (let i = 0; i < h.length; i += 2) out.push([h[i], Number(h[i + 1] || 0)]);
+    return out;
+  }
+  if (typeof h === "object") return Object.entries(h).map(([k, v]) => [k, Number(v || 0)]);
+  return [];
+}

--- a/wisprlitevercel/api/track.js
+++ b/wisprlitevercel/api/track.js
@@ -1,0 +1,86 @@
+// Vercel serverless function: POST /api/track
+// First-party, cookieless, aggregate-only pageview counter. It stores NO IP
+// address and NO personal data. Unique-visitor estimates use a daily-rotating
+// salted hash fed into a Redis HyperLogLog (PFADD), which keeps no identifiers
+// and cannot be reversed or used to track anyone across days.
+//
+// No-op (returns 204) unless Upstash Redis is configured, so the site works
+// fine without it. Required env to enable:
+//   UPSTASH_REDIS_REST_URL    Upstash Redis REST URL
+//   UPSTASH_REDIS_REST_TOKEN  Upstash Redis REST token
+// Optional env:
+//   ANALYTICS_SALT            hash salt (defaults to ADMIN_TOKEN, else a constant)
+
+import crypto from "node:crypto";
+
+const KEEP_DAYS = 120;
+
+export default async function handler(req, res) {
+  if (req.method === "OPTIONS") return res.status(204).end();
+  if (req.method !== "POST") return res.status(405).json({ error: "method_not_allowed" });
+
+  const url = process.env.UPSTASH_REDIS_REST_URL;
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+  if (!url || !token) return res.status(204).end(); // analytics not configured -> silent no-op
+
+  const body =
+    typeof req.body === "string"
+      ? safe(req.body)
+      : req.body && typeof req.body === "object" && !Array.isArray(req.body)
+      ? req.body
+      : {};
+
+  let path = String(body.p || "/").trim().replace(/[\r\n]/g, "");
+  if (!path.startsWith("/")) path = "/";
+  path = path.slice(0, 120);
+
+  const date = new Date().toISOString().slice(0, 10);
+  const ip = String(req.headers["x-forwarded-for"] || "").split(",")[0].trim();
+  const ua = String(req.headers["user-agent"] || "").slice(0, 200);
+  const salt = process.env.ANALYTICS_SALT || process.env.ADMIN_TOKEN || "pipevoice";
+  // One-way, daily-rotating, salted. We feed ONLY this digest into a HyperLogLog;
+  // the raw IP/UA are never stored anywhere.
+  const visitor = crypto.createHash("sha256").update(`${ip}|${ua}|${date}|${salt}`).digest("hex");
+
+  let refHost = "";
+  try {
+    const r = String(body.r || "");
+    if (r) {
+      const h = new URL(r).hostname;
+      if (h && h !== "localhost" && h !== "127.0.0.1" && !/(^|\.)pipevoice\.app$/.test(h)) {
+        refHost = h.slice(0, 100);
+      }
+    }
+  } catch {}
+
+  const cmds = [
+    ["INCR", "pv:total"],
+    ["INCR", `pv:day:${date}`],
+    ["EXPIRE", `pv:day:${date}`, KEEP_DAYS * 86400],
+    ["HINCRBY", "pv:paths", path, 1],
+    ["PFADD", `uv:day:${date}`, visitor],
+    ["EXPIRE", `uv:day:${date}`, KEEP_DAYS * 86400],
+    ["PFADD", "uv:all", visitor],
+  ];
+  if (refHost) cmds.push(["HINCRBY", "pv:refs", refHost, 1]);
+
+  try {
+    await fetch(`${url}/pipeline`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+      body: JSON.stringify(cmds),
+    });
+  } catch {
+    // analytics is best-effort; never let it surface to the visitor
+  }
+  return res.status(204).end();
+}
+
+function safe(s) {
+  try {
+    const v = JSON.parse(s);
+    return v && typeof v === "object" && !Array.isArray(v) ? v : {};
+  } catch {
+    return {};
+  }
+}

--- a/wisprlitevercel/index.html
+++ b/wisprlitevercel/index.html
@@ -642,5 +642,8 @@
     document.addEventListener("keydown", function (e) { if (e.key === "Escape") closeModal(); });
   })();
 </script>
+<script>/* first-party, cookieless pageview beacon -> /api/track (disclosed in /privacy) */
+(function(){try{fetch("/api/track",{method:"POST",keepalive:true,headers:{"Content-Type":"application/json"},body:JSON.stringify({p:location.pathname,r:document.referrer})});}catch(e){}})();
+</script>
 </body>
 </html>

--- a/wisprlitevercel/privacy.html
+++ b/wisprlitevercel/privacy.html
@@ -89,7 +89,7 @@
 
   <main class="legal">
     <h1>Privacy Policy</h1>
-    <p class="updated">Last updated: 20 June 2026</p>
+    <p class="updated">Last updated: 21 June 2026</p>
     <p class="intro">Pipevoice is a free, open-source, push-to-talk voice-typing app for Windows. This policy explains exactly what happens to your data when you use the app and the website at pipevoice.app. The short version: Pipevoice is local-first, the desktop app talks to no server of ours, and we receive none of your data from the app.</p>
 
     <div class="tldr">
@@ -98,7 +98,7 @@
         <li>Your microphone audio and transcribed text are kept <strong>in memory only</strong>, for one utterance at a time, and are never written to disk by the app.</li>
         <li>If you choose a cloud transcription or AI cleanup engine, your audio or text goes to <strong>the provider you picked, using your own API key</strong>. It does not pass through any server we control.</li>
         <li>If you use the fully local engines (Local Whisper, Ollama), <strong>nothing leaves your PC at all</strong>.</li>
-        <li>The website is different: if you submit your email there, it reaches our email provider (Resend) through a serverless function we operate, and the site loads fonts from Google's CDN. Details below.</li>
+        <li>The website is different: if you submit your email there, it reaches our email provider (Resend) through a serverless function we operate, the site loads fonts from Google's CDN, and we keep simple cookieless, aggregate visitor counts (no IP address stored). Details below.</li>
         <li>We never sell your data. There are no ads.</li>
       </ul>
     </div>
@@ -208,10 +208,12 @@
     <ul>
       <li>The site and its signup function are hosted on <strong>Vercel</strong>.</li>
       <li>The website links out to <strong>GitHub</strong> (source code and the app download) and to <strong>SignalEngine</strong> (a footer link). These are plain links and downloads. We do not send your data to them.</li>
+      <li>Aggregate, anonymous visitor counts are stored in <strong>Upstash</strong> (a hosted Redis service). No personal data and no IP addresses are stored there.</li>
     </ul>
 
-    <h3>Cookies and tracking on the website</h3>
-    <p>The website sets no cookies and uses no localStorage, sessionStorage, or IndexedDB. There are no analytics, no tag managers, no tracking pixels, and no third-party tracker scripts. The only outside services the site uses are Google Fonts (for fonts) and Resend (for the optional email signup), both named above.</p>
+    <h3>Analytics and cookies on the website</h3>
+    <p>The website sets no cookies and uses no localStorage, sessionStorage, or IndexedDB. We use no third-party analytics, no tag managers, no tracking pixels, and no third-party tracker scripts.</p>
+    <p>We do keep simple, first-party, aggregate analytics so we can see how many people visit. When a page loads, your browser sends the path you viewed and the referring website to our own <code>/api/track</code> endpoint. To estimate how many distinct people visit without identifying anyone, we take a one-way hash that mixes your IP address, browser user-agent, and the current date with a secret, and feed only that hash into an aggregate counter (a HyperLogLog). That counter stores no identifiers and cannot be reversed. Your IP address itself is never stored, and because the hash includes the date it changes every day, so it cannot be used to follow you over time or across days. These aggregate counts are held in our own Redis datastore (Upstash). We collect no names and nothing that identifies you.</p>
 
     <h2>Your Rights and How to Delete Your Data</h2>
     <ul>
@@ -244,5 +246,8 @@
     </div>
   </footer>
 </div>
+<script>/* first-party, cookieless pageview beacon -> /api/track (disclosed below) */
+(function(){try{fetch("/api/track",{method:"POST",keepalive:true,headers:{"Content-Type":"application/json"},body:JSON.stringify({p:location.pathname,r:document.referrer})});}catch(e){}})();
+</script>
 </body>
 </html>


### PR DESCRIPTION
Password-gated admin area at **/admin**.

- **Downloads** per version from GitHub Releases (live-tested: 19 installs across 12 releases)
- **Subscribers** from Resend (total + founder/agency/sales segment)
- **Visitors**: first-party, **cookieless**, aggregate-only. No IP stored; unique counts via a daily-rotating salted hash in a Redis HyperLogLog (Upstash). Privacy page updated to disclose it fully.

Auth via ADMIN_TOKEN (timing-safe compare). Each data source degrades gracefully if its env isn't set, so downloads + subscribers work the moment ADMIN_TOKEN is added; visitors light up after Upstash keys are added.