### PR TITLE
Voice commands + dictation history (v2.10.0)

### DIFF
--- a/installer/Pipevoice.iss
+++ b/installer/Pipevoice.iss
@@ -4,7 +4,7 @@
 ; Produces installer\Output\Pipevoice-Setup.exe — a per-user install (no admin).
 
 #define AppName "Pipevoice"
-#define AppVersion "2.9.1"
+#define AppVersion "2.10.0"
 #define AppExe "Pipevoice.exe"
 
 [Setup]

--- a/launch.py
+++ b/launch.py
@@ -7,6 +7,8 @@ import sys
 
 if "--settings" in sys.argv:
     from wisprlite.settings import main
+elif "--history" in sys.argv:
+    from wisprlite.history import main
 else:
     from wisprlite.app import main
 

--- a/wisprlite/__init__.py
+++ b/wisprlite/__init__.py
@@ -1,3 +1,3 @@
 """Pipevoice — push-to-talk voice typing for Windows."""
 
-__version__ = "2.9.1"
+__version__ = "2.10.0"

--- a/wisprlite/__main__.py
+++ b/wisprlite/__main__.py
@@ -2,6 +2,8 @@ import sys
 
 if "--settings" in sys.argv:
     from .settings import main
+elif "--history" in sys.argv:
+    from .history import main
 else:
     from .app import main
 

--- a/wisprlite/app.py
+++ b/wisprlite/app.py
@@ -148,25 +148,55 @@ class App:
                 self._set_icon("idle")
                 return
 
-            # AI cleanup ("Flow mode") — OpenAI / Gemini / OpenRouter / local Ollama; falls back to raw.
-            from . import cleanup
+            # Spoken commands (terminal actions) — run on the RAW transcript so
+            # cleanup can't reword "scratch that" / "send it".
+            from . import commands
 
-            if self.cfg.ai_cleanup and cleanup.provider_ready(self.cfg.cleanup_provider):
-                self.overlay.set_state("transcribing", "Polishing…")
-                polished = cleanup.clean(text, self.cfg.cleanup_provider, self.cfg.cleanup_model,
-                                         self.cfg.language, self.cfg.speech_notes)
-                if polished:
-                    text = polished
+            cmd = commands.pre(text, self.cfg.voice_commands)
+            if cmd.discard:
+                self.overlay.set_state("done", "✗ scratched")
+                self._beep(440, 80)
+                self._set_icon("idle")
+                return
+            text = cmd.text
+
+            # AI cleanup ("Flow mode") — OpenAI / Gemini / OpenRouter / local Ollama; falls back to raw.
+            if text and self.cfg.ai_cleanup:
+                from . import cleanup
+
+                if cleanup.provider_ready(self.cfg.cleanup_provider):
+                    self.overlay.set_state("transcribing", "Polishing…")
+                    polished = cleanup.clean(text, self.cfg.cleanup_provider, self.cfg.cleanup_model,
+                                             self.cfg.language, self.cfg.speech_notes)
+                    if polished:
+                        text = polished
+
+            # inline formatting commands ("new line") — after cleanup so newlines survive
+            text = commands.inline(text, self.cfg.voice_commands)
 
             # user word-fixes, applied last so they always stick
             text = apply_replacements(text, self.cfg.replacements)
 
+            press_enter = self.cfg.auto_enter or cmd.press_enter
+            if not text and not press_enter:
+                self.overlay.hide()
+                self._set_icon("idle")
+                return
+
             if self._clipboard_only:
-                copy_clipboard(text)
-                self.overlay.set_state("done", "Copied to clipboard")
+                if text:
+                    copy_clipboard(text)
+                self.overlay.set_state("done", "Copied to clipboard" if text else "↵")
             else:
-                self.overlay.set_state("done", text)
-                type_text(text, self.cfg.output_mode, press_enter=self.cfg.auto_enter)
+                self.overlay.set_state("done", text or "↵")
+                type_text(text, self.cfg.output_mode, press_enter=press_enter)
+            if self.cfg.history_enabled and text:
+                try:
+                    from . import history
+
+                    history.record(text, "clipboard" if self._clipboard_only else "typed")
+                except Exception:
+                    pass
             self._beep(990, 60)
             self._set_icon("idle")
         finally:
@@ -239,6 +269,21 @@ class App:
                 subprocess.Popen([_pythonw(), "-m", "wisprlite", "--settings"], cwd=parent)
         except Exception as exc:
             self._fail(f"settings: {exc}")
+
+    def open_history(self) -> None:
+        import os
+        import subprocess
+
+        try:
+            if getattr(sys, "frozen", False):
+                subprocess.Popen([sys.executable, "--history"])
+            else:
+                from .autostart import _pythonw
+
+                parent = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+                subprocess.Popen([_pythonw(), "-m", "wisprlite", "--history"], cwd=parent)
+        except Exception as exc:
+            self._fail(f"history: {exc}")
 
     def autostart_enabled(self) -> bool:
         return autostart.is_enabled()

--- a/wisprlite/commands.py
+++ b/wisprlite/commands.py
@@ -1,0 +1,79 @@
+"""Spoken commands: turn dictated phrases into formatting or control actions.
+
+Runs on the FINAL transcript inside app.py:_finish. Two kinds:
+
+  - Terminal actions (``pre`` — run on the RAW transcript, before AI cleanup so
+    cleanup can't reword them): "scratch that" discards the whole utterance;
+    "send it" / "press enter" type the text then hit Enter once. A trailing
+    "... send it" types the prefix and presses Enter.
+
+  - Inline substitutions (``inline`` — run AFTER cleanup so newlines survive):
+    a phrase standing alone becomes a literal, e.g. "new line" -> "\n".
+
+Matching is deliberately conservative so ordinary speech isn't mangled:
+terminal actions fire only when they are essentially the whole utterance, and
+inline phrases are replaced only when they stand alone (word boundaries).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+# phrase -> literal text, replaced only when the phrase stands alone
+INLINE = {
+    "new paragraph": "\n\n",
+    "new line": "\n",
+    "next line": "\n",
+    "newline": "\n",
+    "tab key": "\t",
+}
+
+# whole-utterance phrases that throw the dictation away
+DISCARD_PHRASES = {"scratch that", "cancel that", "delete that", "forget that", "never mind"}
+
+# whole-utterance (or trailing) phrases meaning "type it, then press Enter"
+ENTER_PHRASES = {"press enter", "send it", "send message", "hit enter", "enter key"}
+
+
+@dataclass
+class Result:
+    text: str
+    discard: bool = False
+    press_enter: bool = False
+
+
+def _norm(s: str) -> str:
+    return re.sub(r"[\s.,!?]+$", "", (s or "").strip().lower())
+
+
+def pre(text: str, enabled: bool = True) -> Result:
+    """Terminal actions on the raw transcript (before cleanup)."""
+    if not enabled or not text:
+        return Result(text=text)
+
+    whole = _norm(text)
+    if whole in DISCARD_PHRASES:
+        return Result(text="", discard=True)
+    if whole in ENTER_PHRASES:
+        return Result(text="", press_enter=True)
+
+    # trailing "... send it" -> type the prefix, then Enter
+    for phrase in ENTER_PHRASES:
+        m = re.search(rf"[\s,]+{re.escape(phrase)}[\s.,!?]*$", text, flags=re.IGNORECASE)
+        if m:
+            return Result(text=text[: m.start()].rstrip(), press_enter=True)
+
+    return Result(text=text)
+
+
+def inline(text: str, enabled: bool = True) -> str:
+    """Inline literal substitutions (after cleanup)."""
+    if not enabled or not text:
+        return text
+    out = text
+    for phrase, literal in INLINE.items():
+        # eat surrounding spaces/tabs and any punctuation the recognizer attached
+        # so "New line." -> "\n" and "a new line, b" -> "a\nb", not "\n." / " \n, "
+        out = re.sub(rf"[ \t]*(?<!\w){re.escape(phrase)}(?!\w)[.,!?]*[ \t]*", literal, out, flags=re.IGNORECASE)
+    return out

--- a/wisprlite/config.py
+++ b/wisprlite/config.py
@@ -77,6 +77,9 @@ class Config:
     speech_notes: str = ""          # free text about the user's accent / speech, fed to AI cleanup
     replacements: dict = field(default_factory=dict)  # {wrong: right} post-fixes
     key_prompt_skipped_for: str = ""  # engine the user dismissed the key prompt for (stops re-nagging)
+    voice_commands: bool = True       # spoken commands: "new line", "scratch that", "send it"
+    history_enabled: bool = True      # keep a local dictation history (history.jsonl)
+    history_size: int = 50            # entries shown in the history viewer
 
     @classmethod
     def load(cls) -> "Config":

--- a/wisprlite/history.py
+++ b/wisprlite/history.py
@@ -1,0 +1,187 @@
+"""Recent dictation history: a small JSONL log plus a viewer window.
+
+The running app appends each final transcript to %APPDATA%\\Pipevoice\\history.jsonl
+(newest last, capped). The viewer (``python -m wisprlite --history``) is a
+separate short-lived Tk process that reads the file and lets you re-copy any
+entry. JSONL is the source of truth because the viewer runs in its own process.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+
+from . import config
+
+CAP = 200  # max lines kept on disk
+
+BG = "#13151d"
+CARD = "#1b1e29"
+FG = "#e5e7eb"
+MUTED = "#94a3b8"
+ACCENT = "#e06c75"
+GOOD = "#98c379"
+
+
+def _path():
+    return config.config_dir() / "history.jsonl"
+
+
+def record(text: str, kind: str = "typed") -> None:
+    """Append one entry; keep at most CAP lines. Never raises."""
+    text = (text or "").strip()
+    if not text:
+        return
+    p = _path()
+    try:
+        lines = p.read_text(encoding="utf-8").splitlines() if p.exists() else []
+        lines.append(json.dumps({"ts": time.time(), "text": text, "kind": kind}, ensure_ascii=False))
+        if len(lines) > CAP:
+            lines = lines[-CAP:]
+        p.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    except Exception:
+        pass
+
+
+def load(limit: int = 50):
+    """Most recent entries, newest first. Never raises."""
+    out = []
+    try:
+        p = _path()
+        if p.exists():
+            for line in p.read_text(encoding="utf-8").splitlines():
+                line = line.strip()
+                if line:
+                    try:
+                        out.append(json.loads(line))
+                    except Exception:
+                        pass
+    except Exception:
+        pass
+    out.reverse()
+    return out[:limit]
+
+
+def clear() -> None:
+    try:
+        _path().unlink(missing_ok=True)
+    except Exception:
+        pass
+
+
+def _ago(ts: float) -> str:
+    try:
+        d = max(0, time.time() - float(ts))
+    except Exception:
+        return ""
+    if d < 60:
+        return "just now"
+    if d < 3600:
+        return f"{int(d // 60)}m ago"
+    if d < 86400:
+        return f"{int(d // 3600)}h ago"
+    return f"{int(d // 86400)}d ago"
+
+
+def main() -> None:
+    """The --history viewer window."""
+    try:
+        import tkinter as tk
+        from tkinter import ttk
+    except Exception:
+        return
+    from .typer import copy_clipboard
+
+    cfg = config.Config.load()
+    entries = load(getattr(cfg, "history_size", 50) or 50)
+
+    root = tk.Tk()
+    root.title("Pipevoice history")
+    root.configure(bg=BG)
+    ico = config.asset_path("wisprlite.ico")
+    if ico:
+        try:
+            root.iconbitmap(ico)
+        except Exception:
+            pass
+
+    style = ttk.Style(root)
+    try:
+        style.theme_use("clam")
+    except Exception:
+        pass
+    style.configure("TButton", background=CARD, foreground=FG, padding=5, borderwidth=0)
+    style.map("TButton", background=[("active", "#262a3a")])
+    style.configure("Vertical.TScrollbar", background=CARD, troughcolor=BG, borderwidth=0, arrowcolor=MUTED)
+
+    head = tk.Frame(root, bg=BG, padx=18, pady=14)
+    head.pack(fill="x")
+    tk.Label(head, text="Dictation history", bg=BG, fg=ACCENT,
+             font=("Segoe UI", 14, "bold")).pack(side="left")
+    tk.Label(head, text=f"  last {len(entries)}", bg=BG, fg=MUTED,
+             font=("Segoe UI", 9)).pack(side="left")
+
+    body = tk.Frame(root, bg=BG)
+    body.pack(fill="both", expand=True)
+    canvas = tk.Canvas(body, bg=BG, highlightthickness=0, width=520, height=440)
+    vbar = ttk.Scrollbar(body, orient="vertical", command=canvas.yview)
+    canvas.configure(yscrollcommand=vbar.set)
+    vbar.pack(side="right", fill="y")
+    canvas.pack(side="left", fill="both", expand=True)
+    inner = tk.Frame(canvas, bg=BG)
+    canvas.create_window((0, 0), window=inner, anchor="nw")
+    inner.bind("<Configure>", lambda e: canvas.configure(scrollregion=canvas.bbox("all")))
+    canvas.bind_all("<MouseWheel>", lambda e: canvas.yview_scroll(int(-e.delta / 120), "units"))
+
+    def copy_row(text, btn):
+        copy_clipboard(text)
+        btn.config(text="Copied ✓")
+        root.after(1100, lambda: btn.config(text="Copy"))
+
+    if not entries:
+        tk.Label(inner, text="Nothing dictated yet.", bg=BG, fg=MUTED,
+                 font=("Segoe UI", 10), padx=20, pady=24).pack(anchor="w")
+    for e in entries:
+        card = tk.Frame(inner, bg=CARD, padx=14, pady=11)
+        card.pack(fill="x", padx=16, pady=5)
+        top = tk.Frame(card, bg=CARD)
+        top.pack(fill="x")
+        kind = e.get("kind", "typed")
+        tk.Label(top, text=("◉ clipboard" if kind == "clipboard" else "◉ typed"),
+                 bg=CARD, fg=(GOOD if kind == "clipboard" else MUTED),
+                 font=("Consolas", 8)).pack(side="left")
+        tk.Label(top, text=_ago(e.get("ts", 0)), bg=CARD, fg=MUTED,
+                 font=("Consolas", 8)).pack(side="left", padx=(10, 0))
+        btn = ttk.Button(top, text="Copy")
+        btn.pack(side="right")
+        btn.config(command=lambda t=e.get("text", ""), b=btn: copy_row(t, b))
+        tk.Label(card, text=e.get("text", ""), bg=CARD, fg=FG, font=("Segoe UI", 10),
+                 anchor="w", justify="left", wraplength=460).pack(fill="x", pady=(6, 0))
+
+    foot = tk.Frame(root, bg=BG, padx=18, pady=12)
+    foot.pack(fill="x")
+
+    def do_clear():
+        clear()
+        for w in inner.winfo_children():
+            w.destroy()
+        tk.Label(inner, text="History cleared.", bg=BG, fg=MUTED,
+                 font=("Segoe UI", 10), padx=20, pady=24).pack(anchor="w")
+
+    tk.Button(foot, text="Clear history", command=do_clear, bg=CARD, fg=MUTED,
+              activebackground="#262a3a", activeforeground=FG, relief="flat",
+              padx=12, pady=6, font=("Segoe UI", 9)).pack(side="left")
+    tk.Button(foot, text="Close", command=root.destroy, bg=ACCENT, fg="#1a0c0d",
+              activebackground="#e8838b", relief="flat", padx=18, pady=6,
+              font=("Segoe UI", 9, "bold")).pack(side="right")
+
+    root.update_idletasks()
+    w = max(560, root.winfo_reqwidth())
+    h = min(620, max(360, root.winfo_reqheight()))
+    sw, sh = root.winfo_screenwidth(), root.winfo_screenheight()
+    root.geometry(f"{w}x{h}+{(sw - w) // 2}+{(sh - h) // 3}")
+    root.mainloop()
+
+
+if __name__ == "__main__":
+    main()

--- a/wisprlite/settings.py
+++ b/wisprlite/settings.py
@@ -282,6 +282,8 @@ def main(first_run: bool = False) -> None:
     sounds_var = tk.BooleanVar(value=cfg.sounds)
     autostart_var = tk.BooleanVar(value=autostart.is_enabled())
     auto_update_var = tk.BooleanVar(value=cfg.auto_update)
+    voice_commands_var = tk.BooleanVar(value=cfg.voice_commands)
+    history_var = tk.BooleanVar(value=cfg.history_enabled)
 
     def combo(var, options, width=26):
         c = ttk.Combobox(frm, textvariable=var, values=options, state="readonly", width=width)
@@ -397,6 +399,9 @@ def main(first_run: bool = False) -> None:
     ttk.Checkbutton(frm, text="Press Enter after typing (auto-send)",
                     variable=auto_enter_var).grid(row=row, column=0, columnspan=3,
                                                   sticky="w", padx=14, pady=3); row += 1
+    ttk.Checkbutton(frm, text="Spoken commands (\"new line\", \"scratch that\", \"send it\")",
+                    variable=voice_commands_var).grid(row=row, column=0, columnspan=3,
+                                                      sticky="w", padx=14, pady=3); row += 1
     label("Vocabulary", "names/jargon, comma-sep"); entry(vocab_var); row += 1
     label("Word fixes", "wrong=right, comma-sep"); entry(fixes_var); row += 1
     label("Speech notes", "accent / stutter / fillers — guides AI cleanup"); entry(speech_notes_var); row += 1
@@ -410,6 +415,8 @@ def main(first_run: bool = False) -> None:
     ttk.Checkbutton(frm, text="Start on Windows login", variable=autostart_var).grid(
         row=row, column=0, columnspan=2, sticky="w", padx=14, pady=3); row += 1
     ttk.Checkbutton(frm, text="Automatic updates (check on startup)", variable=auto_update_var).grid(
+        row=row, column=0, columnspan=2, sticky="w", padx=14, pady=3); row += 1
+    ttk.Checkbutton(frm, text="Keep a local dictation history", variable=history_var).grid(
         row=row, column=0, columnspan=2, sticky="w", padx=14, pady=3); row += 1
 
     # --- Save / Cancel (live in the fixed footer) ---
@@ -431,6 +438,8 @@ def main(first_run: bool = False) -> None:
         cfg.overlay = bool(overlay_var.get())
         cfg.sounds = bool(sounds_var.get())
         cfg.auto_update = bool(auto_update_var.get())
+        cfg.voice_commands = bool(voice_commands_var.get())
+        cfg.history_enabled = bool(history_var.get())
         cfg.ai_cleanup = bool(ai_cleanup_var.get())
         cfg.cleanup_provider = value_for(cleanup_var, CLEANUP_PROVIDERS)
         cfg.cleanup_model = cleanup_model_var.get().strip()

--- a/wisprlite/tray.py
+++ b/wisprlite/tray.py
@@ -88,6 +88,7 @@ class Tray:
             )),
             Menu.SEPARATOR,
             Item("Settings…", lambda i, it: app.open_settings(), default=True),
+            Item("History…", lambda i, it: app.open_history()),
             Item("Show overlay", lambda i, it: app.toggle_overlay(),
                  checked=lambda it: app.cfg.overlay),
             Item("Sounds", lambda i, it: app.toggle_sounds(),

--- a/wisprlite/typer.py
+++ b/wisprlite/typer.py
@@ -23,10 +23,10 @@ def apply_replacements(text: str, mapping: dict) -> str:
 
 
 def type_text(text: str, mode: str = "type", press_enter: bool = False) -> None:
-    if not text:
+    if not text and not press_enter:
         return
 
-    if mode == "paste":
+    if text and mode == "paste":
         try:
             import pyperclip
 
@@ -50,7 +50,8 @@ def type_text(text: str, mode: str = "type", press_enter: bool = False) -> None:
         except Exception:
             pass  # pyperclip missing or failed -> fall through to typing
 
-    keyboard.write(text, delay=0)
+    if text:
+        keyboard.write(text, delay=0)
     if press_enter:
         time.sleep(0.05)
         keyboard.send("enter")


### PR DESCRIPTION
Phase 1 of the approved upgrade plan (stickiness).

**Voice commands** (`commands.py`): "scratch that" discards; "send it"/"press enter" types then Enters (whole-utterance or trailing); "new line"/"new paragraph"/"tab key" become literals with attached punctuation/spaces consumed. Parsed in `_finish`: terminal actions before cleanup, inline subs after, user replacements still last.

**Dictation history** (`history.py`): final transcripts logged to `history.jsonl` (capped); new themed `--history` viewer (re-copy + clear) from the tray.

Both gated by settings toggles. Cross-model review (codex) caught two issues, fixed: `--history` now routed in the frozen `launch.py` entrypoint, and inline commands consume attached punctuation. compileall clean; commands + history unit-tested.