### PR TITLE
Key prompt X-close + running-app picker (v2.16.0)

### DIFF
--- a/installer/Pipevoice.iss
+++ b/installer/Pipevoice.iss
@@ -4,7 +4,7 @@
 ; Produces installer\Output\Pipevoice-Setup.exe — a per-user install (no admin).
 
 #define AppName "Pipevoice"
-#define AppVersion "2.15.0"
+#define AppVersion "2.16.0"
 #define AppExe "Pipevoice.exe"
 
 [Setup]

--- a/wisprlite/__init__.py
+++ b/wisprlite/__init__.py
@@ -1,3 +1,3 @@
 """Pipevoice — push-to-talk voice typing for Windows."""
 
-__version__ = "2.15.0"
+__version__ = "2.16.0"

--- a/wisprlite/foreground.py
+++ b/wisprlite/foreground.py
@@ -57,6 +57,44 @@ def detect() -> dict:
         return {}
 
 
+def list_windows() -> list:
+    """Visible top-level windows for an app picker: [{'exe','title'}], deduped by
+    exe and sorted. Returns [] off Windows (the picker still allows typing)."""
+    import os
+
+    fake = os.getenv("PV_FAKE_WINDOWS")  # test seam for headless rendering
+    if fake:
+        return [{"exe": e.strip(), "title": e.strip().split(".")[0].title()}
+                for e in fake.split(",") if e.strip()]
+    found = {}
+    try:
+        u = ctypes.windll.user32
+
+        @ctypes.WINFUNCTYPE(ctypes.c_bool, wintypes.HWND, wintypes.LPARAM)
+        def _cb(hwnd, lparam):
+            try:
+                if not u.IsWindowVisible(hwnd):
+                    return True
+                n = u.GetWindowTextLengthW(hwnd)
+                if n == 0:
+                    return True  # skip title-less windows (usually not real apps)
+                tbuf = ctypes.create_unicode_buffer(n + 1)
+                u.GetWindowTextW(hwnd, tbuf, n + 1)
+                pid = wintypes.DWORD()
+                u.GetWindowThreadProcessId(hwnd, ctypes.byref(pid))
+                exe = _exe_for_pid(pid.value)
+                if exe and exe != "explorer.exe" and exe not in found:
+                    found[exe] = tbuf.value or ""
+            except Exception:
+                pass
+            return True
+
+        u.EnumWindows(_cb, 0)
+    except Exception:
+        return []
+    return [{"exe": e, "title": t} for e, t in sorted(found.items())]
+
+
 def is_no_text_target(ctx: dict) -> bool:
     """True only when we POSITIVELY know there is no text target (desktop / shell /
     nothing). Returns False when unknown, so we never wrongly divert a real app's

--- a/wisprlite/keyprompt.py
+++ b/wisprlite/keyprompt.py
@@ -153,6 +153,8 @@ def _dialog(cfg) -> None:
                          padx=16, pady=7, font=("Segoe UI", 9, "bold"))
     save_btn.pack(side="right")
     entry.bind("<Return>", save)
+    # Closing via the window's X is also a dismissal: remember it like "Skip".
+    root.protocol("WM_DELETE_WINDOW", skip)
 
     root.update_idletasks()
     w, h = root.winfo_width(), root.winfo_height()

--- a/wisprlite/profiles.py
+++ b/wisprlite/profiles.py
@@ -63,6 +63,9 @@ def main() -> None:
 
     cfg = config.Config.load()
     cards = []
+    from . import foreground
+    running = foreground.list_windows()
+    app_values = [w["exe"] + ("  —  " + w["title"][:34] if w.get("title") else "") for w in running]
 
     root = tk.Tk()
     root.title("Pipevoice app profiles")
@@ -101,7 +104,7 @@ def main() -> None:
     head.pack(fill="x")
     tk.Label(head, text="App profiles", bg=BG, fg=ACCENT, font=("Segoe UI", 16, "bold")).pack(anchor="w")
     tk.Label(head, text="Give an app its own behaviour. Terminal: raw + Enter. Chat: polished + auto-send.\n"
-                        "Editor: no AI cleanup. Matched by the app's exe name (Task Manager, Details tab).",
+                        "Editor: no AI cleanup. Pick a running app from the dropdown, or type its exe name.",
              bg=BG, fg=MUTED, font=("Segoe UI", 9), justify="left").pack(anchor="w", pady=(5, 0))
 
     footer = tk.Frame(root, bg=BG, padx=22, pady=12)
@@ -129,10 +132,9 @@ def main() -> None:
 
         r1 = tk.Frame(c, bg=CARD)
         r1.pack(fill="x")
-        tk.Label(r1, text="App (exe):", bg=CARD, fg=FG, font=("Segoe UI", 9)).pack(side="left")
+        tk.Label(r1, text="App:", bg=CARD, fg=FG, font=("Segoe UI", 9)).pack(side="left")
         exe_var = tk.StringVar(value=exe)
-        ttk.Entry(r1, textvariable=exe_var, width=22).pack(side="left", padx=(8, 0))
-        tk.Label(r1, text="e.g. code.exe", bg=CARD, fg=MUTED, font=("Segoe UI", 8)).pack(side="left", padx=(8, 0))
+        ttk.Combobox(r1, textvariable=exe_var, values=app_values, width=34).pack(side="left", padx=(8, 0))
         ttk.Button(r1, text="Remove", command=lambda: (c.destroy(), card in cards and cards.remove(card))).pack(side="right")
 
         r2 = tk.Frame(c, bg=CARD)
@@ -166,7 +168,7 @@ def main() -> None:
     def save():
         out = []
         for card in cards:
-            exe = card["exe"].get().strip().lower()
+            exe = card["exe"].get().split("—")[0].strip().lower()
             if not exe:
                 continue
             ov = {


### PR DESCRIPTION
Closing the API-key prompt via the window X now remembers the dismissal (was only the Skip button), so it stops re-nagging on restart. And the App-profiles picker is now a **dropdown of running apps** instead of a hand-typed exe box (still accepts typed input). Rendered + verified under Xvfb; codex clean.