### PR TITLE
Fix self-update hang on 'Restarting…' (v2.21.0)

### DIFF
--- a/installer/Pipevoice.iss
+++ b/installer/Pipevoice.iss
@@ -4,7 +4,7 @@
 ; Produces installer\Output\Pipevoice-Setup.exe — a per-user install (no admin).
 
 #define AppName "Pipevoice"
-#define AppVersion "2.20.0"
+#define AppVersion "2.21.0"
 #define AppExe "Pipevoice.exe"
 
 [Setup]
@@ -46,8 +46,14 @@ Name: "{userstartup}\{#AppName}"; Filename: "{app}\{#AppExe}"; Tasks: startup
 Name: "startup"; Description: "Start {#AppName} automatically when I log in"; GroupDescription: "Startup:"; Flags: unchecked
 
 [Run]
-; The app prompts for the API key on first launch, so just start it.
-Filename: "{app}\{#AppExe}"; Description: "Launch {#AppName}"; Flags: nowait postinstall
+; Interactive install: optional "Launch Pipevoice" checkbox on the final page.
+Filename: "{app}\{#AppExe}"; Description: "Launch {#AppName}"; Flags: nowait postinstall skipifsilent
+; Silent self-update (/VERYSILENT from the in-app updater): relaunch the app
+; ourselves. Restart Manager's RESTARTAPPLICATIONS is unreliable after a forced
+; close, and the postinstall entry above is skipped when silent, so without this
+; the update could finish with no app running. The single-instance lock makes any
+; overlap with RESTARTAPPLICATIONS safe (the second launch just exits).
+Filename: "{app}\{#AppExe}"; Flags: nowait; Check: WizardSilent
 
 [UninstallDelete]
 Type: filesandordirs; Name: "{userappdata}\{#AppName}"

--- a/wisprlite/__init__.py
+++ b/wisprlite/__init__.py
@@ -1,3 +1,3 @@
 """Pipevoice — push-to-talk voice typing for Windows."""
 
-__version__ = "2.20.0"
+__version__ = "2.21.0"

--- a/wisprlite/about.py
+++ b/wisprlite/about.py
@@ -7,6 +7,7 @@ wraps it in its own short-lived Tk process.
 
 from __future__ import annotations
 
+import os
 import re
 import threading
 import webbrowser
@@ -101,6 +102,19 @@ def build(container, root, wheel=None) -> None:
     inner.bind("<Configure>", lambda e: canvas.configure(scrollregion=canvas.bbox("all")))
     wheel(canvas)
 
+    def _exit_for_install():
+        # This window runs as its own process and, in the onedir build, holds an
+        # open lock on the very files the installer must replace (Pipevoice.exe,
+        # python311.dll). Closing it frees those locks so the silent installer can
+        # swap files and relaunch the app; leaving it open is what made the update
+        # hang on "Installing…" forever. Exit promptly (before the installer takes
+        # its Restart-Manager snapshot) so it isn't reopened after the update.
+        try:
+            root.destroy()
+        except Exception:
+            pass
+        os._exit(0)
+
     def do_update():
         btn.config(state="disabled", text="Downloading…")
         status.config(text="Downloading the update…", fg=MUTED)
@@ -110,8 +124,10 @@ def build(container, root, wheel=None) -> None:
 
             def done():
                 if ok:
-                    status.config(text="Installing… Pipevoice will restart in a moment.", fg=GOOD)
-                    btn.config(text="Restarting…")
+                    status.config(text="Update downloaded. Pipevoice will close to install, "
+                                       "then reopen on the new version.", fg=GOOD)
+                    btn.config(text="Installing…")
+                    root.after(900, _exit_for_install)
                 else:
                     status.config(text="Update failed. Check your connection and try again.", fg=WARN)
                     btn.config(state="normal", text="Try again", command=do_update)

--- a/wisprlite/updater.py
+++ b/wisprlite/updater.py
@@ -193,11 +193,15 @@ def download_and_run(info: dict) -> bool:
                 pass
             return False
     # Let the installer (not us) close + replace + relaunch the running exe.
+    # FORCECLOSEAPPLICATIONS is essential: the tray app and any open settings
+    # window don't answer Windows' Restart Manager (Tk/pystray ignore the close
+    # request), so without forcing, the install can't unlock python311.dll /
+    # Pipevoice.exe and stalls. Forcing closes them; RESTARTAPPLICATIONS relaunches.
     try:
         flags = getattr(subprocess, "DETACHED_PROCESS", 0) | getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
         subprocess.Popen(
             [dest, "/VERYSILENT", "/SUPPRESSMSGBOXES", "/NORESTART",
-             "/CLOSEAPPLICATIONS", "/RESTARTAPPLICATIONS"],
+             "/CLOSEAPPLICATIONS", "/FORCECLOSEAPPLICATIONS", "/RESTARTAPPLICATIONS"],
             creationflags=flags,
             close_fds=True,
         )


### PR DESCRIPTION
## The bug
Clicking **Update now** in About leaves the window stuck on "Installing… / Restarting…" forever and the app never updates (reported on 2.19.0 → 2.20.0).

## Root cause
The About/Settings window is its **own** onedir `Pipevoice.exe` process and locks `python311.dll` / `Pipevoice.exe`, the exact files the silent installer must overwrite. The old code just changed the button to "Restarting…" and **never closed the window**, so the installer could never replace the locked files and stalled. Tk/pystray also don't answer Windows Restart Manager, so `CloseApplications=yes` couldn't close them either.

## Fixes
1. **`about.py`** — after launching the installer, the window closes itself (`root.destroy` + `os._exit`) ~900ms later, releasing its file locks and clearing the stuck UI.
2. **`updater.py`** — add `/FORCECLOSEAPPLICATIONS` so Restart Manager force-closes the unresponsive tray app and frees the locked files.
3. **`installer/Pipevoice.iss`** — `RESTARTAPPLICATIONS` is unreliable after a forced close and the `postinstall` launch entry is skipped in silent installs, so a new `Check: WizardSilent` `[Run]` entry explicitly relaunches the app during a silent self-update. The single-instance TCP lock makes any overlap with RM harmless. The original launch entry gets `skipifsilent`.

Bumped to **v2.21.0** (`__init__.py` + `.iss`).

## Verification
- `py_compile` clean; About window rendered under Xvfb at v2.21.0 (no layout regression, `os` import fine).
- **codex** cross-model review: first pass flagged that `/RESTARTAPPLICATIONS` alone wouldn't reliably relaunch a force-closed app → added the `WizardSilent` `[Run]` relaunch → re-review: **resolved** (`WizardSilent` confirmed, no double-launch given the lock).

Note: the runtime close/relaunch path can only be fully exercised on a real Windows install, not in this Linux env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)