### PR TITLE
Settings: clean tabs, wider window, fuller app picker (v2.18.0)

### DIFF
--- a/installer/Pipevoice.iss
+++ b/installer/Pipevoice.iss
@@ -4,7 +4,7 @@
 ; Produces installer\Output\Pipevoice-Setup.exe — a per-user install (no admin).
 
 #define AppName "Pipevoice"
-#define AppVersion "2.17.0"
+#define AppVersion "2.18.0"
 #define AppExe "Pipevoice.exe"
 
 [Setup]

--- a/wisprlite/__init__.py
+++ b/wisprlite/__init__.py
@@ -1,3 +1,3 @@
 """Pipevoice — push-to-talk voice typing for Windows."""
 
-__version__ = "2.17.0"
+__version__ = "2.18.0"

--- a/wisprlite/profiles.py
+++ b/wisprlite/profiles.py
@@ -48,6 +48,18 @@ ACCENT = "#e06c75"
 P_ENGINES = [("", "(app default)"), ("deepgram", "Deepgram"), ("openai", "OpenAI"), ("local", "Local")]
 P_OUTPUTS = [("type", "Type"), ("paste", "Paste"), ("clipboard", "Clipboard")]
 
+# Common apps so popular targets appear even when they aren't currently running.
+COMMON_APPS = [
+    ("code.exe", "VS Code"), ("cursor.exe", "Cursor"), ("chrome.exe", "Chrome"),
+    ("msedge.exe", "Edge"), ("firefox.exe", "Firefox"),
+    ("windowsterminal.exe", "Windows Terminal"), ("powershell.exe", "PowerShell"),
+    ("cmd.exe", "Command Prompt"), ("slack.exe", "Slack"), ("discord.exe", "Discord"),
+    ("ms-teams.exe", "Teams"), ("notepad.exe", "Notepad"), ("notepad++.exe", "Notepad++"),
+    ("winword.exe", "Word"), ("outlook.exe", "Outlook"), ("obsidian.exe", "Obsidian"),
+    ("idea64.exe", "IntelliJ IDEA"), ("explorer.exe", "File Explorer"),
+    ("telegram.exe", "Telegram"), ("whatsapp.exe", "WhatsApp"),
+]
+
 
 def _value_for(label, table):
     return {l: k for k, l in table}.get(label, table[0][0])
@@ -65,7 +77,12 @@ def main() -> None:
     cards = []
     from . import foreground
     running = foreground.list_windows()
-    app_values = [w["exe"] + ("  —  " + w["title"][:34] if w.get("title") else "") for w in running]
+    have = {w["exe"].lower() for w in running}
+    merged = list(running) + [{"exe": e, "title": t} for e, t in COMMON_APPS if e.lower() not in have]
+    app_values = sorted(
+        (w["exe"] + ("  —  " + w["title"][:34] if w.get("title") else "") for w in merged),
+        key=str.lower,
+    )
 
     root = tk.Tk()
     root.title("Pipevoice app profiles")
@@ -104,7 +121,7 @@ def main() -> None:
     head.pack(fill="x")
     tk.Label(head, text="App profiles", bg=BG, fg=ACCENT, font=("Segoe UI", 16, "bold")).pack(anchor="w")
     tk.Label(head, text="Give an app its own behaviour. Terminal: raw + Enter. Chat: polished + auto-send.\n"
-                        "Editor: no AI cleanup. Pick a running app from the dropdown, or type its exe name.",
+                        "Editor: no AI cleanup. Pick from the dropdown (running + common apps), or type any exe name.",
              bg=BG, fg=MUTED, font=("Segoe UI", 9), justify="left").pack(anchor="w", pady=(5, 0))
 
     footer = tk.Frame(root, bg=BG, padx=22, pady=12)

--- a/wisprlite/settings.py
+++ b/wisprlite/settings.py
@@ -183,7 +183,7 @@ def main(first_run: bool = False) -> None:
     root = tk.Tk()
     root.title("Set up Pipevoice" if first_run else "Pipevoice settings")
     root.configure(bg=BG)
-    root.resizable(False, True)
+    root.resizable(True, True)
     ico = config.asset_path("wisprlite.ico")
     if ico:
         try:
@@ -242,16 +242,41 @@ def main(first_run: bool = False) -> None:
 
     # Fixed footer (Save/Cancel always visible), then a tabbed body: the form
     # plus a Guide tab that explains engines, speed and polish options.
-    footer = ttk.Frame(root, padding=(14, 9))
+    footer = ttk.Frame(root, padding=(16, 10))
     footer.pack(side="bottom", fill="x")
-    nb = ttk.Notebook(root)
-    nb.pack(side="top", fill="both", expand=True)
-    tab_settings = ttk.Frame(nb)
-    tab_guide = ttk.Frame(nb)
-    tab_about = ttk.Frame(nb)
-    nb.add(tab_settings, text="Settings")
-    nb.add(tab_guide, text="Guide")
-    nb.add(tab_about, text="About")
+
+    # Custom underline tab bar (ttk.Notebook tabs render poorly on clam).
+    tabbar = tk.Frame(root, bg=BG)
+    tabbar.pack(side="top", fill="x", padx=22, pady=(12, 0))
+    tk.Frame(root, bg="#272b37", height=1).pack(side="top", fill="x")
+    body_wrap = tk.Frame(root, bg=BG)
+    body_wrap.pack(side="top", fill="both", expand=True)
+
+    tab_settings = tk.Frame(body_wrap, bg=BG)
+    tab_guide = tk.Frame(body_wrap, bg=BG)
+    tab_about = tk.Frame(body_wrap, bg=BG)
+    _tabs = [("Settings", tab_settings), ("Guide", tab_guide), ("About", tab_about)]
+    _tab_w = {}
+
+    def _show_tab(name):
+        for _n, _f in _tabs:
+            _f.pack_forget()
+        dict(_tabs)[name].pack(fill="both", expand=True)
+        for _n, (lbl, ul) in _tab_w.items():
+            on = _n == name
+            lbl.config(fg=ACCENT if on else MUTED)
+            ul.config(bg=ACCENT if on else BG)
+
+    for _name, _frame in _tabs:
+        w = tk.Frame(tabbar, bg=BG)
+        w.pack(side="left", padx=(0, 8))
+        lbl = tk.Label(w, text=_name, bg=BG, fg=MUTED, font=("Segoe UI", 11, "bold"),
+                       cursor="hand2", padx=10, pady=8)
+        lbl.pack()
+        ul = tk.Frame(w, bg=BG, height=2)
+        ul.pack(fill="x")
+        lbl.bind("<Button-1>", lambda e, n=_name: _show_tab(n))
+        _tab_w[_name] = (lbl, ul)
 
     # --- Settings tab: scrollable form ---
     _canvas = tk.Canvas(tab_settings, bg=BG, highlightthickness=0)
@@ -265,6 +290,7 @@ def main(first_run: bool = False) -> None:
     _wheel(_canvas)
     _build_guide(tab_guide, _wheel)
     about.build(tab_about, root, _wheel)
+    _show_tab("Settings")
     DIV = "#272b37"
 
     def card(title, subtitle=None):
@@ -595,10 +621,10 @@ def main(first_run: bool = False) -> None:
     cw = frm.winfo_reqwidth() + 22          # form width + scrollbar
     ch = frm.winfo_reqheight()
     sw, sh = root.winfo_screenwidth(), root.winfo_screenheight()
-    win_w = max(cw, 660)                    # roomy: keeps descriptions clear of the controls
-    win_h = min(ch + 96, sh - 80)           # + tab strip + footer; never off-screen
+    win_w = max(cw, 760)                    # wider: descriptions sit clear of the controls
+    win_h = min(ch + 110, sh - 150)         # leave room for the taskbar so the footer is never cut off
     x = max(0, (sw - win_w) // 2)
-    y = max(0, (sh - win_h) // 3)
+    y = max(16, (sh - win_h) // 5)          # sit near the top so the bottom stays on-screen
     root.geometry(f"{win_w}x{win_h}+{x}+{y}")
     winui.dark_titlebar(root)
     root.mainloop()


### PR DESCRIPTION
Acts on live feedback, all verified by rendering under Xvfb: custom **underline tab bar** (replaces the ugly sunken ttk tabs); **wider + resizable window** with the height capped so the **footer is never cut off** on small/high-DPI laptops; and the app-profiles picker now lists **common apps** (VS Code, Cursor, terminals, etc.) alongside running ones so they always appear. codex clean.