### PR TITLE
Fix About update check: one source for status + changelog (v2.15.0)

### DIFF
--- a/installer/Pipevoice.iss
+++ b/installer/Pipevoice.iss
@@ -4,7 +4,7 @@
 ; Produces installer\Output\Pipevoice-Setup.exe — a per-user install (no admin).
 
 #define AppName "Pipevoice"
-#define AppVersion "2.14.0"
+#define AppVersion "2.15.0"
 #define AppExe "Pipevoice.exe"
 
 [Setup]

--- a/wisprlite/__init__.py
+++ b/wisprlite/__init__.py
@@ -1,3 +1,3 @@
 """Pipevoice — push-to-talk voice typing for Windows."""
 
-__version__ = "2.14.0"
+__version__ = "2.15.0"

--- a/wisprlite/about.py
+++ b/wisprlite/about.py
@@ -118,25 +118,31 @@ def build(container, root, wheel=None) -> None:
             root.after(0, done)
         threading.Thread(target=work, daemon=True).start()
 
-    def check():
+    def load():
         status.config(text="Checking for updates…", fg=MUTED)
         btn.config(state="disabled", text="Checking…")
 
         def work():
-            rel = updater.latest_release()
-            info = updater.info_from_latest(rel) if rel and rel.get("newer") else None
+            # One call powers BOTH the version check and the changelog, so they
+            # can never disagree (the latest release is just the newest in the list).
+            rels = updater.recent_releases(8)
+            latest = rels[0] if rels else None
+            info = None
+            if latest and updater.is_newer(latest.get("tag", "")) and latest.get("url"):
+                info = updater.info_from_latest(latest)
 
             def done():
-                if rel is None:
+                render_changelog(rels)
+                if not rels:
                     status.config(text="Could not reach GitHub. Check your connection.", fg=WARN)
-                    btn.config(state="normal", text="Check again", command=check, style="TButton")
-                elif rel.get("newer") and info:
+                    btn.config(state="normal", text="Check again", command=load, style="TButton")
+                elif info:
                     state["info"] = info
-                    status.config(text=f"Update available: v{rel['version']}", fg=ACCENT)
+                    status.config(text=f"Update available: v{latest['version']}", fg=ACCENT)
                     btn.config(state="normal", text="Update now  →", command=do_update, style="Accent.TButton")
                 else:
                     status.config(text="You're on the latest version.", fg=GOOD)
-                    btn.config(state="normal", text="Check again", command=check, style="TButton")
+                    btn.config(state="normal", text="Check again", command=load, style="TButton")
             root.after(0, done)
         threading.Thread(target=work, daemon=True).start()
 
@@ -164,16 +170,9 @@ def build(container, root, wheel=None) -> None:
             tk.Label(card, text=notes, bg=CARD, fg=MUTED, font=("Segoe UI", 9),
                      anchor="w", justify="left", wraplength=430).pack(fill="x", pady=(7, 0))
 
-    def load_changelog():
-        def work():
-            rels = updater.recent_releases(6)
-            root.after(0, lambda: render_changelog(rels))
-        threading.Thread(target=work, daemon=True).start()
-
     tk.Label(inner, text="Loading release notes…", bg=BG, fg=MUTED,
              font=("Segoe UI", 10), padx=28, pady=10).pack(anchor="w")
-    check()
-    load_changelog()
+    load()
 
 
 def main() -> None:

--- a/wisprlite/updater.py
+++ b/wisprlite/updater.py
@@ -124,13 +124,29 @@ def recent_releases(n: int = 6) -> list:
         return []
     out = []
     for rel in (data if isinstance(data, list) else []):
+        setup_url = sha_url = None
+        for a in rel.get("assets", []):
+            nm = a.get("name", "")
+            if nm == ASSET:
+                setup_url = a.get("browser_download_url")
+            elif nm == ASSET + ".sha256":
+                sha_url = a.get("browser_download_url")
+        tag = rel.get("tag_name", "")
         out.append({
-            "tag": rel.get("tag_name", ""),
-            "name": rel.get("name") or rel.get("tag_name", ""),
+            "tag": tag,
+            "version": tag.lstrip("vV"),
+            "name": rel.get("name") or tag,
             "published_at": rel.get("published_at", ""),
             "body": rel.get("body", "") or "",
+            "url": setup_url,
+            "sha_url": sha_url,
         })
     return out
+
+
+def is_newer(tag: str) -> bool:
+    """True if `tag` is a newer release than the running version."""
+    return _parse_version(tag or "") > _parse_version(__version__)
 
 
 def _sha256(path: str) -> str:


### PR DESCRIPTION
Fixes the About window showing "Could not reach GitHub" while the changelog loaded fine. The status and changelog used two separate API calls that could disagree; now a single `recent_releases()` call powers both (the newest item is the latest release). Adds installer url/sha to recent_releases + `is_newer()`. Verified against live GitHub.