### PR TITLE
UI polish: dark title bar + whitespace + About tab (v2.13.0)

### DIFF
--- a/installer/Pipevoice.iss
+++ b/installer/Pipevoice.iss
@@ -4,7 +4,7 @@
 ; Produces installer\Output\Pipevoice-Setup.exe — a per-user install (no admin).
 
 #define AppName "Pipevoice"
-#define AppVersion "2.12.0"
+#define AppVersion "2.13.0"
 #define AppExe "Pipevoice.exe"
 
 [Setup]

--- a/wisprlite/__init__.py
+++ b/wisprlite/__init__.py
@@ -1,3 +1,3 @@
 """Pipevoice — push-to-talk voice typing for Windows."""
 
-__version__ = "2.12.0"
+__version__ = "2.13.0"

--- a/wisprlite/about.py
+++ b/wisprlite/about.py
@@ -1,10 +1,8 @@
-"""About / Updates window (python -m wisprlite --about).
+"""About / Updates: current version, live update check, "Update now", changelog.
 
-Shows the current version, checks GitHub for a newer release, offers an
-"Update now" button, and lists recent release notes as a changelog. Runs as a
-short-lived separate Tk process (same pattern as settings/history), so the
-"Update now" path just calls the proven updater.download_and_run() and lets the
-Inno installer close + relaunch the app.
+`build(container, root, wheel)` populates any frame, so the same UI is used both
+as the standalone --about window and as the About tab inside Settings. `main()`
+wraps it in its own short-lived Tk process.
 """
 
 from __future__ import annotations
@@ -54,76 +52,55 @@ def _date(iso: str) -> str:
     return f"{int(d)} {months[int(mo)]} {y}"
 
 
-def main() -> None:
-    try:
-        import tkinter as tk
-        from tkinter import ttk
-    except Exception:
-        return
+def _wheel_global(canvas):
+    canvas.bind("<Enter>", lambda e: canvas.bind_all(
+        "<MouseWheel>", lambda ev: canvas.yview_scroll(int(-ev.delta / 120), "units")))
+    canvas.bind("<Leave>", lambda e: canvas.unbind_all("<MouseWheel>"))
+
+
+def build(container, root, wheel=None) -> None:
+    """Populate `container` with the About/Updates UI. `root` is the toplevel
+    (used for thread-safe .after); `wheel` scopes mousewheel to our canvas."""
+    import tkinter as tk
+    from tkinter import ttk
     from . import updater
 
+    if wheel is None:
+        wheel = _wheel_global
     state = {"info": None}
 
-    root = tk.Tk()
-    root.title("About Pipevoice")
-    root.configure(bg=BG)
-    root.resizable(False, True)
-    ico = config.asset_path("wisprlite.ico")
-    if ico:
-        try:
-            root.iconbitmap(ico)
-        except Exception:
-            pass
-
-    style = ttk.Style(root)
-    try:
-        style.theme_use("clam")
-    except Exception:
-        pass
-    style.configure("TButton", background=CARD, foreground=FG, padding=7, borderwidth=0)
-    style.map("TButton", background=[("active", "#262a3a")], foreground=[("disabled", MUTED)])
-    style.configure("Accent.TButton", background=ACCENT, foreground="#1a0c0d",
-                    font=("Segoe UI", 9, "bold"), padding=8, borderwidth=0)
-    style.map("Accent.TButton", background=[("active", "#e8838b")])
-    style.configure("Vertical.TScrollbar", background=CARD, troughcolor=BG, borderwidth=0, arrowcolor=MUTED)
-
-    head = tk.Frame(root, bg=BG, padx=26, pady=20)
+    head = tk.Frame(container, bg=BG, padx=28, pady=24)
     head.pack(fill="x")
     tk.Label(head, text="Pipevoice", bg=BG, fg=ACCENT, font=("Segoe UI", 21, "bold")).pack(anchor="w")
     tk.Label(head, text=f"Version {__version__}", bg=BG, fg=MUTED,
-             font=("Consolas", 10)).pack(anchor="w", pady=(1, 12))
+             font=("Consolas", 10)).pack(anchor="w", pady=(3, 16))
 
     status = tk.Label(head, text="Checking for updates…", bg=BG, fg=MUTED, font=("Segoe UI", 10))
     status.pack(anchor="w")
-    btn = ttk.Button(head, text="Checking…", state="disabled", style="Accent.TButton")
-    btn.pack(anchor="w", pady=(10, 0))
+    actions = tk.Frame(head, bg=BG)
+    actions.pack(anchor="w", fill="x", pady=(14, 0))
+    btn = ttk.Button(actions, text="Checking…", state="disabled", style="Accent.TButton")
+    btn.pack(side="left")
+    link = tk.Label(actions, text="All releases ↗", bg=BG, fg=ACCENT, cursor="hand2",
+                    font=("Segoe UI", 9, "underline"))
+    link.pack(side="left", padx=(16, 0))
+    link.bind("<Button-1>", lambda e: webbrowser.open(RELEASES_URL))
 
-    tk.Label(root, text="WHAT'S NEW", bg=BG, fg=ACCENT,
-             font=("Segoe UI", 9, "bold")).pack(anchor="w", padx=26, pady=(16, 4))
+    tk.Label(container, text="WHAT'S NEW", bg=BG, fg=ACCENT,
+             font=("Segoe UI", 9, "bold")).pack(anchor="w", padx=28, pady=(20, 8))
 
-    body = tk.Frame(root, bg=BG)
-    body.pack(fill="both", expand=True)
-    canvas = tk.Canvas(body, bg=BG, highlightthickness=0, width=480, height=300)
-    vbar = ttk.Scrollbar(body, orient="vertical", command=canvas.yview)
+    bodyf = tk.Frame(container, bg=BG)
+    bodyf.pack(fill="both", expand=True)
+    canvas = tk.Canvas(bodyf, bg=BG, highlightthickness=0, width=480, height=280)
+    vbar = ttk.Scrollbar(bodyf, orient="vertical", command=canvas.yview)
     canvas.configure(yscrollcommand=vbar.set)
     vbar.pack(side="right", fill="y")
     canvas.pack(side="left", fill="both", expand=True)
     inner = tk.Frame(canvas, bg=BG)
     canvas.create_window((0, 0), window=inner, anchor="nw")
     inner.bind("<Configure>", lambda e: canvas.configure(scrollregion=canvas.bbox("all")))
-    canvas.bind_all("<MouseWheel>", lambda e: canvas.yview_scroll(int(-e.delta / 120), "units"))
+    wheel(canvas)
 
-    foot = tk.Frame(root, bg=BG, padx=26, pady=12)
-    foot.pack(fill="x")
-    link = tk.Label(foot, text="All releases on GitHub ↗", bg=BG, fg=ACCENT, cursor="hand2",
-                    font=("Segoe UI", 9, "underline"))
-    link.pack(side="left")
-    link.bind("<Button-1>", lambda e: webbrowser.open(RELEASES_URL))
-    tk.Button(foot, text="Close", command=root.destroy, bg=CARD, fg=FG, relief="flat",
-              activebackground="#262a3a", activeforeground=FG, padx=16, pady=6,
-              font=("Segoe UI", 9)).pack(side="right")
-
-    # ---- update flow ----
     def do_update():
         btn.config(state="disabled", text="Downloading…")
         status.config(text="Downloading the update…", fg=MUTED)
@@ -168,17 +145,16 @@ def main() -> None:
             w.destroy()
         if not rels:
             tk.Label(inner, text="Could not load release notes.", bg=BG, fg=MUTED,
-                     font=("Segoe UI", 10), padx=26, pady=10).pack(anchor="w")
+                     font=("Segoe UI", 10), padx=28, pady=10).pack(anchor="w")
             return
         for rel in rels:
-            card = tk.Frame(inner, bg=CARD, padx=14, pady=11)
-            card.pack(fill="x", padx=22, pady=5)
+            card = tk.Frame(inner, bg=CARD, padx=15, pady=12)
+            card.pack(fill="x", padx=24, pady=6)
             top = tk.Frame(card, bg=CARD)
             top.pack(fill="x")
             tag = rel.get("tag", "")
-            is_current = tag.lstrip("vV") == __version__
-            tk.Label(top, text=tag, bg=CARD, fg=FG, font=("Segoe UI", 10, "bold")).pack(side="left")
-            if is_current:
+            tk.Label(top, text=tag, bg=CARD, fg=FG, font=("Segoe UI", 11, "bold")).pack(side="left")
+            if tag.lstrip("vV") == __version__:
                 tk.Label(top, text=" current ", bg=ACCENT, fg="#1a0c0d",
                          font=("Segoe UI", 7, "bold")).pack(side="left", padx=(8, 0))
             dt = _date(rel.get("published_at", ""))
@@ -186,7 +162,7 @@ def main() -> None:
                 tk.Label(top, text=dt, bg=CARD, fg=MUTED, font=("Consolas", 8)).pack(side="right")
             notes = _clean_notes(rel.get("body", "")) or "No notes for this release."
             tk.Label(card, text=notes, bg=CARD, fg=MUTED, font=("Segoe UI", 9),
-                     anchor="w", justify="left", wraplength=430).pack(fill="x", pady=(6, 0))
+                     anchor="w", justify="left", wraplength=430).pack(fill="x", pady=(7, 0))
 
     def load_changelog():
         def work():
@@ -195,15 +171,57 @@ def main() -> None:
         threading.Thread(target=work, daemon=True).start()
 
     tk.Label(inner, text="Loading release notes…", bg=BG, fg=MUTED,
-             font=("Segoe UI", 10), padx=26, pady=10).pack(anchor="w")
+             font=("Segoe UI", 10), padx=28, pady=10).pack(anchor="w")
     check()
     load_changelog()
 
+
+def main() -> None:
+    try:
+        import tkinter as tk
+        from tkinter import ttk
+    except Exception:
+        return
+    from . import winui
+
+    root = tk.Tk()
+    root.title("About Pipevoice")
+    root.configure(bg=BG)
+    root.resizable(False, True)
+    ico = config.asset_path("wisprlite.ico")
+    if ico:
+        try:
+            root.iconbitmap(ico)
+        except Exception:
+            pass
+
+    style = ttk.Style(root)
+    try:
+        style.theme_use("clam")
+    except Exception:
+        pass
+    style.configure("Accent.TButton", background=ACCENT, foreground="#1a0c0d",
+                    font=("Segoe UI", 9, "bold"), padding=8, borderwidth=0)
+    style.map("Accent.TButton", background=[("active", "#e8838b")])
+    style.configure("TButton", background=CARD, foreground=FG, padding=7, borderwidth=0)
+    style.map("TButton", background=[("active", "#262a3a")], foreground=[("disabled", MUTED)])
+    style.configure("Vertical.TScrollbar", background=CARD, troughcolor=BG, borderwidth=0, arrowcolor=MUTED)
+
+    # Reserve the bottom for Close first, then build fills the cavity above it.
+    foot = tk.Frame(root, bg=BG, padx=28, pady=14)
+    foot.pack(side="bottom", fill="x")
+    tk.Button(foot, text="Close", command=root.destroy, bg=CARD, fg=FG, relief="flat",
+              activebackground="#262a3a", activeforeground=FG, padx=18, pady=6,
+              font=("Segoe UI", 9)).pack(side="right")
+
+    build(root, root)
+
     root.update_idletasks()
-    w = max(540, root.winfo_reqwidth())
-    h = min(640, max(420, root.winfo_reqheight()))
+    w = max(560, root.winfo_reqwidth())
+    h = min(660, max(440, root.winfo_reqheight()))
     sw, sh = root.winfo_screenwidth(), root.winfo_screenheight()
     root.geometry(f"{w}x{h}+{(sw - w) // 2}+{(sh - h) // 3}")
+    winui.dark_titlebar(root)
     root.mainloop()
 
 

--- a/wisprlite/history.py
+++ b/wisprlite/history.py
@@ -180,6 +180,8 @@ def main() -> None:
     h = min(620, max(360, root.winfo_reqheight()))
     sw, sh = root.winfo_screenwidth(), root.winfo_screenheight()
     root.geometry(f"{w}x{h}+{(sw - w) // 2}+{(sh - h) // 3}")
+    from . import winui
+    winui.dark_titlebar(root)
     root.mainloop()
 
 

--- a/wisprlite/keyprompt.py
+++ b/wisprlite/keyprompt.py
@@ -158,6 +158,8 @@ def _dialog(cfg) -> None:
     w, h = root.winfo_width(), root.winfo_height()
     sw, sh = root.winfo_screenwidth(), root.winfo_screenheight()
     root.geometry(f"+{(sw - w) // 2}+{(sh - h) // 3}")
+    from . import winui
+    winui.dark_titlebar(root)
     try:
         root.attributes("-topmost", True)
     except Exception:

--- a/wisprlite/settings.py
+++ b/wisprlite/settings.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import threading
 
-from . import autostart, cleanup, config
+from . import about, autostart, cleanup, config, winui
 
 ENGINES = [("deepgram", "Deepgram — fastest, live"),
            ("openai", "OpenAI Whisper — accurate, slight wait"),
@@ -179,10 +179,11 @@ def main(first_run: bool = False) -> None:
     except Exception:
         pass
     style.configure(".", background=BG, foreground=FG, fieldbackground=CARD,
-                    bordercolor="#2a2e3d", lightcolor=CARD, darkcolor=CARD)
-    style.configure("TLabel", background=BG, foreground=FG)
-    style.configure("Muted.TLabel", background=BG, foreground=MUTED, font=("Segoe UI", 8))
-    style.configure("Head.TLabel", background=BG, foreground=ACCENT, font=("Segoe UI", 10, "bold"))
+                    bordercolor="#2a2e3d", lightcolor=CARD, darkcolor=CARD,
+                    font=("Segoe UI", 10))
+    style.configure("TLabel", background=BG, foreground=FG, font=("Segoe UI", 10))
+    style.configure("Muted.TLabel", background=BG, foreground=MUTED, font=("Segoe UI", 9))
+    style.configure("Head.TLabel", background=BG, foreground=ACCENT, font=("Segoe UI", 13, "bold"))
     style.configure("TButton", background=CARD, foreground=FG, padding=6)
     style.map("TButton", background=[("active", "#262a3a")])
     style.configure("Accent.TButton", background=ACCENT, foreground="#1a0c0d",
@@ -211,7 +212,7 @@ def main(first_run: bool = False) -> None:
     root.option_add("*TCombobox*Listbox.selectForeground", "#1a0c0d")
     style.configure("TEntry", fieldbackground=CARD, foreground=FG, insertcolor=FG)
 
-    pad = dict(padx=14, pady=5, sticky="w")
+    pad = dict(padx=14, pady=8, sticky="w")
 
     def _wheel(canvas):
         # Scroll whichever canvas the pointer is over (two scroll areas exist).
@@ -227,8 +228,10 @@ def main(first_run: bool = False) -> None:
     nb.pack(side="top", fill="both", expand=True)
     tab_settings = ttk.Frame(nb)
     tab_guide = ttk.Frame(nb)
+    tab_about = ttk.Frame(nb)
     nb.add(tab_settings, text="Settings")
     nb.add(tab_guide, text="Guide")
+    nb.add(tab_about, text="About")
 
     # --- Settings tab: scrollable form ---
     _canvas = tk.Canvas(tab_settings, bg=BG, highlightthickness=0)
@@ -236,17 +239,18 @@ def main(first_run: bool = False) -> None:
     _canvas.configure(yscrollcommand=_vbar.set)
     _vbar.pack(side="right", fill="y")
     _canvas.pack(side="left", fill="both", expand=True)
-    frm = ttk.Frame(_canvas, padding=18)
+    frm = ttk.Frame(_canvas, padding=26)
     _canvas.create_window((0, 0), window=frm, anchor="nw")
     frm.bind("<Configure>", lambda e: _canvas.configure(scrollregion=_canvas.bbox("all")))
     _wheel(_canvas)
     _build_guide(tab_guide, _wheel)
+    about.build(tab_about, root, _wheel)
     row = 0
 
     def header(text):
         nonlocal row
         ttk.Label(frm, text=text, style="Head.TLabel").grid(row=row, column=0, columnspan=3,
-                                                             sticky="w", padx=14, pady=(12, 2))
+                                                             sticky="w", padx=14, pady=(24, 6))
         row += 1
 
     def label(text, hint=None):
@@ -290,12 +294,12 @@ def main(first_run: bool = False) -> None:
 
     def combo(var, options, width=26):
         c = ttk.Combobox(frm, textvariable=var, values=options, state="readonly", width=width)
-        c.grid(row=row, column=1, padx=6, pady=5, sticky="w")
+        c.grid(row=row, column=1, padx=6, pady=8, sticky="w")
         return c
 
     def entry(var, width=29):
         e = ttk.Entry(frm, textvariable=var, width=width)
-        e.grid(row=row, column=1, padx=6, pady=5, sticky="w")
+        e.grid(row=row, column=1, padx=6, pady=8, sticky="w")
         return e
 
     # --- General ---
@@ -375,14 +379,14 @@ def main(first_run: bool = False) -> None:
     header("API keys")
     label("OpenAI key", "saved" if config.openai_key() else "not set")
     e_oai = ttk.Entry(frm, textvariable=oai_key_var, width=29, show="•")
-    e_oai.grid(row=row, column=1, padx=6, pady=5, sticky="w"); row += 1
+    e_oai.grid(row=row, column=1, padx=6, pady=8, sticky="w"); row += 1
     label("Deepgram key", "saved" if config.deepgram_key() else "not set")
     e_dg = ttk.Entry(frm, textvariable=dg_key_var, width=29, show="•")
-    e_dg.grid(row=row, column=1, padx=6, pady=5, sticky="w"); row += 1
+    e_dg.grid(row=row, column=1, padx=6, pady=8, sticky="w"); row += 1
     label("Gemini key", "saved" if config.gemini_key() else "not set")
-    ttk.Entry(frm, textvariable=gem_key_var, width=29, show="•").grid(row=row, column=1, padx=6, pady=5, sticky="w"); row += 1
+    ttk.Entry(frm, textvariable=gem_key_var, width=29, show="•").grid(row=row, column=1, padx=6, pady=8, sticky="w"); row += 1
     label("OpenRouter key", "saved" if config.openrouter_key() else "not set")
-    ttk.Entry(frm, textvariable=or_key_var, width=29, show="•").grid(row=row, column=1, padx=6, pady=5, sticky="w"); row += 1
+    ttk.Entry(frm, textvariable=or_key_var, width=29, show="•").grid(row=row, column=1, padx=6, pady=8, sticky="w"); row += 1
     ttk.Label(frm, text="Leave a key blank to keep the current one.",
               style="Muted.TLabel").grid(row=row, column=0, columnspan=3,
                                           sticky="w", padx=14); row += 1
@@ -391,7 +395,7 @@ def main(first_run: bool = False) -> None:
     header("Transcription")
     ttk.Checkbutton(frm, text="Polish with AI (Flow mode — tidies fillers & punctuation)",
                     variable=ai_cleanup_var).grid(row=row, column=0, columnspan=3,
-                                                  sticky="w", padx=14, pady=3); row += 1
+                                                  sticky="w", padx=14, pady=5); row += 1
     label("Cleanup with"); combo(cleanup_var, [l for _, l in CLEANUP_PROVIDERS], width=24); row += 1
     label("Cleanup model", "blank = provider default"); entry(cleanup_model_var); row += 1
 
@@ -401,10 +405,10 @@ def main(first_run: bool = False) -> None:
     cleanup_var.trace_add("write", _on_cleanup_provider)
     ttk.Checkbutton(frm, text="Press Enter after typing (auto-send)",
                     variable=auto_enter_var).grid(row=row, column=0, columnspan=3,
-                                                  sticky="w", padx=14, pady=3); row += 1
+                                                  sticky="w", padx=14, pady=5); row += 1
     ttk.Checkbutton(frm, text="Spoken commands (\"new line\", \"scratch that\", \"send it\")",
                     variable=voice_commands_var).grid(row=row, column=0, columnspan=3,
-                                                      sticky="w", padx=14, pady=3); row += 1
+                                                      sticky="w", padx=14, pady=5); row += 1
     label("Vocabulary", "names & jargon — better recognition"); row += 1
     vocab_box = tk.Frame(frm, bg=BG)
     vocab_box.grid(row=row, column=0, columnspan=3, sticky="w", padx=14, pady=(0, 6))
@@ -440,15 +444,15 @@ def main(first_run: bool = False) -> None:
     # --- Toggles ---
     header("Behaviour")
     ttk.Checkbutton(frm, text="Show live overlay", variable=overlay_var).grid(
-        row=row, column=0, columnspan=2, sticky="w", padx=14, pady=3); row += 1
+        row=row, column=0, columnspan=2, sticky="w", padx=14, pady=5); row += 1
     ttk.Checkbutton(frm, text="Play start/stop sounds", variable=sounds_var).grid(
-        row=row, column=0, columnspan=2, sticky="w", padx=14, pady=3); row += 1
+        row=row, column=0, columnspan=2, sticky="w", padx=14, pady=5); row += 1
     ttk.Checkbutton(frm, text="Start on Windows login", variable=autostart_var).grid(
-        row=row, column=0, columnspan=2, sticky="w", padx=14, pady=3); row += 1
+        row=row, column=0, columnspan=2, sticky="w", padx=14, pady=5); row += 1
     ttk.Checkbutton(frm, text="Automatic updates (check on startup)", variable=auto_update_var).grid(
-        row=row, column=0, columnspan=2, sticky="w", padx=14, pady=3); row += 1
+        row=row, column=0, columnspan=2, sticky="w", padx=14, pady=5); row += 1
     ttk.Checkbutton(frm, text="Keep a local dictation history", variable=history_var).grid(
-        row=row, column=0, columnspan=2, sticky="w", padx=14, pady=3); row += 1
+        row=row, column=0, columnspan=2, sticky="w", padx=14, pady=5); row += 1
 
     # --- Advanced ---
     header("Advanced")
@@ -535,6 +539,7 @@ def main(first_run: bool = False) -> None:
     x = max(0, (sw - win_w) // 2)
     y = max(0, (sh - win_h) // 3)
     root.geometry(f"{win_w}x{win_h}+{x}+{y}")
+    winui.dark_titlebar(root)
     root.mainloop()
 
 

--- a/wisprlite/welcome.py
+++ b/wisprlite/welcome.py
@@ -155,6 +155,8 @@ def show_welcome() -> bool:
     w, h = root.winfo_width(), root.winfo_height()
     sw, sh = root.winfo_screenwidth(), root.winfo_screenheight()
     root.geometry(f"+{(sw - w) // 2}+{max(0, (sh - h) // 5)}")
+    from . import winui
+    winui.dark_titlebar(root)
     try:
         root.attributes("-topmost", True)
     except Exception:

--- a/wisprlite/winui.py
+++ b/wisprlite/winui.py
@@ -1,0 +1,30 @@
+"""Windows-only window-chrome helpers. Silent no-op on other platforms / older
+Windows builds, so callers can always call them.
+"""
+
+from __future__ import annotations
+
+import ctypes
+
+DARK = "#13151d"
+
+
+def dark_titlebar(root, color: str = DARK) -> None:
+    """Force a dark title bar (Windows 10 1809+ / 11) instead of the user's
+    accent color. No-op if DWM is unavailable."""
+    try:
+        root.update_idletasks()
+        hwnd = ctypes.windll.user32.GetParent(root.winfo_id())
+        dwm = ctypes.windll.dwmapi
+        # DWMWA_USE_IMMERSIVE_DARK_MODE = 20 (was 19 on early 1809 builds)
+        on = ctypes.c_int(1)
+        if dwm.DwmSetWindowAttribute(hwnd, 20, ctypes.byref(on), ctypes.sizeof(on)) != 0:
+            dwm.DwmSetWindowAttribute(hwnd, 19, ctypes.byref(on), ctypes.sizeof(on))
+        # DWMWA_CAPTION_COLOR = 35 (Win 11 22000+): match our dark background. 0x00BBGGRR
+        r = int(color[1:3], 16)
+        g = int(color[3:5], 16)
+        b = int(color[5:7], 16)
+        bgr = ctypes.c_int((b << 16) | (g << 8) | r)
+        dwm.DwmSetWindowAttribute(hwnd, 35, ctypes.byref(bgr), ctypes.sizeof(bgr))
+    except Exception:
+        pass


### PR DESCRIPTION
Acts on UI feedback: forces a **dark title bar** (kills the red OS-accent caption) across all dialogs via DWM; bigger type hierarchy + more whitespace in Settings; and **About / What's new is now a Settings tab** (reused via about.build()), not just the tray. compileall + codex clean.