### PR TITLE
First-party UTM campaign attribution (no pixels)

### DIFF
--- a/wisprlitevercel/admin.html
+++ b/wisprlitevercel/admin.html
@@ -80,6 +80,8 @@
     border:1px solid var(--border-soft);border-radius:var(--r);padding:12px 14px}
   .two{display:grid;grid-template-columns:1fr 1fr;gap:14px}
   @media(max-width:720px){.two{grid-template-columns:1fr}}
+  .three{display:grid;grid-template-columns:repeat(3,1fr);gap:18px}
+  @media(max-width:720px){.three{grid-template-columns:1fr;gap:8px}}
   .pe{color:var(--accent)}
 </style>
 </head>
@@ -199,9 +201,27 @@
     return '<div class="panel"><h2>'+esc(title)+'</h2><div class="h2sub">'+esc(sub)+'</div>'+inner+'</div>';
   }
 
+  function campaignsPanel(vis){
+    if (vis.configured === false || vis.error) return "";
+    var s = vis.topSources||[], m = vis.topMediums||[], c = vis.topCampaigns||[];
+    if (!s.length && !m.length && !c.length)
+      return panel("Campaign attribution", "first-party UTM tags · no pixels",
+        '<div class="note">No campaign data yet. Tag your links like <span class="pe">pipevoice.app/?utm_source=twitter&amp;utm_medium=social&amp;utm_campaign=launch</span> and traffic will break down here by source, medium, and campaign.</div>');
+    function tbl(rows, label){
+      return rows.map(function(x){ return '<tr><td class="tag">'+esc(x[label])+'</td><td class="n">'+num(x.views)+'</td></tr>'; }).join("")
+        || '<tr><td colspan="2" class="note" style="border:none">none yet</td></tr>';
+    }
+    return panel("Campaign attribution", "where campaign traffic comes from · first-party UTM tags, no pixels",
+      '<div class="three">' +
+        '<div><h2 style="font-size:13px;margin-bottom:10px">Sources</h2><table><tbody>'+tbl(s,"source")+'</tbody></table></div>' +
+        '<div><h2 style="font-size:13px;margin-bottom:10px">Mediums</h2><table><tbody>'+tbl(m,"medium")+'</tbody></table></div>' +
+        '<div><h2 style="font-size:13px;margin-bottom:10px">Campaigns</h2><table><tbody>'+tbl(c,"campaign")+'</tbody></table></div>' +
+      '</div>');
+  }
+
   function render(d){
     document.getElementById("genAt").textContent = d.generatedAt ? ("updated " + new Date(d.generatedAt).toLocaleString()) : "";
-    content.innerHTML = kpiRow(d) + downloadsPanel(d.downloads||{}) + visitorsPanel(d.visitors||{}) + subscribersPanel(d.subscribers||{});
+    content.innerHTML = kpiRow(d) + downloadsPanel(d.downloads||{}) + visitorsPanel(d.visitors||{}) + campaignsPanel(d.visitors||{}) + subscribersPanel(d.subscribers||{});
   }
 
   async function show(token){

--- a/wisprlitevercel/api/admin.js
+++ b/wisprlitevercel/api/admin.js
@@ -101,6 +101,9 @@ async function getVisitors() {
     ["PFCOUNT", "uv:all"],
     ["HGETALL", "pv:paths"],
     ["HGETALL", "pv:refs"],
+    ["HGETALL", "utm:source"],
+    ["HGETALL", "utm:medium"],
+    ["HGETALL", "utm:campaign"],
   ];
   for (const d of days) {
     cmds.push(["GET", `pv:day:${d}`]);
@@ -119,15 +122,18 @@ async function getVisitors() {
   const uniqueAll = Number(val(1) || 0);
   const topPaths = pairs(val(2)).sort((a, b) => b[1] - a[1]).slice(0, 12).map(([path, views]) => ({ path, views }));
   const topRefs = pairs(val(3)).sort((a, b) => b[1] - a[1]).slice(0, 12).map(([host, views]) => ({ host, views }));
+  const topSources = pairs(val(4)).sort((a, b) => b[1] - a[1]).slice(0, 12).map(([source, views]) => ({ source, views }));
+  const topMediums = pairs(val(5)).sort((a, b) => b[1] - a[1]).slice(0, 12).map(([medium, views]) => ({ medium, views }));
+  const topCampaigns = pairs(val(6)).sort((a, b) => b[1] - a[1]).slice(0, 12).map(([campaign, views]) => ({ campaign, views }));
 
   const last7 = [];
-  let idx = 4;
+  let idx = 7;
   for (const d of days) {
     const views = Number(val(idx++) || 0);
     const uniques = Number(val(idx++) || 0);
     last7.push({ date: d, views, uniques });
   }
-  return { configured: true, totalViews, uniqueAll, last7, topPaths, topRefs };
+  return { configured: true, totalViews, uniqueAll, last7, topPaths, topRefs, topSources, topMediums, topCampaigns };
 }
 
 function pairs(h) {

--- a/wisprlitevercel/api/track.js
+++ b/wisprlitevercel/api/track.js
@@ -64,6 +64,14 @@ export default async function handler(req, res) {
   ];
   if (refHost) cmds.push(["HINCRBY", "pv:refs", refHost, 1]);
 
+  // First-party campaign attribution: aggregate counts of utm_* tags in the
+  // link the visitor followed. No PII; same first-party endpoint, no pixels.
+  const clean = (s) => String(s || "").toLowerCase().trim().replace(/[\r\n]/g, "").slice(0, 80);
+  const src = clean(body.utm_source), med = clean(body.utm_medium), camp = clean(body.utm_campaign);
+  if (src) cmds.push(["HINCRBY", "utm:source", src, 1]);
+  if (med) cmds.push(["HINCRBY", "utm:medium", med, 1]);
+  if (camp) cmds.push(["HINCRBY", "utm:campaign", camp, 1]);
+
   try {
     await fetch(`${url}/pipeline`, {
       method: "POST",

--- a/wisprlitevercel/index.html
+++ b/wisprlitevercel/index.html
@@ -643,7 +643,7 @@
   })();
 </script>
 <script>/* first-party, cookieless pageview beacon -> /api/track (disclosed in /privacy) */
-(function(){try{fetch("/api/track",{method:"POST",keepalive:true,headers:{"Content-Type":"application/json"},body:JSON.stringify({p:location.pathname,r:document.referrer})});}catch(e){}})();
+(function(){try{var q=new URLSearchParams(location.search),b={p:location.pathname,r:document.referrer};["utm_source","utm_medium","utm_campaign"].forEach(function(k){var v=q.get(k);if(v)b[k]=v;});fetch("/api/track",{method:"POST",keepalive:true,headers:{"Content-Type":"application/json"},body:JSON.stringify(b)});}catch(e){}})();
 </script>
 </body>
 </html>

--- a/wisprlitevercel/privacy.html
+++ b/wisprlitevercel/privacy.html
@@ -213,7 +213,7 @@
 
     <h3>Analytics and cookies on the website</h3>
     <p>The website sets no cookies and uses no localStorage, sessionStorage, or IndexedDB. We use no third-party analytics, no tag managers, no tracking pixels, and no third-party tracker scripts.</p>
-    <p>We do keep simple, first-party, aggregate analytics so we can see how many people visit. When a page loads, your browser sends the path you viewed and the referring website to our own <code>/api/track</code> endpoint. To estimate how many distinct people visit without identifying anyone, we take a one-way hash that mixes your IP address, browser user-agent, and the current date with a secret, and feed only that hash into an aggregate counter (a HyperLogLog). That counter stores no identifiers and cannot be reversed. Your IP address itself is never stored, and because the hash includes the date it changes every day, so it cannot be used to follow you over time or across days. These aggregate counts are held in our own Redis datastore (Upstash). We collect no names and nothing that identifies you.</p>
+    <p>We do keep simple, first-party, aggregate analytics so we can see how many people visit. When a page loads, your browser sends the path you viewed, the referring website, and any campaign tags (the <code>utm_source</code>, <code>utm_medium</code>, and <code>utm_campaign</code> values in the link you followed, if present) to our own <code>/api/track</code> endpoint. To estimate how many distinct people visit without identifying anyone, we take a one-way hash that mixes your IP address, browser user-agent, and the current date with a secret, and feed only that hash into an aggregate counter (a HyperLogLog). That counter stores no identifiers and cannot be reversed. Your IP address itself is never stored, and because the hash includes the date it changes every day, so it cannot be used to follow you over time or across days. These aggregate counts are held in our own Redis datastore (Upstash). We collect no names and nothing that identifies you.</p>
 
     <h2>Your Rights and How to Delete Your Data</h2>
     <ul>
@@ -247,7 +247,7 @@
   </footer>
 </div>
 <script>/* first-party, cookieless pageview beacon -> /api/track (disclosed below) */
-(function(){try{fetch("/api/track",{method:"POST",keepalive:true,headers:{"Content-Type":"application/json"},body:JSON.stringify({p:location.pathname,r:document.referrer})});}catch(e){}})();
+(function(){try{var q=new URLSearchParams(location.search),b={p:location.pathname,r:document.referrer};["utm_source","utm_medium","utm_campaign"].forEach(function(k){var v=q.get(k);if(v)b[k]=v;});fetch("/api/track",{method:"POST",keepalive:true,headers:{"Content-Type":"application/json"},body:JSON.stringify(b)});}catch(e){}})();
 </script>
 </body>
 </html>


### PR DESCRIPTION
Gives you the campaign-measurement upside ad pixels are usually for, with zero third-party tracking.

- Beacon sends `utm_source/medium/campaign` when present; `/api/track` aggregates counts (no PII); `/api/admin` returns them; admin gets a **Campaign attribution** panel (Sources / Mediums / Campaigns) with a tagging-pattern empty state.
- Privacy page updated to disclose UTM capture. Still 100% first-party and cookieless.
- Rendered the new panel with sample data before commit.