### PR TITLE
Advanced settings + vocabulary manager (v2.11.0)

### DIFF
--- a/installer/Pipevoice.iss
+++ b/installer/Pipevoice.iss
@@ -4,7 +4,7 @@
 ; Produces installer\Output\Pipevoice-Setup.exe — a per-user install (no admin).
 
 #define AppName "Pipevoice"
-#define AppVersion "2.10.0"
+#define AppVersion "2.11.0"
 #define AppExe "Pipevoice.exe"
 
 [Setup]

--- a/wisprlite/__init__.py
+++ b/wisprlite/__init__.py
@@ -1,3 +1,3 @@
 """Pipevoice — push-to-talk voice typing for Windows."""
 
-__version__ = "2.10.0"
+__version__ = "2.11.0"

--- a/wisprlite/app.py
+++ b/wisprlite/app.py
@@ -77,6 +77,7 @@ class App:
                 model=self.cfg.deepgram_model,
                 language=self.cfg.language or "en-US",
                 keywords=kw,
+                finish_timeout=self.cfg.deepgram_finish_timeout,
             )
         if name == "local":
             from .engines.local_engine import LocalEngine
@@ -189,7 +190,8 @@ class App:
                 self.overlay.set_state("done", "Copied to clipboard" if text else "↵")
             else:
                 self.overlay.set_state("done", text or "↵")
-                type_text(text, self.cfg.output_mode, press_enter=press_enter)
+                type_text(text, self.cfg.output_mode, press_enter=press_enter,
+                          paste_speed=self.cfg.paste_speed)
             if self.cfg.history_enabled and text:
                 try:
                     from . import history
@@ -366,7 +368,8 @@ class App:
         self.cfg = new  # hotkey/mode/output read live via lambdas
 
         engine_keys = ("engine", "openai_model", "deepgram_model",
-                       "local_model_size", "language", "device", "vocabulary")
+                       "local_model_size", "language", "device", "vocabulary",
+                       "deepgram_finish_timeout")
         if any(getattr(old, k) != getattr(new, k) for k in engine_keys):
             self._engine = None
             self.recorder.device = config.device_arg(new)

--- a/wisprlite/config.py
+++ b/wisprlite/config.py
@@ -80,6 +80,8 @@ class Config:
     voice_commands: bool = True       # spoken commands: "new line", "scratch that", "send it"
     history_enabled: bool = True      # keep a local dictation history (history.jsonl)
     history_size: int = 50            # entries shown in the history viewer
+    deepgram_finish_timeout: float = 6.0  # seconds to wait for Deepgram's final words
+    paste_speed: str = "normal"       # fast | normal | slow — clipboard-paste timing
 
     @classmethod
     def load(cls) -> "Config":

--- a/wisprlite/engines/deepgram_engine.py
+++ b/wisprlite/engines/deepgram_engine.py
@@ -36,6 +36,7 @@ class _DeepgramSession(Session):
         self._finals: list[str] = []
         self._done = threading.Event()
         self._error: Optional[str] = None
+        self._finish_timeout = getattr(engine, "finish_timeout", 6.0)
 
         listen = engine.client.listen
         if hasattr(listen, "websocket"):
@@ -103,7 +104,7 @@ class _DeepgramSession(Session):
             self.conn.finish()
         except Exception:
             pass
-        self._done.wait(timeout=6)
+        self._done.wait(timeout=self._finish_timeout)
         if self._error:
             raise RuntimeError(self._error)
         return " ".join(self._finals).strip()
@@ -120,13 +121,14 @@ class DeepgramEngine(Engine):
     streaming = True
 
     def __init__(self, api_key: str, model: str = "nova-2", language: str = "en-US",
-                 keywords: Optional[list] = None) -> None:
+                 keywords: Optional[list] = None, finish_timeout: float = 6.0) -> None:
         from deepgram import DeepgramClient
 
         self.client = DeepgramClient(api_key)
         self.model = model
         self.language = language
         self.keywords = keywords or None
+        self.finish_timeout = finish_timeout
 
     def start_session(self, on_partial: Optional[OnPartial] = None) -> Session:
         return _DeepgramSession(self, on_partial)

--- a/wisprlite/settings.py
+++ b/wisprlite/settings.py
@@ -18,6 +18,7 @@ ENGINES = [("deepgram", "Deepgram — fastest, live"),
            ("local", "Local Whisper — private & free, slower")]
 MODES = [("ptt", "Push-to-talk (hold)"), ("toggle", "Toggle (tap on/off)")]
 OUTPUTS = [("type", "Type keystrokes"), ("paste", "Clipboard + Ctrl+V")]
+PASTE_SPEEDS = [("fast", "Fast"), ("normal", "Normal"), ("slow", "Slow")]
 CLEANUP_PROVIDERS = [("openai", "OpenAI"), ("gemini", "Google Gemini (free tier)"),
                      ("openrouter", "OpenRouter (free models)"), ("ollama", "Local — Ollama (offline)")]
 LOCAL_SIZES = ["tiny.en", "base.en", "small.en", "medium.en",
@@ -275,7 +276,9 @@ def main(first_run: bool = False) -> None:
     cleanup_var = tk.StringVar(value=dict(CLEANUP_PROVIDERS).get(cfg.cleanup_provider, CLEANUP_PROVIDERS[0][1]))
     cleanup_model_var = tk.StringVar(value=cfg.cleanup_model)
     auto_enter_var = tk.BooleanVar(value=cfg.auto_enter)
-    vocab_var = tk.StringVar(value=cfg.vocabulary)
+    min_seconds_var = tk.StringVar(value=str(cfg.min_seconds))
+    dg_timeout_var = tk.StringVar(value=str(cfg.deepgram_finish_timeout))
+    paste_speed_var = tk.StringVar(value=dict(PASTE_SPEEDS).get(cfg.paste_speed, PASTE_SPEEDS[1][1]))
     fixes_var = tk.StringVar(value=", ".join(f"{k}={v}" for k, v in cfg.replacements.items()))
     speech_notes_var = tk.StringVar(value=cfg.speech_notes)
     overlay_var = tk.BooleanVar(value=cfg.overlay)
@@ -402,7 +405,35 @@ def main(first_run: bool = False) -> None:
     ttk.Checkbutton(frm, text="Spoken commands (\"new line\", \"scratch that\", \"send it\")",
                     variable=voice_commands_var).grid(row=row, column=0, columnspan=3,
                                                       sticky="w", padx=14, pady=3); row += 1
-    label("Vocabulary", "names/jargon, comma-sep"); entry(vocab_var); row += 1
+    label("Vocabulary", "names & jargon — better recognition"); row += 1
+    vocab_box = tk.Frame(frm, bg=BG)
+    vocab_box.grid(row=row, column=0, columnspan=3, sticky="w", padx=14, pady=(0, 6))
+    vocab_list = tk.Listbox(vocab_box, height=4, width=30, bg=CARD, fg=FG,
+                            selectbackground=ACCENT, selectforeground="#1a0c0d",
+                            highlightthickness=1, highlightbackground="#2a2e3d",
+                            relief="flat", activestyle="none", exportselection=False,
+                            font=("Segoe UI", 9))
+    vocab_list.grid(row=0, column=0, rowspan=2, sticky="w")
+    for _t in [t.strip() for t in (cfg.vocabulary or "").split(",") if t.strip()]:
+        vocab_list.insert("end", _t)
+    vocab_add_var = tk.StringVar()
+    _vadd = ttk.Entry(vocab_box, textvariable=vocab_add_var, width=20)
+    _vadd.grid(row=0, column=1, padx=(8, 0), sticky="nw")
+
+    def _vocab_add(*_a):
+        t = vocab_add_var.get().strip().strip(",")
+        if t and t not in vocab_list.get(0, "end"):
+            vocab_list.insert("end", t)
+        vocab_add_var.set("")
+
+    def _vocab_remove():
+        for i in reversed(vocab_list.curselection()):
+            vocab_list.delete(i)
+
+    _vadd.bind("<Return>", _vocab_add)
+    ttk.Button(vocab_box, text="Add", command=_vocab_add, width=7).grid(row=0, column=2, padx=(6, 0), sticky="nw")
+    ttk.Button(vocab_box, text="Remove", command=_vocab_remove, width=7).grid(row=1, column=1, padx=(8, 0), pady=(4, 0), sticky="nw")
+    row += 1
     label("Word fixes", "wrong=right, comma-sep"); entry(fixes_var); row += 1
     label("Speech notes", "accent / stutter / fillers — guides AI cleanup"); entry(speech_notes_var); row += 1
 
@@ -418,6 +449,14 @@ def main(first_run: bool = False) -> None:
         row=row, column=0, columnspan=2, sticky="w", padx=14, pady=3); row += 1
     ttk.Checkbutton(frm, text="Keep a local dictation history", variable=history_var).grid(
         row=row, column=0, columnspan=2, sticky="w", padx=14, pady=3); row += 1
+
+    # --- Advanced ---
+    header("Advanced")
+    ttk.Label(frm, text="Most people never need these.",
+              style="Muted.TLabel").grid(row=row, column=0, columnspan=3, sticky="w", padx=14); row += 1
+    label("Min seconds", "ignore taps shorter than this"); entry(min_seconds_var, width=8); row += 1
+    label("Deepgram wait", "seconds to wait for final words"); entry(dg_timeout_var, width=8); row += 1
+    label("Paste speed", "slower is more reliable in some apps"); combo(paste_speed_var, [l for _, l in PASTE_SPEEDS], width=12); row += 1
 
     # --- Save / Cancel (live in the fixed footer) ---
     def value_for(var, table):
@@ -444,7 +483,16 @@ def main(first_run: bool = False) -> None:
         cfg.cleanup_provider = value_for(cleanup_var, CLEANUP_PROVIDERS)
         cfg.cleanup_model = cleanup_model_var.get().strip()
         cfg.auto_enter = bool(auto_enter_var.get())
-        cfg.vocabulary = vocab_var.get().strip()
+        cfg.vocabulary = ", ".join(vocab_list.get(0, "end"))
+        try:
+            cfg.min_seconds = max(0.05, min(2.0, float(min_seconds_var.get())))
+        except ValueError:
+            pass
+        try:
+            cfg.deepgram_finish_timeout = max(1.0, min(30.0, float(dg_timeout_var.get())))
+        except ValueError:
+            pass
+        cfg.paste_speed = value_for(paste_speed_var, PASTE_SPEEDS)
         cfg.speech_notes = speech_notes_var.get().strip()
         fixes = {}
         for part in fixes_var.get().split(","):

--- a/wisprlite/typer.py
+++ b/wisprlite/typer.py
@@ -22,9 +22,19 @@ def apply_replacements(text: str, mapping: dict) -> str:
     return text
 
 
-def type_text(text: str, mode: str = "type", press_enter: bool = False) -> None:
+PASTE_TIMINGS = {
+    # (sleep before paste, sleep before clipboard-restore, sleep before Enter)
+    "fast":   (0.01, 0.08, 0.03),
+    "normal": (0.03, 0.15, 0.05),
+    "slow":   (0.09, 0.35, 0.12),
+}
+
+
+def type_text(text: str, mode: str = "type", press_enter: bool = False,
+              paste_speed: str = "normal") -> None:
     if not text and not press_enter:
         return
+    pre_ms, restore_ms, enter_ms = PASTE_TIMINGS.get(paste_speed, PASTE_TIMINGS["normal"])
 
     if text and mode == "paste":
         try:
@@ -35,16 +45,16 @@ def type_text(text: str, mode: str = "type", press_enter: bool = False) -> None:
             except Exception:
                 prev = None
             pyperclip.copy(text)
-            time.sleep(0.03)
+            time.sleep(pre_ms)
             keyboard.send("ctrl+v")
             if prev is not None:
-                time.sleep(0.15)
+                time.sleep(restore_ms)
                 try:
                     pyperclip.copy(prev)
                 except Exception:
                     pass
             if press_enter:
-                time.sleep(0.05)
+                time.sleep(enter_ms)
                 keyboard.send("enter")
             return
         except Exception:
@@ -53,7 +63,7 @@ def type_text(text: str, mode: str = "type", press_enter: bool = False) -> None:
     if text:
         keyboard.write(text, delay=0)
     if press_enter:
-        time.sleep(0.05)
+        time.sleep(enter_ms)
         keyboard.send("enter")
 
 


### PR DESCRIPTION
Phase 2 (speed & accuracy).

**Advanced section**: exposes the previously-hardcoded **Min seconds**, **Deepgram wait** (finish timeout, threaded through the engine), and a **Paste speed** Fast/Normal/Slow enum (replaces hardcoded paste sleeps via `typer.PASTE_TIMINGS`). `deepgram_finish_timeout` added to the engine-rebuild keys.

**Vocabulary manager**: the cramped single field becomes a Listbox + Add/Remove, still stored as the same comma-joined string so engine plumbing is untouched.

compileall clean; codex review clean; no dangling `vocab_var`.