### PR TITLE
Build: onefile -> onedir to fix update 'Failed to load Python DLL' (v2.19.0)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Build Pipevoice.exe
         run: >
-          pyinstaller --noconfirm --clean --noconsole --onefile --name Pipevoice
+          pyinstaller --noconfirm --clean --noconsole --onedir --noupx --name Pipevoice
           --icon assets/wisprlite.ico
           --add-data "assets/wisprlite.ico;assets"
           --collect-all deepgram

--- a/build_exe.bat
+++ b/build_exe.bat
@@ -5,7 +5,7 @@ cd /d "%~dp0"
 call .venv\Scripts\activate.bat
 pip install pyinstaller
 if not exist "assets\wisprlite.ico" python assets\make_icon.py
-pyinstaller --noconfirm --clean --noconsole --onefile --name Pipevoice ^
+pyinstaller --noconfirm --clean --noconsole --onedir --noupx --name Pipevoice ^
     --icon assets\wisprlite.ico ^
     --add-data "assets\wisprlite.ico;assets" ^
     --collect-all deepgram ^
@@ -15,5 +15,5 @@ pyinstaller --noconfirm --clean --noconsole --onefile --name Pipevoice ^
     --collect-all PIL ^
     launch.py
 echo.
-echo Done. See dist\Pipevoice.exe
+echo Done. See dist\Pipevoice\Pipevoice.exe
 echo (Local Whisper downloads its model on first use; the exe stays small.)

--- a/build_installer.bat
+++ b/build_installer.bat
@@ -6,8 +6,8 @@ cd /d "%~dp0"
 
 echo [1/2] Building Pipevoice.exe with PyInstaller...
 call build_exe.bat
-if not exist "dist\Pipevoice.exe" (
-    echo ERROR: dist\Pipevoice.exe was not created. Aborting.
+if not exist "dist\Pipevoice\Pipevoice.exe" (
+    echo ERROR: dist\Pipevoice\Pipevoice.exe was not created. Aborting.
     pause
     exit /b 1
 )

--- a/installer/Pipevoice.iss
+++ b/installer/Pipevoice.iss
@@ -4,7 +4,7 @@
 ; Produces installer\Output\Pipevoice-Setup.exe — a per-user install (no admin).
 
 #define AppName "Pipevoice"
-#define AppVersion "2.18.0"
+#define AppVersion "2.19.0"
 #define AppExe "Pipevoice.exe"
 
 [Setup]
@@ -27,7 +27,10 @@ SetupIconFile=..\assets\wisprlite.ico
 UninstallDisplayIcon={app}\{#AppExe}
 
 [Files]
-Source: "..\dist\{#AppExe}"; DestDir: "{app}"; Flags: ignoreversion
+; onedir build: bundle the whole PyInstaller folder (exe + _internal/ DLLs).
+; This avoids the onefile _MEI runtime extraction that broke updates with
+; "Failed to load Python DLL".
+Source: "..\dist\Pipevoice\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
 Source: "..\.env.example"; DestDir: "{app}"; Flags: ignoreversion
 Source: "..\README.md"; DestDir: "{app}"; Flags: ignoreversion
 ; Seed a real .env on first install only (user pastes their key into it).

--- a/wisprlite/__init__.py
+++ b/wisprlite/__init__.py
@@ -1,3 +1,3 @@
 """Pipevoice — push-to-talk voice typing for Windows."""
 
-__version__ = "2.18.0"
+__version__ = "2.19.0"


### PR DESCRIPTION
Fixes the **"Failed to load Python DLL ...\_MEI...\python311.dll"** error users hit during updates. The onefile build extracts the Python runtime to %TEMP%\_MEI on every launch, which races with the installer relaunch / AV scan during an update. **onedir** keeps the runtime in `_internal/` next to the exe, no extraction, faster start, AV-friendlier. Installer now bundles the whole folder; `--noupx` added (UPX can corrupt the bundled DLLs). codex caught the stale local build-path check.