### PR TITLE
Settings: History tab + app-profiles Browse/search (v2.22.0)

### DIFF
--- a/installer/Pipevoice.iss
+++ b/installer/Pipevoice.iss
@@ -4,7 +4,7 @@
 ; Produces installer\Output\Pipevoice-Setup.exe — a per-user install (no admin).
 
 #define AppName "Pipevoice"
-#define AppVersion "2.21.0"
+#define AppVersion "2.22.0"
 #define AppExe "Pipevoice.exe"
 
 [Setup]

--- a/wisprlite/__init__.py
+++ b/wisprlite/__init__.py
@@ -1,3 +1,3 @@
 """Pipevoice — push-to-talk voice typing for Windows."""
 
-__version__ = "2.21.0"
+__version__ = "2.22.0"

--- a/wisprlite/history.py
+++ b/wisprlite/history.py
@@ -83,47 +83,59 @@ def _ago(ts: float) -> str:
     return f"{int(d // 86400)}d ago"
 
 
-def main() -> None:
-    """The --history viewer window."""
+def _copy_to_clipboard(root, text: str) -> bool:
+    """Copy without going through typer (which imports the Windows-only `keyboard`).
+    pyperclip first, then Tk's own clipboard as a fallback. True only on success."""
+    if not text:
+        return False
     try:
-        import tkinter as tk
-        from tkinter import ttk
-    except Exception:
-        return
-    from .typer import copy_clipboard
+        import pyperclip
 
+        pyperclip.copy(text)
+        return True
+    except Exception:
+        pass
+    try:
+        root.clipboard_clear()
+        root.clipboard_append(text)
+        root.update()  # flush so other apps can read it
+        return True
+    except Exception:
+        return False
+
+
+def _wheel_global(canvas):
+    canvas.bind("<Enter>", lambda e: canvas.bind_all(
+        "<MouseWheel>", lambda ev: canvas.yview_scroll(int(-ev.delta / 120), "units")))
+    canvas.bind("<Leave>", lambda e: canvas.unbind_all("<MouseWheel>"))
+
+
+def build(container, root, wheel=None) -> None:
+    """Populate `container` with the dictation-history list + Clear control. Used
+    both as the standalone --history window and as the History tab in Settings.
+    `root` is the toplevel (for thread-safe .after); `wheel` scopes the mousewheel."""
+    import tkinter as tk
+    from tkinter import ttk
+
+    if wheel is None:
+        wheel = _wheel_global
     cfg = config.Config.load()
     entries = load(getattr(cfg, "history_size", 50) or 50)
 
-    root = tk.Tk()
-    root.title("Pipevoice history")
-    root.configure(bg=BG)
-    ico = config.asset_path("wisprlite.ico")
-    if ico:
-        try:
-            root.iconbitmap(ico)
-        except Exception:
-            pass
-
-    style = ttk.Style(root)
-    try:
-        style.theme_use("clam")
-    except Exception:
-        pass
-    style.configure("TButton", background=CARD, foreground=FG, padding=5, borderwidth=0)
-    style.map("TButton", background=[("active", "#262a3a")])
-    style.configure("Vertical.TScrollbar", background=CARD, troughcolor=BG, borderwidth=0, arrowcolor=MUTED)
-
-    head = tk.Frame(root, bg=BG, padx=18, pady=14)
+    head = tk.Frame(container, bg=BG, padx=18, pady=14)
     head.pack(fill="x")
     tk.Label(head, text="Dictation history", bg=BG, fg=ACCENT,
              font=("Segoe UI", 14, "bold")).pack(side="left")
-    tk.Label(head, text=f"  last {len(entries)}", bg=BG, fg=MUTED,
-             font=("Segoe UI", 9)).pack(side="left")
+    count = tk.Label(head, text=f"  last {len(entries)}", bg=BG, fg=MUTED, font=("Segoe UI", 9))
+    count.pack(side="left")
 
-    body = tk.Frame(root, bg=BG)
+    # Clear sits at the bottom; pack it before the list so the list fills above it.
+    foot = tk.Frame(container, bg=BG, padx=18, pady=12)
+    foot.pack(side="bottom", fill="x")
+
+    body = tk.Frame(container, bg=BG)
     body.pack(fill="both", expand=True)
-    canvas = tk.Canvas(body, bg=BG, highlightthickness=0, width=520, height=440)
+    canvas = tk.Canvas(body, bg=BG, highlightthickness=0, width=520, height=420)
     vbar = ttk.Scrollbar(body, orient="vertical", command=canvas.yview)
     canvas.configure(yscrollcommand=vbar.set)
     vbar.pack(side="right", fill="y")
@@ -131,11 +143,11 @@ def main() -> None:
     inner = tk.Frame(canvas, bg=BG)
     canvas.create_window((0, 0), window=inner, anchor="nw")
     inner.bind("<Configure>", lambda e: canvas.configure(scrollregion=canvas.bbox("all")))
-    canvas.bind_all("<MouseWheel>", lambda e: canvas.yview_scroll(int(-e.delta / 120), "units"))
+    wheel(canvas)
 
     def copy_row(text, btn):
-        copy_clipboard(text)
-        btn.config(text="Copied ✓")
+        ok = _copy_to_clipboard(root, text)
+        btn.config(text="Copied ✓" if ok else "Copy failed")
         root.after(1100, lambda: btn.config(text="Copy"))
 
     if not entries:
@@ -158,22 +170,54 @@ def main() -> None:
         tk.Label(card, text=e.get("text", ""), bg=CARD, fg=FG, font=("Segoe UI", 10),
                  anchor="w", justify="left", wraplength=460).pack(fill="x", pady=(6, 0))
 
-    foot = tk.Frame(root, bg=BG, padx=18, pady=12)
-    foot.pack(fill="x")
-
     def do_clear():
         clear()
         for w in inner.winfo_children():
             w.destroy()
+        count.config(text="  cleared")
         tk.Label(inner, text="History cleared.", bg=BG, fg=MUTED,
                  font=("Segoe UI", 10), padx=20, pady=24).pack(anchor="w")
 
     tk.Button(foot, text="Clear history", command=do_clear, bg=CARD, fg=MUTED,
               activebackground="#262a3a", activeforeground=FG, relief="flat",
               padx=12, pady=6, font=("Segoe UI", 9)).pack(side="left")
-    tk.Button(foot, text="Close", command=root.destroy, bg=ACCENT, fg="#1a0c0d",
+
+
+def main() -> None:
+    """The standalone --history viewer window."""
+    try:
+        import tkinter as tk
+        from tkinter import ttk
+    except Exception:
+        return
+
+    root = tk.Tk()
+    root.title("Pipevoice history")
+    root.configure(bg=BG)
+    ico = config.asset_path("wisprlite.ico")
+    if ico:
+        try:
+            root.iconbitmap(ico)
+        except Exception:
+            pass
+
+    style = ttk.Style(root)
+    try:
+        style.theme_use("clam")
+    except Exception:
+        pass
+    style.configure("TButton", background=CARD, foreground=FG, padding=5, borderwidth=0)
+    style.map("TButton", background=[("active", "#262a3a")])
+    style.configure("Vertical.TScrollbar", background=CARD, troughcolor=BG, borderwidth=0, arrowcolor=MUTED)
+
+    # Reserve the bottom for Close, then build fills the cavity above it.
+    closebar = tk.Frame(root, bg=BG, padx=18, pady=12)
+    closebar.pack(side="bottom", fill="x")
+    tk.Button(closebar, text="Close", command=root.destroy, bg=ACCENT, fg="#1a0c0d",
               activebackground="#e8838b", relief="flat", padx=18, pady=6,
               font=("Segoe UI", 9, "bold")).pack(side="right")
+
+    build(root, root)
 
     root.update_idletasks()
     w = max(560, root.winfo_reqwidth())

--- a/wisprlite/profiles.py
+++ b/wisprlite/profiles.py
@@ -8,6 +8,8 @@ mutate saved settings; app.py applies them for one utterance only.
 
 from __future__ import annotations
 
+import os
+
 from . import config
 
 KEYS = ("engine", "ai_cleanup", "auto_enter", "output_mode")
@@ -49,13 +51,14 @@ P_ENGINES = [("", "(app default)"), ("deepgram", "Deepgram"), ("openai", "OpenAI
 P_OUTPUTS = [("type", "Type"), ("paste", "Paste"), ("clipboard", "Clipboard")]
 
 # Common apps so popular targets appear even when they aren't currently running.
+# Full product names so a natural search ("visual studio code") matches.
 COMMON_APPS = [
-    ("code.exe", "VS Code"), ("cursor.exe", "Cursor"), ("chrome.exe", "Chrome"),
-    ("msedge.exe", "Edge"), ("firefox.exe", "Firefox"),
+    ("code.exe", "Visual Studio Code"), ("cursor.exe", "Cursor"), ("chrome.exe", "Google Chrome"),
+    ("msedge.exe", "Microsoft Edge"), ("firefox.exe", "Mozilla Firefox"),
     ("windowsterminal.exe", "Windows Terminal"), ("powershell.exe", "PowerShell"),
     ("cmd.exe", "Command Prompt"), ("slack.exe", "Slack"), ("discord.exe", "Discord"),
-    ("ms-teams.exe", "Teams"), ("notepad.exe", "Notepad"), ("notepad++.exe", "Notepad++"),
-    ("winword.exe", "Word"), ("outlook.exe", "Outlook"), ("obsidian.exe", "Obsidian"),
+    ("ms-teams.exe", "Microsoft Teams"), ("notepad.exe", "Notepad"), ("notepad++.exe", "Notepad++"),
+    ("winword.exe", "Microsoft Word"), ("outlook.exe", "Microsoft Outlook"), ("obsidian.exe", "Obsidian"),
     ("idea64.exe", "IntelliJ IDEA"), ("explorer.exe", "File Explorer"),
     ("telegram.exe", "Telegram"), ("whatsapp.exe", "WhatsApp"),
 ]
@@ -120,6 +123,9 @@ def main() -> None:
     style.configure("Accent.TButton", background=ACCENT, foreground="#1a0c0d",
                     font=("Segoe UI", 9, "bold"), padding=7, borderwidth=0)
     style.map("Accent.TButton", background=[("active", "#e8838b")])
+    # Lighter than the card so in-card buttons (Browse) read as buttons, not text.
+    style.configure("Pick.TButton", background="#2a2f3d", foreground=FG, padding=6, borderwidth=0)
+    style.map("Pick.TButton", background=[("active", "#333a4a")])
     style.configure("TCheckbutton", background=CARD, foreground=FG)
     style.map("TCheckbutton", background=[("active", CARD)])
     style.configure("TCombobox", fieldbackground=CARD, background=CARD, foreground=FG, arrowcolor=FG)
@@ -136,7 +142,7 @@ def main() -> None:
     head.pack(fill="x")
     tk.Label(head, text="App profiles", bg=BG, fg=ACCENT, font=("Segoe UI", 16, "bold")).pack(anchor="w")
     tk.Label(head, text="Give an app its own behaviour. Terminal: raw + Enter. Chat: polished + auto-send.\n"
-                        "Editor: no AI cleanup. Start typing in the App box to search, or type any exe name.",
+                        "Editor: no AI cleanup. Search your open apps, or Browse to pick any program.",
              bg=BG, fg=MUTED, font=("Segoe UI", 9), justify="left").pack(anchor="w", pady=(5, 0))
 
     footer = tk.Frame(root, bg=BG, padx=22, pady=12)
@@ -167,12 +173,31 @@ def main() -> None:
         card = {}
 
         tk.Label(inner, text="APP", bg=CARD, fg=MUTED, font=("Segoe UI", 8, "bold")).pack(anchor="w")
+        tk.Label(inner, text="Type to search your open apps, or Browse to pick any program (.exe).",
+                 bg=CARD, fg=MUTED, font=("Segoe UI", 8)).pack(anchor="w", pady=(2, 0))
         pick = tk.Frame(inner, bg=CARD)
-        pick.pack(fill="x", pady=(5, 0))
+        pick.pack(fill="x", pady=(6, 0))
         exe_var = tk.StringVar(value=exe)
-        cb = ttk.Combobox(pick, textvariable=exe_var, values=app_values, width=40)
+        cb = ttk.Combobox(pick, textvariable=exe_var, values=app_values, width=32)
         cb.pack(side="left")
         _searchable(cb, app_values)
+
+        def browse(var=exe_var):
+            # Native file picker, so the user can grab any installed program by
+            # navigating to its .exe instead of guessing the process name.
+            from tkinter import filedialog
+            la = os.environ.get("LOCALAPPDATA")
+            cands = [os.path.join(la, "Programs")] if la else []
+            cands += [la, os.environ.get("ProgramFiles"), os.environ.get("ProgramW6432")]
+            initial = next((c for c in cands if c and os.path.isdir(c)), os.path.expanduser("~"))
+            path = filedialog.askopenfilename(
+                parent=root, title="Pick a program",
+                initialdir=initial,
+                filetypes=[("Programs", "*.exe"), ("All files", "*.*")])
+            if path:
+                var.set(os.path.basename(path))
+
+        ttk.Button(pick, text="Browse…", style="Pick.TButton", command=browse).pack(side="left", padx=(8, 0))
         ttk.Button(pick, text="Remove",
                    command=lambda: (wrap.destroy(), card in cards and cards.remove(card))).pack(side="right")
 

--- a/wisprlite/settings.py
+++ b/wisprlite/settings.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import threading
 
-from . import about, autostart, cleanup, config, winui
+from . import about, autostart, cleanup, config, history, winui
 
 ENGINES = [("deepgram", "Deepgram — fastest, live"),
            ("openai", "OpenAI Whisper — accurate, slight wait"),
@@ -253,9 +253,11 @@ def main(first_run: bool = False) -> None:
     body_wrap.pack(side="top", fill="both", expand=True)
 
     tab_settings = tk.Frame(body_wrap, bg=BG)
+    tab_history = tk.Frame(body_wrap, bg=BG)
     tab_guide = tk.Frame(body_wrap, bg=BG)
     tab_about = tk.Frame(body_wrap, bg=BG)
-    _tabs = [("Settings", tab_settings), ("Guide", tab_guide), ("About", tab_about)]
+    _tabs = [("Settings", tab_settings), ("History", tab_history),
+             ("Guide", tab_guide), ("About", tab_about)]
     _tab_w = {}
 
     def _show_tab(name):
@@ -288,6 +290,7 @@ def main(first_run: bool = False) -> None:
     _canvas.create_window((0, 0), window=frm, anchor="nw")
     frm.bind("<Configure>", lambda e: _canvas.configure(scrollregion=_canvas.bbox("all")))
     _wheel(_canvas)
+    history.build(tab_history, root, _wheel)
     _build_guide(tab_guide, _wheel)
     about.build(tab_about, root, _wheel)
     _show_tab("Settings")


### PR DESCRIPTION
Two requests: make Settings the one "main portal" with everything, and fix the app-profiles picker (couldn't find VS Code, no obvious search).

## History in the main portal
`history.py`'s viewer is refactored into a reusable `build(container, root, wheel)` (like `about.build`) plus a thin standalone `main()`. `settings.py` gains a **History** tab → tab bar is now **Settings | History | Guide | About**. The standalone tray `--history` window still works (same `build()`).

Clipboard copy no longer imports `typer` (which pulls in the Windows-only `keyboard`); it uses `pyperclip` with a Tk-clipboard fallback and reports **real** status, "Copied ✓" only when it actually copied, otherwise "Copy failed" (no more blind success).

## App profiles: search + Browse
- A **Browse…** button opens a native file picker (`.exe`) so you can grab any installed program (VS Code, anything) by navigating to it, no guessing the process name. The basename goes into the app field and saves correctly.
- Clear search hint above the field; the picker still type-to-filters your open apps.
- Common-apps list now uses full names ("Visual Studio Code", "Microsoft Edge", …) so a natural search matches.
- `Pick.TButton` style so Browse reads as a button on the card.

## Verification
`py_compile` clean. Rendered under Xvfb: Settings (4 tabs), the History view (entries + Copy + Clear), and the profiles editor (visible Browse button). codex first flagged that the lazy clipboard import still depended on `keyboard` and the button reported false success → fixed by decoupling from `typer` and reporting accurate status → re-review **resolved**.

Bumped to **v2.22.0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)