### PR TITLE
Per-app profiles + clipboard fallback (v2.14.0)

### DIFF
--- a/installer/Pipevoice.iss
+++ b/installer/Pipevoice.iss
@@ -4,7 +4,7 @@
 ; Produces installer\Output\Pipevoice-Setup.exe — a per-user install (no admin).
 
 #define AppName "Pipevoice"
-#define AppVersion "2.13.0"
+#define AppVersion "2.14.0"
 #define AppExe "Pipevoice.exe"
 
 [Setup]

--- a/launch.py
+++ b/launch.py
@@ -11,6 +11,8 @@ elif "--history" in sys.argv:
     from wisprlite.history import main
 elif "--about" in sys.argv:
     from wisprlite.about import main
+elif "--profiles" in sys.argv:
+    from wisprlite.profiles import main
 else:
     from wisprlite.app import main
 

--- a/wisprlite/__init__.py
+++ b/wisprlite/__init__.py
@@ -1,3 +1,3 @@
 """Pipevoice — push-to-talk voice typing for Windows."""
 
-__version__ = "2.13.0"
+__version__ = "2.14.0"

--- a/wisprlite/__main__.py
+++ b/wisprlite/__main__.py
@@ -6,6 +6,8 @@ elif "--history" in sys.argv:
     from .history import main
 elif "--about" in sys.argv:
     from .about import main
+elif "--profiles" in sys.argv:
+    from .profiles import main
 else:
     from .app import main
 

--- a/wisprlite/app.py
+++ b/wisprlite/app.py
@@ -48,9 +48,11 @@ class App:
             is_paused=lambda: self.paused,
         )
 
-        self._engine = None
+        self._engines = {}            # per-engine cache (name -> engine), for per-app profiles
         self._session = None
         self._clipboard_only = False
+        self._active = {}             # per-utterance profile overrides (never mutates cfg)
+        self._fg_ctx = {}             # foreground window captured at hotkey-press time
         self._started_at = 0.0
         self._busy = threading.Lock()
         self._stop = threading.Event()
@@ -86,10 +88,17 @@ class App:
                                language=(self.cfg.language or "").split("-")[0] or None, prompt=vocab)
         raise RuntimeError(f"Unknown engine: {name}")
 
-    def _get_engine(self):
-        if self._engine is None:
-            self._engine = self._build_engine()
-        return self._engine
+    def _get_engine(self, name: str | None = None):
+        name = name or self.cfg.engine
+        eng = self._engines.get(name)
+        if eng is None:
+            eng = self._build_engine(name)
+            self._engines[name] = eng
+        return eng
+
+    def _eff(self, key):
+        """Effective value for this utterance: a per-app profile override, else the setting."""
+        return self._active.get(key, getattr(self.cfg, key))
 
     def _prewarm(self) -> None:
         def work():
@@ -105,12 +114,20 @@ class App:
         if not self._busy.acquire(blocking=False):
             return  # still finishing the previous utterance
         self._clipboard_only = clipboard
+        # Capture the focused app NOW (before our overlay shows) and resolve a
+        # per-app profile into per-utterance overrides. Never mutates self.cfg.
         try:
-            engine = self._get_engine()
+            from . import foreground, profiles
+            self._fg_ctx = foreground.detect()
+            self._active = profiles.resolve(self.cfg.profiles, self._fg_ctx)
+        except Exception:
+            self._fg_ctx, self._active = {}, {}
+        try:
+            engine = self._get_engine(self._active.get("engine"))
             self._session = engine.start_session(on_partial=self.overlay.set_text)
         except Exception as exc:
             self._session = None
-            log.exception("could not start session (engine=%s)", self.cfg.engine)
+            log.exception("could not start session (engine=%s)", self._active.get("engine") or self.cfg.engine)
             self._fail(str(exc))
             self._release()
             return
@@ -162,7 +179,7 @@ class App:
             text = cmd.text
 
             # AI cleanup ("Flow mode") — OpenAI / Gemini / OpenRouter / local Ollama; falls back to raw.
-            if text and self.cfg.ai_cleanup:
+            if text and self._eff("ai_cleanup"):
                 from . import cleanup
 
                 if cleanup.provider_ready(self.cfg.cleanup_provider):
@@ -178,20 +195,26 @@ class App:
             # user word-fixes, applied last so they always stick
             text = apply_replacements(text, self.cfg.replacements)
 
-            press_enter = self.cfg.auto_enter or cmd.press_enter
+            press_enter = self._eff("auto_enter") or cmd.press_enter
             if not text and not press_enter:
                 self.overlay.hide()
                 self._set_icon("idle")
                 return
 
-            if self._clipboard_only:
+            # Output: clipboard hotkey, a profile's clipboard output, or no text
+            # target focused (desktop/shell) -> copy instead of typing into the void.
+            from . import foreground
+
+            out = self._eff("output_mode")
+            to_clipboard = (self._clipboard_only or out == "clipboard"
+                            or foreground.is_no_text_target(self._fg_ctx))
+            if to_clipboard:
                 if text:
                     copy_clipboard(text)
                 self.overlay.set_state("done", "Copied to clipboard" if text else "↵")
             else:
                 self.overlay.set_state("done", text or "↵")
-                type_text(text, self.cfg.output_mode, press_enter=press_enter,
-                          paste_speed=self.cfg.paste_speed)
+                type_text(text, out, press_enter=press_enter, paste_speed=self.cfg.paste_speed)
             if self.cfg.history_enabled and text:
                 try:
                     from . import history
@@ -203,11 +226,15 @@ class App:
             self._set_icon("idle")
         finally:
             self._session = None
+            self._active = {}
+            self._fg_ctx = {}
             self._release()
 
     def _fallback(self, audio, err) -> str:
         """If a cloud engine failed (e.g. offline), try local Whisper once."""
-        if self.cfg.engine == "local":
+        # Use the engine actually active this utterance (a profile may override it).
+        active_engine = self._active.get("engine") or self.cfg.engine
+        if active_engine == "local":
             self._fail(str(err))
             return ""
         try:
@@ -223,7 +250,6 @@ class App:
     # ---- tray actions -----------------------------------------------------
     def set_engine(self, name: str) -> None:
         self.cfg.engine = name
-        self._engine = None
         self.cfg.save()
         self.tray.update()
         self._prewarm()
@@ -301,6 +327,21 @@ class App:
                 subprocess.Popen([_pythonw(), "-m", "wisprlite", "--about"], cwd=parent)
         except Exception as exc:
             self._fail(f"about: {exc}")
+
+    def open_profiles(self) -> None:
+        import os
+        import subprocess
+
+        try:
+            if getattr(sys, "frozen", False):
+                subprocess.Popen([sys.executable, "--profiles"])
+            else:
+                from .autostart import _pythonw
+
+                parent = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+                subprocess.Popen([_pythonw(), "-m", "wisprlite", "--profiles"], cwd=parent)
+        except Exception as exc:
+            self._fail(f"profiles: {exc}")
 
     def autostart_enabled(self) -> bool:
         return autostart.is_enabled()
@@ -386,10 +427,10 @@ class App:
                        "local_model_size", "language", "device", "vocabulary",
                        "deepgram_finish_timeout")
         if any(getattr(old, k) != getattr(new, k) for k in engine_keys):
-            self._engine = None
+            self._engines = {}
             self.recorder.device = config.device_arg(new)
             self._prewarm()
-        elif self._engine is None:
+        elif not self._engines:
             # engine wasn't built yet (e.g. key was missing) — try now
             self._prewarm()
 

--- a/wisprlite/config.py
+++ b/wisprlite/config.py
@@ -83,6 +83,7 @@ class Config:
     deepgram_finish_timeout: float = 6.0  # seconds to wait for Deepgram's final words
     paste_speed: str = "normal"       # fast | normal | slow — clipboard-paste timing
     last_version: str = ""            # app version last run, to detect a fresh update
+    profiles: list = field(default_factory=list)  # per-app behaviour overrides
 
     @classmethod
     def load(cls) -> "Config":

--- a/wisprlite/foreground.py
+++ b/wisprlite/foreground.py
@@ -1,0 +1,71 @@
+"""Detect the focused (foreground) window: exe basename + title + class.
+
+Windows-only via ctypes; returns {} on any failure or non-Windows, matching the
+codebase's fault-tolerant style. Also flags the case where there is clearly no
+text target (the desktop, the taskbar, or no window), so dictation can fall back
+to the clipboard instead of typing into the void.
+"""
+
+from __future__ import annotations
+
+import ctypes
+from ctypes import wintypes
+
+# window classes that mean "no app text target" (desktop / taskbar / start menu)
+_SHELL_CLASSES = {
+    "Progman", "WorkerW", "Shell_TrayWnd", "Shell_SecondaryTrayWnd",
+    "Windows.UI.Core.CoreWindow", "MultitaskingViewFrame", "XamlExplorerHostIslandWindow",
+}
+
+
+def _exe_for_pid(pid: int) -> str:
+    try:
+        k = ctypes.windll.kernel32
+        PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+        h = k.OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, False, pid)
+        if not h:
+            return ""
+        try:
+            size = wintypes.DWORD(260)
+            buf = ctypes.create_unicode_buffer(260)
+            if k.QueryFullProcessImageNameW(h, 0, buf, ctypes.byref(size)):
+                path = buf.value or ""
+                return path.replace("\\", "/").split("/")[-1].lower()
+            return ""
+        finally:
+            k.CloseHandle(h)
+    except Exception:
+        return ""
+
+
+def detect() -> dict:
+    """Return {'exe','title','cls'} for the foreground window, or {} on failure."""
+    try:
+        u = ctypes.windll.user32
+        hwnd = u.GetForegroundWindow()
+        if not hwnd:
+            return {}
+        n = u.GetWindowTextLengthW(hwnd)
+        tbuf = ctypes.create_unicode_buffer(n + 1)
+        u.GetWindowTextW(hwnd, tbuf, n + 1)
+        cbuf = ctypes.create_unicode_buffer(256)
+        u.GetClassNameW(hwnd, cbuf, 256)
+        pid = wintypes.DWORD()
+        u.GetWindowThreadProcessId(hwnd, ctypes.byref(pid))
+        return {"exe": _exe_for_pid(pid.value), "title": tbuf.value or "", "cls": cbuf.value or ""}
+    except Exception:
+        return {}
+
+
+def is_no_text_target(ctx: dict) -> bool:
+    """True only when we POSITIVELY know there is no text target (desktop / shell /
+    nothing). Returns False when unknown, so we never wrongly divert a real app's
+    text to the clipboard (Chromium apps hide their caret, so we don't guess)."""
+    if not ctx:
+        return False
+    if ctx.get("cls", "") in _SHELL_CLASSES:
+        return True
+    # the desktop is explorer.exe with no window title
+    if ctx.get("exe", "") == "explorer.exe" and not ctx.get("title", ""):
+        return True
+    return False

--- a/wisprlite/profiles.py
+++ b/wisprlite/profiles.py
@@ -1,0 +1,202 @@
+"""Per-app profiles: when the focused app matches, apply per-utterance overrides
+(engine, ai_cleanup, auto_enter, output_mode). resolve() does the matching;
+main() is the --profiles editor window.
+
+A profile is {name, match:{exe|title_contains}, overrides:{...}}. Overrides never
+mutate saved settings; app.py applies them for one utterance only.
+"""
+
+from __future__ import annotations
+
+from . import config
+
+KEYS = ("engine", "ai_cleanup", "auto_enter", "output_mode")
+
+
+def resolve(profiles, ctx) -> dict:
+    """Overrides of the first profile whose match fits ctx, else {}."""
+    if not profiles or not ctx:
+        return {}
+    exe = (ctx.get("exe") or "").lower()
+    title = (ctx.get("title") or "").lower()
+    for p in profiles:
+        if not isinstance(p, dict):
+            continue
+        match = p.get("match") or {}
+        m_exe = (match.get("exe") or "").lower()
+        m_title = (match.get("title_contains") or "").lower()
+        if not (m_exe or m_title):
+            continue
+        ok = True
+        if m_exe:
+            ok = ok and exe == m_exe
+        if m_title:
+            ok = ok and m_title in title
+        if ok:
+            ov = p.get("overrides") or {}
+            return {k: v for k, v in ov.items() if k in KEYS}
+    return {}
+
+
+# ---- editor window --------------------------------------------------------
+BG = "#13151d"
+CARD = "#1b1e29"
+FG = "#e5e7eb"
+MUTED = "#94a3b8"
+ACCENT = "#e06c75"
+
+P_ENGINES = [("", "(app default)"), ("deepgram", "Deepgram"), ("openai", "OpenAI"), ("local", "Local")]
+P_OUTPUTS = [("type", "Type"), ("paste", "Paste"), ("clipboard", "Clipboard")]
+
+
+def _value_for(label, table):
+    return {l: k for k, l in table}.get(label, table[0][0])
+
+
+def main() -> None:
+    try:
+        import tkinter as tk
+        from tkinter import ttk
+    except Exception:
+        return
+    from . import winui
+
+    cfg = config.Config.load()
+    cards = []
+
+    root = tk.Tk()
+    root.title("Pipevoice app profiles")
+    root.configure(bg=BG)
+    ico = config.asset_path("wisprlite.ico")
+    if ico:
+        try:
+            root.iconbitmap(ico)
+        except Exception:
+            pass
+
+    style = ttk.Style(root)
+    try:
+        style.theme_use("clam")
+    except Exception:
+        pass
+    style.configure(".", background=BG, foreground=FG, font=("Segoe UI", 10))
+    style.configure("TButton", background=CARD, foreground=FG, padding=6, borderwidth=0)
+    style.map("TButton", background=[("active", "#262a3a")])
+    style.configure("Accent.TButton", background=ACCENT, foreground="#1a0c0d",
+                    font=("Segoe UI", 9, "bold"), padding=7, borderwidth=0)
+    style.map("Accent.TButton", background=[("active", "#e8838b")])
+    style.configure("TCheckbutton", background=CARD, foreground=FG)
+    style.map("TCheckbutton", background=[("active", CARD)])
+    style.configure("TCombobox", fieldbackground=CARD, background=CARD, foreground=FG, arrowcolor=FG)
+    style.map("TCombobox", fieldbackground=[("readonly", CARD)], foreground=[("readonly", FG)],
+              selectbackground=[("readonly", CARD)], selectforeground=[("readonly", FG)],
+              background=[("readonly", CARD), ("active", CARD)])
+    style.configure("TEntry", fieldbackground=CARD, foreground=FG, insertcolor=FG)
+    root.option_add("*TCombobox*Listbox.background", CARD)
+    root.option_add("*TCombobox*Listbox.foreground", FG)
+    root.option_add("*TCombobox*Listbox.selectBackground", ACCENT)
+    root.option_add("*TCombobox*Listbox.selectForeground", "#1a0c0d")
+
+    head = tk.Frame(root, bg=BG, padx=22, pady=18)
+    head.pack(fill="x")
+    tk.Label(head, text="App profiles", bg=BG, fg=ACCENT, font=("Segoe UI", 16, "bold")).pack(anchor="w")
+    tk.Label(head, text="Give an app its own behaviour. Terminal: raw + Enter. Chat: polished + auto-send.\n"
+                        "Editor: no AI cleanup. Matched by the app's exe name (Task Manager, Details tab).",
+             bg=BG, fg=MUTED, font=("Segoe UI", 9), justify="left").pack(anchor="w", pady=(5, 0))
+
+    footer = tk.Frame(root, bg=BG, padx=22, pady=12)
+    footer.pack(side="bottom", fill="x")
+
+    bodyf = tk.Frame(root, bg=BG)
+    bodyf.pack(fill="both", expand=True)
+    canvas = tk.Canvas(bodyf, bg=BG, highlightthickness=0, width=560, height=350)
+    vbar = ttk.Scrollbar(bodyf, orient="vertical", command=canvas.yview)
+    canvas.configure(yscrollcommand=vbar.set)
+    vbar.pack(side="right", fill="y")
+    canvas.pack(side="left", fill="both", expand=True)
+    holder = tk.Frame(canvas, bg=BG)
+    canvas.create_window((0, 0), window=holder, anchor="nw")
+    holder.bind("<Configure>", lambda e: canvas.configure(scrollregion=canvas.bbox("all")))
+    canvas.bind("<Enter>", lambda e: canvas.bind_all(
+        "<MouseWheel>", lambda ev: canvas.yview_scroll(int(-ev.delta / 120), "units")))
+    canvas.bind("<Leave>", lambda e: canvas.unbind_all("<MouseWheel>"))
+
+    def add_card(exe="", overrides=None):
+        overrides = overrides or {}
+        c = tk.Frame(holder, bg=CARD, padx=14, pady=12)
+        c.pack(fill="x", padx=16, pady=6)
+        card = {}
+
+        r1 = tk.Frame(c, bg=CARD)
+        r1.pack(fill="x")
+        tk.Label(r1, text="App (exe):", bg=CARD, fg=FG, font=("Segoe UI", 9)).pack(side="left")
+        exe_var = tk.StringVar(value=exe)
+        ttk.Entry(r1, textvariable=exe_var, width=22).pack(side="left", padx=(8, 0))
+        tk.Label(r1, text="e.g. code.exe", bg=CARD, fg=MUTED, font=("Segoe UI", 8)).pack(side="left", padx=(8, 0))
+        ttk.Button(r1, text="Remove", command=lambda: (c.destroy(), card in cards and cards.remove(card))).pack(side="right")
+
+        r2 = tk.Frame(c, bg=CARD)
+        r2.pack(fill="x", pady=(9, 0))
+        tk.Label(r2, text="Engine", bg=CARD, fg=MUTED, font=("Segoe UI", 9)).pack(side="left")
+        engine_var = tk.StringVar(value=dict(P_ENGINES).get(overrides.get("engine", ""), P_ENGINES[0][1]))
+        ttk.Combobox(r2, textvariable=engine_var, values=[l for _, l in P_ENGINES],
+                     state="readonly", width=13).pack(side="left", padx=(6, 18))
+        tk.Label(r2, text="Output", bg=CARD, fg=MUTED, font=("Segoe UI", 9)).pack(side="left")
+        output_var = tk.StringVar(value=dict(P_OUTPUTS).get(overrides.get("output_mode", cfg.output_mode), P_OUTPUTS[0][1]))
+        ttk.Combobox(r2, textvariable=output_var, values=[l for _, l in P_OUTPUTS],
+                     state="readonly", width=11).pack(side="left", padx=(6, 0))
+
+        r3 = tk.Frame(c, bg=CARD)
+        r3.pack(fill="x", pady=(9, 0))
+        cleanup_var = tk.BooleanVar(value=bool(overrides.get("ai_cleanup", cfg.ai_cleanup)))
+        autoenter_var = tk.BooleanVar(value=bool(overrides.get("auto_enter", cfg.auto_enter)))
+        ttk.Checkbutton(r3, text="AI cleanup", variable=cleanup_var).pack(side="left")
+        ttk.Checkbutton(r3, text="Auto-Enter", variable=autoenter_var).pack(side="left", padx=(18, 0))
+
+        card.update(exe=exe_var, engine=engine_var, output=output_var,
+                    cleanup=cleanup_var, autoenter=autoenter_var)
+        cards.append(card)
+
+    for p in (cfg.profiles or []):
+        if isinstance(p, dict):
+            add_card((p.get("match") or {}).get("exe", ""), p.get("overrides") or {})
+    if not cfg.profiles:
+        add_card()
+
+    def save():
+        out = []
+        for card in cards:
+            exe = card["exe"].get().strip().lower()
+            if not exe:
+                continue
+            ov = {
+                "ai_cleanup": bool(card["cleanup"].get()),
+                "auto_enter": bool(card["autoenter"].get()),
+                "output_mode": _value_for(card["output"].get(), P_OUTPUTS),
+            }
+            eng = _value_for(card["engine"].get(), P_ENGINES)
+            if eng:
+                ov["engine"] = eng
+            out.append({"name": exe, "match": {"exe": exe}, "overrides": ov})
+        # Reload first so we only change `profiles`, not other settings the user
+        # may have edited in the Settings window meanwhile.
+        fresh = config.Config.load()
+        fresh.profiles = out
+        fresh.save()
+        root.destroy()
+
+    ttk.Button(footer, text="+ Add app profile", command=lambda: add_card()).pack(side="left")
+    ttk.Button(footer, text="Save", style="Accent.TButton", command=save).pack(side="right")
+    ttk.Button(footer, text="Cancel", command=root.destroy).pack(side="right", padx=(0, 8))
+
+    root.update_idletasks()
+    w = max(620, root.winfo_reqwidth())
+    h = min(640, max(420, root.winfo_reqheight()))
+    sw, sh = root.winfo_screenwidth(), root.winfo_screenheight()
+    root.geometry(f"{w}x{h}+{(sw - w) // 2}+{(sh - h) // 3}")
+    winui.dark_titlebar(root)
+    root.mainloop()
+
+
+if __name__ == "__main__":
+    main()

--- a/wisprlite/settings.py
+++ b/wisprlite/settings.py
@@ -68,6 +68,24 @@ _URLS = {
 }
 
 
+def _launch_child(arg: str) -> None:
+    """Spawn another Pipevoice child window (e.g. the --profiles editor)."""
+    import os
+    import subprocess
+    import sys
+
+    try:
+        if getattr(sys, "frozen", False):
+            subprocess.Popen([sys.executable, arg])
+        else:
+            from .autostart import _pythonw
+
+            parent = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+            subprocess.Popen([_pythonw(), "-m", "wisprlite", arg], cwd=parent)
+    except Exception:
+        pass
+
+
 def _build_guide(parent, wheel) -> None:
     """Populate the Guide tab: how it works, engine speed, polish, tips."""
     import tkinter as tk
@@ -453,6 +471,9 @@ def main(first_run: bool = False) -> None:
         row=row, column=0, columnspan=2, sticky="w", padx=14, pady=5); row += 1
     ttk.Checkbutton(frm, text="Keep a local dictation history", variable=history_var).grid(
         row=row, column=0, columnspan=2, sticky="w", padx=14, pady=5); row += 1
+    ttk.Button(frm, text="Manage app profiles…",
+               command=lambda: _launch_child("--profiles")).grid(
+        row=row, column=0, columnspan=2, sticky="w", padx=14, pady=(10, 4)); row += 1
 
     # --- Advanced ---
     header("Advanced")
@@ -468,6 +489,11 @@ def main(first_run: bool = False) -> None:
         return label_to_value.get(var.get(), table[0][0])
 
     def save(close=True):
+        # Don't clobber app profiles edited in the separate Profiles window.
+        try:
+            cfg.profiles = config.Config.load().profiles
+        except Exception:
+            pass
         cfg.engine = value_for(engine_var, ENGINES)
         cfg.mode = value_for(mode_var, MODES)
         cfg.output_mode = value_for(output_var, OUTPUTS)

--- a/wisprlite/tray.py
+++ b/wisprlite/tray.py
@@ -89,6 +89,7 @@ class Tray:
             Menu.SEPARATOR,
             Item("Settings…", lambda i, it: app.open_settings(), default=True),
             Item("History…", lambda i, it: app.open_history()),
+            Item("App profiles…", lambda i, it: app.open_profiles()),
             Item("Show overlay", lambda i, it: app.toggle_overlay(),
                  checked=lambda it: app.cfg.overlay),
             Item("Sounds", lambda i, it: app.toggle_sounds(),


### PR DESCRIPTION
Phase 3. Per-app behaviour (engine / AI cleanup / auto-Enter / output) resolved from the focused app's exe, applied per-utterance, never mutating saved settings. Plus the conservative clipboard fallback: if there's no text target (desktop/shell) or a profile sets output=clipboard, copy instead of typing. Chromium caret is unknowable so we never guess against real apps.

New foreground.py (ctypes) + profiles.py (resolver + --profiles editor); app.py per-engine cache + _eff() override; Settings button + tray item. No-profile behaviour unchanged. Logic simulated; codex caught + fixed the _fallback active-engine bug.