### PR TITLE
Agent MCP: pipevoice.listen + pipevoice.transcribe

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,24 @@ Switch engines anytime in **Tray → Engine**. Your choice persists.
 `medium.en`, or multilingual `small` / `medium` / `large-v3`. Bigger = slower
 but more accurate; a GPU helps a lot (it auto-detects CUDA).
 
+## Talk to your AI agent (MCP)
+
+PipeVoice can act as a local MCP server so agents (Claude Code, Cursor, Cline) can use
+your voice — no API key, everything runs on your machine:
+
+- **`listen`** — the agent asks a question, you answer by voice (push-to-talk by
+  default, or hands-free), and it gets the text back.
+- **`transcribe`** — hand it a local audio or video file and get the transcript with
+  word/segment timestamps, or ready-made captions (`format: "srt"` / `"vtt"`).
+
+Enable **Agent MCP (listen + transcribe)** in the tray menu, then register it once with
+your client (the app shows the exact command when you toggle it on):
+
+    claude mcp add pipevoice -- python -m wisprlite --mcp        # running from source
+    claude mcp add pipevoice -- "C:\Path\To\Pipevoice.exe" --mcp # installed build
+
+The server is loopback-only and off by default.
+
 ## The overlay HUD
 
 The pill shows what's happening:

--- a/docs/superpowers/plans/2026-06-22-pipevoice-agent-mcp.md
+++ b/docs/superpowers/plans/2026-06-22-pipevoice-agent-mcp.md
@@ -1,0 +1,1179 @@
+# PipeVoice Agent MCP (`listen` + `transcribe`) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Expose two MCP tools from the running PipeVoice tray app — `pipevoice.listen` (ask the user for a spoken answer on demand) and `pipevoice.transcribe` (turn a local audio/video file into timed text via local whisper) — so AI agents get voice input and a key-free transcription service.
+
+**Architecture:** Approach B from the spec. A lightweight stdio MCP server (`Pipevoice.exe --mcp` / `python -m wisprlite --mcp`), spawned by the client, forwards calls over a stdlib loopback TCP "control bridge" to the resident tray app. The resident app keeps near-zero footprint (no web framework); it reuses the existing recorder/overlay/engine/cleanup pipeline for `listen` and a warm local-whisper model for `transcribe`.
+
+**Tech Stack:** Python 3.10+, `faster-whisper` (already a dep, supports `word_timestamps`), the official `mcp` SDK (new dep, used only in the shim), stdlib `socket`/`json`/`threading`/`concurrent.futures`. Target OS Windows; pure-logic units are developed and tested on the Linux dev box with plain `python3` + `assert` (the repo has no pytest/test harness — matching that norm).
+
+**Spec:** `docs/superpowers/specs/2026-06-22-pipevoice-agent-mcp-listen-design.md`
+
+**Testing convention:** Pure units get a standalone `tests/test_*.py` run with `python3 tests/test_x.py` (asserts; exits non-zero on failure). GUI/mic/model/SDK paths can't run on the Linux dev box and carry an explicit **Manual verification (Windows)** checklist instead.
+
+**Branch:** `feat/agent-mcp-listen` (already created).
+
+---
+
+## File map
+
+| File | New/Mod | Responsibility |
+|---|---|---|
+| `wisprlite/captions.py` | New | Pure SRT/VTT formatting from segment dicts. |
+| `wisprlite/vad.py` | New | Pure trailing-silence endpointer for hands-free listen. |
+| `wisprlite/agent_bridge.py` | New | Loopback TCP control bridge (listener + client) + JSON line protocol. |
+| `wisprlite/engines/local_engine.py` | Mod | Add module-level `transcribe_file()` + `_segments_to_dicts()` (warm model, word timestamps). |
+| `wisprlite/mcp_shim.py` | New | `--mcp` stdio MCP server exposing `listen`+`transcribe`, forwarding via the bridge. |
+| `wisprlite/config.py` | Mod | New config fields (mcp_enabled/port/mode/silence/transcribe model). |
+| `wisprlite/app.py` | Mod | `_polish()` refactor; `on_agent_listen/transcribe`, `_agent_dispatch`, bridge lifecycle, tray hook, `_finish` routing. |
+| `wisprlite/tray.py` | Mod | "Agent MCP" toggle menu item. |
+| `wisprlite/__main__.py` | Mod | `--mcp` dispatch. |
+| `requirements.txt` | Mod | Add `mcp`. |
+| `tests/test_captions.py`, `tests/test_vad.py`, `tests/test_agent_bridge.py`, `tests/test_transcribe_shaper.py`, `tests/test_mcp_send.py` | New | Pure-unit checks. |
+| `README.md` / `docs/index.html` | Mod | Document the MCP feature + `claude mcp add`. |
+
+---
+
+## Task 1: Captions formatter (`captions.py`)
+
+**Files:**
+- Create: `wisprlite/captions.py`
+- Test: `tests/test_captions.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_captions.py`:
+
+```python
+import sys, pathlib
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent))
+from wisprlite import captions
+
+SEGS = [
+    {"start": 0.0, "end": 1.5, "text": "Hello there.", "words": []},
+    {"start": 1.5, "end": 3.25, "text": "General Kenobi.", "words": []},
+]
+
+def test_format_timestamp():
+    assert captions.format_timestamp(0) == "00:00:00,000"
+    assert captions.format_timestamp(3.25) == "00:00:03,250"
+    assert captions.format_timestamp(3661.5, vtt=True) == "01:01:01.500"
+    assert captions.format_timestamp(-2) == "00:00:00,000"
+
+def test_to_srt():
+    out = captions.to_srt(SEGS)
+    assert out == (
+        "1\n00:00:00,000 --> 00:00:01,500\nHello there.\n\n"
+        "2\n00:00:01,500 --> 00:00:03,250\nGeneral Kenobi.\n"
+    )
+
+def test_to_vtt():
+    out = captions.to_vtt(SEGS)
+    assert out.startswith("WEBVTT\n\n")
+    assert "00:00:00.000 --> 00:00:01.500\nHello there." in out
+    assert "00:00:01.500 --> 00:00:03.250\nGeneral Kenobi." in out
+
+if __name__ == "__main__":
+    test_format_timestamp(); test_to_srt(); test_to_vtt()
+    print("OK")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python3 tests/test_captions.py`
+Expected: FAIL — `ModuleNotFoundError: No module named 'wisprlite.captions'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `wisprlite/captions.py`:
+
+```python
+"""Pure SRT / WebVTT formatting from segment dicts.
+
+A segment dict is {"start": float, "end": float, "text": str, "words": [...]}.
+No dependencies, no I/O — trivially testable.
+"""
+
+from __future__ import annotations
+
+
+def format_timestamp(seconds: float, vtt: bool = False) -> str:
+    if seconds is None or seconds < 0:
+        seconds = 0.0
+    ms_total = int(round(seconds * 1000))
+    h, ms_total = divmod(ms_total, 3_600_000)
+    m, ms_total = divmod(ms_total, 60_000)
+    s, ms = divmod(ms_total, 1000)
+    sep = "." if vtt else ","
+    return f"{h:02d}:{m:02d}:{s:02d}{sep}{ms:03d}"
+
+
+def to_srt(segments) -> str:
+    lines = []
+    for i, seg in enumerate(segments, 1):
+        lines.append(str(i))
+        lines.append(f"{format_timestamp(seg['start'])} --> {format_timestamp(seg['end'])}")
+        lines.append((seg.get("text") or "").strip())
+        lines.append("")
+    return ("\n".join(lines).strip() + "\n") if lines else ""
+
+
+def to_vtt(segments) -> str:
+    out = ["WEBVTT", ""]
+    for seg in segments:
+        out.append(f"{format_timestamp(seg['start'], vtt=True)} --> {format_timestamp(seg['end'], vtt=True)}")
+        out.append((seg.get("text") or "").strip())
+        out.append("")
+    return "\n".join(out).strip() + "\n"
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python3 tests/test_captions.py`
+Expected: `OK`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add wisprlite/captions.py tests/test_captions.py
+git commit -m "feat(mcp): captions.py — SRT/VTT formatting from segment dicts"
+```
+
+---
+
+## Task 2: Silence endpointer (`vad.py`)
+
+**Files:**
+- Create: `wisprlite/vad.py`
+- Test: `tests/test_vad.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_vad.py`:
+
+```python
+import sys, pathlib
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent))
+from wisprlite.vad import SilenceEndpointer
+
+def feed_seq(ep, levels):
+    return [ep.feed(x) for x in levels]
+
+def test_leading_silence_never_triggers():
+    ep = SilenceEndpointer(threshold=0.02, silence_ms=200, block_ms=50)  # 4 silent blocks
+    assert not any(feed_seq(ep, [0.0] * 50))  # no speech yet -> never stop
+
+def test_speech_then_silence_triggers():
+    ep = SilenceEndpointer(threshold=0.02, silence_ms=200, block_ms=50)  # 4 blocks
+    results = feed_seq(ep, [0.1, 0.1, 0.0, 0.0, 0.0, 0.0])  # speak, then 4 silent
+    assert results[-1] is True
+    assert results[:4] == [False, False, False, False]  # not yet (needs 4 silent)
+
+def test_sustained_speech_never_triggers():
+    ep = SilenceEndpointer(threshold=0.02, silence_ms=200, block_ms=50)
+    assert not any(feed_seq(ep, [0.1] * 50))
+
+def test_silence_resets_on_new_speech():
+    ep = SilenceEndpointer(threshold=0.02, silence_ms=200, block_ms=50)
+    feed_seq(ep, [0.1, 0.0, 0.0, 0.1])  # 2 silent then speech resets the counter
+    assert ep.feed(0.0) is False  # only 1 silent block since the reset
+
+if __name__ == "__main__":
+    test_leading_silence_never_triggers(); test_speech_then_silence_triggers()
+    test_sustained_speech_never_triggers(); test_silence_resets_on_new_speech()
+    print("OK")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python3 tests/test_vad.py`
+Expected: FAIL — `ModuleNotFoundError: No module named 'wisprlite.vad'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `wisprlite/vad.py`:
+
+```python
+"""Trailing-silence endpointer for hands-free capture.
+
+Pure decision logic over the recorder's smoothed RMS level (audio.py:24).
+Stop only after speech has started AND the level has stayed below `threshold`
+for `silence_ms`. No DSP, no deps.
+"""
+
+from __future__ import annotations
+
+
+class SilenceEndpointer:
+    def __init__(self, threshold: float = 0.02, silence_ms: int = 800, block_ms: int = 50) -> None:
+        self.threshold = threshold
+        self.silence_blocks_needed = max(1, int(round(silence_ms / max(1, block_ms))))
+        self._speech_started = False
+        self._silent_blocks = 0
+
+    def feed(self, level: float) -> bool:
+        """Return True when the capture should stop."""
+        if level >= self.threshold:
+            self._speech_started = True
+            self._silent_blocks = 0
+            return False
+        if self._speech_started:
+            self._silent_blocks += 1
+            if self._silent_blocks >= self.silence_blocks_needed:
+                return True
+        return False
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python3 tests/test_vad.py`
+Expected: `OK`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add wisprlite/vad.py tests/test_vad.py
+git commit -m "feat(mcp): vad.py — trailing-silence endpointer for hands-free listen"
+```
+
+---
+
+## Task 3: Control bridge (`agent_bridge.py`)
+
+**Files:**
+- Create: `wisprlite/agent_bridge.py`
+- Test: `tests/test_agent_bridge.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_agent_bridge.py`:
+
+```python
+import sys, pathlib, time
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent))
+from wisprlite import agent_bridge
+
+def test_roundtrip_and_dispatch():
+    seen = {}
+    def dispatch(req):
+        seen["req"] = req
+        if req["op"] == "ping":
+            return {"status": "ok", "text": "pong"}
+        return {"status": "error", "error": "unknown op"}
+
+    listener = agent_bridge.ControlListener(0, dispatch)  # port 0 -> ephemeral
+    listener.start()
+    port = listener.port  # resolved after bind
+    try:
+        resp = agent_bridge.send_request(port, {"op": "ping", "x": 1}, timeout=5.0)
+        assert resp == {"status": "ok", "text": "pong"}, resp
+        assert seen["req"] == {"op": "ping", "x": 1}, seen
+        bad = agent_bridge.send_request(port, {"op": "nope"}, timeout=5.0)
+        assert bad["status"] == "error", bad
+    finally:
+        listener.stop()
+
+def test_dispatch_exception_becomes_error():
+    def dispatch(req):
+        raise ValueError("boom")
+    listener = agent_bridge.ControlListener(0, dispatch)
+    listener.start()
+    try:
+        resp = agent_bridge.send_request(listener.port, {"op": "x"}, timeout=5.0)
+        assert resp["status"] == "error" and "boom" in resp["error"], resp
+    finally:
+        listener.stop()
+
+if __name__ == "__main__":
+    test_roundtrip_and_dispatch(); test_dispatch_exception_becomes_error()
+    print("OK")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python3 tests/test_agent_bridge.py`
+Expected: FAIL — `ModuleNotFoundError: No module named 'wisprlite.agent_bridge'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `wisprlite/agent_bridge.py`:
+
+```python
+"""Loopback control bridge: lets the `--mcp` shim drive the running tray app.
+
+Stdlib socket + newline-delimited JSON. Binds 127.0.0.1 only. Lazy/optional:
+if it can't bind, the caller logs and the feature stays off. This keeps the
+resident app's footprint to a single stdlib socket listener — no web framework.
+"""
+
+from __future__ import annotations
+
+import json
+import socket
+import threading
+from typing import Callable
+
+
+def encode(obj) -> bytes:
+    return (json.dumps(obj) + "\n").encode("utf-8")
+
+
+def decode(line: bytes) -> dict:
+    return json.loads(line.decode("utf-8"))
+
+
+def send_request(port: int, obj: dict, timeout: float = 120.0) -> dict:
+    """Client side (used by the shim). Connect, send one request, read one reply."""
+    with socket.create_connection(("127.0.0.1", port), timeout=5.0) as s:
+        s.settimeout(timeout)
+        s.sendall(encode(obj))
+        f = s.makefile("rb")
+        line = f.readline()
+        return decode(line) if line else {"status": "error", "error": "no response"}
+
+
+class ControlListener:
+    """Accepts one JSON request per connection, calls ``dispatch(req) -> resp``."""
+
+    def __init__(self, port: int, dispatch: Callable[[dict], dict]) -> None:
+        self.port = port
+        self.dispatch = dispatch
+        self._sock = None
+        self._thread = None
+        self._stop = threading.Event()
+
+    def start(self) -> None:
+        self._sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self._sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self._sock.bind(("127.0.0.1", self.port))
+        self.port = self._sock.getsockname()[1]  # resolve ephemeral (port 0)
+        self._sock.listen(4)
+        self._sock.settimeout(0.5)
+        self._stop.clear()
+        self._thread = threading.Thread(target=self._serve, daemon=True)
+        self._thread.start()
+
+    def _serve(self) -> None:
+        while not self._stop.is_set():
+            try:
+                conn, _ = self._sock.accept()
+            except socket.timeout:
+                continue
+            except OSError:
+                break
+            threading.Thread(target=self._handle, args=(conn,), daemon=True).start()
+
+    def _handle(self, conn) -> None:
+        try:
+            f = conn.makefile("rwb")
+            line = f.readline()
+            if not line:
+                return
+            try:
+                resp = self.dispatch(decode(line))
+            except Exception as exc:  # never crash the bridge on a bad request
+                resp = {"status": "error", "error": str(exc)}
+            f.write(encode(resp))
+            f.flush()
+        finally:
+            try:
+                conn.close()
+            except Exception:
+                pass
+
+    def stop(self) -> None:
+        self._stop.set()
+        if self._sock is not None:
+            try:
+                self._sock.close()
+            except Exception:
+                pass
+            self._sock = None
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python3 tests/test_agent_bridge.py`
+Expected: `OK`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add wisprlite/agent_bridge.py tests/test_agent_bridge.py
+git commit -m "feat(mcp): agent_bridge.py — loopback JSON control bridge"
+```
+
+---
+
+## Task 4: Transcribe function (`local_engine.transcribe_file`)
+
+**Files:**
+- Modify: `wisprlite/engines/local_engine.py` (append module-level functions after the `LocalEngine` class, currently ends at line 57)
+- Test: `tests/test_transcribe_shaper.py`
+
+The faster-whisper call needs a model + audio (not runnable on the Linux box), so we isolate the **pure** segment→dict shaping into `_segments_to_dicts()` and test that with fake objects. The model glue is verified manually on Windows (Task 12).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_transcribe_shaper.py`:
+
+```python
+import sys, pathlib
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent))
+from wisprlite.engines.local_engine import _segments_to_dicts
+
+class W:
+    def __init__(self, start, end, word): self.start, self.end, self.word = start, end, word
+
+class S:
+    def __init__(self, start, end, text, words): self.start, self.end, self.text, self.words = start, end, text, words
+
+def test_shaping_with_words():
+    segs = [S(0.0, 1.234567, " Hello ", [W(0.0, 0.5, "Hello")])]
+    out = _segments_to_dicts(segs)
+    assert out == [{"start": 0.0, "end": 1.235, "text": "Hello",
+                    "words": [{"start": 0.0, "end": 0.5, "word": "Hello"}]}], out
+
+def test_shaping_without_words():
+    segs = [S(1.0, 2.0, "no words", None)]
+    out = _segments_to_dicts(segs)
+    assert out[0]["words"] == [], out
+
+if __name__ == "__main__":
+    test_shaping_with_words(); test_shaping_without_words()
+    print("OK")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python3 tests/test_transcribe_shaper.py`
+Expected: FAIL — `ImportError: cannot import name '_segments_to_dicts'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `wisprlite/engines/local_engine.py` (after line 57):
+
+```python
+
+
+# ---- file transcription with word-level timestamps (for the agent MCP) -------
+import threading as _threading
+
+_TRANSCRIBE_MODEL = None
+_TRANSCRIBE_KEY = None
+_TRANSCRIBE_LOCK = _threading.Lock()
+
+
+def _segments_to_dicts(segments) -> list:
+    """Shape faster-whisper segments into plain JSON-able dicts. Pure."""
+    out = []
+    for seg in segments:
+        words = []
+        for w in (getattr(seg, "words", None) or []):
+            words.append({"start": round(float(w.start), 3),
+                          "end": round(float(w.end), 3),
+                          "word": w.word})
+        out.append({"start": round(float(seg.start), 3),
+                    "end": round(float(seg.end), 3),
+                    "text": (seg.text or "").strip(),
+                    "words": words})
+    return out
+
+
+def _get_transcribe_model(model_size: str, device: str = "auto", compute_type: str = "int8"):
+    global _TRANSCRIBE_MODEL, _TRANSCRIBE_KEY
+    key = (model_size, device, compute_type)
+    if _TRANSCRIBE_MODEL is None or _TRANSCRIBE_KEY != key:
+        from faster_whisper import WhisperModel
+        _TRANSCRIBE_MODEL = WhisperModel(model_size, device=device, compute_type=compute_type)
+        _TRANSCRIBE_KEY = key
+    return _TRANSCRIBE_MODEL
+
+
+def transcribe_file(path: str, *, language=None, model_size: str = "base.en",
+                    device: str = "auto", compute_type: str = "int8") -> dict:
+    """Transcribe an audio/video file to text + word/segment timestamps.
+
+    Serialized behind a lock (one shared warm model). faster-whisper decodes
+    audio from many container formats via its bundled PyAV/ffmpeg.
+    """
+    with _TRANSCRIBE_LOCK:
+        model = _get_transcribe_model(model_size, device, compute_type)
+        segments, info = model.transcribe(
+            path, language=language or None, word_timestamps=True,
+            vad_filter=True, beam_size=1,
+        )
+        seg_dicts = _segments_to_dicts(segments)  # consumes the generator inside the lock
+    text = " ".join(s["text"] for s in seg_dicts).strip()
+    return {"text": text,
+            "language": getattr(info, "language", None),
+            "duration": round(float(getattr(info, "duration", 0.0) or 0.0), 3),
+            "segments": seg_dicts}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python3 tests/test_transcribe_shaper.py`
+Expected: `OK`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add wisprlite/engines/local_engine.py tests/test_transcribe_shaper.py
+git commit -m "feat(mcp): local_engine.transcribe_file with word timestamps"
+```
+
+---
+
+## Task 5: Config fields (`config.py`)
+
+**Files:**
+- Modify: `wisprlite/config.py` (the `Config` dataclass; add after line 86 `profiles: list = ...`)
+
+- [ ] **Step 1: Add the fields**
+
+In `wisprlite/config.py`, immediately after the `profiles` field (line 86), add:
+
+```python
+    # Agent MCP server (listen + transcribe). Off by default; opt-in via the tray.
+    mcp_enabled: bool = False
+    mcp_port: int = 49518             # loopback control bridge (distinct from the 49517 lock)
+    mcp_default_mode: str = "push_to_talk"  # push_to_talk | hands_free  (for `listen`)
+    hands_free_silence_ms: int = 800  # trailing silence that ends a hands-free capture
+    transcribe_model_size: str = ""   # blank = reuse local_model_size
+```
+
+- [ ] **Step 2: Verify it loads**
+
+Run: `python3 -c "from wisprlite.config import Config; c=Config(); print(c.mcp_enabled, c.mcp_port, c.mcp_default_mode, c.hands_free_silence_ms, repr(c.transcribe_model_size))"`
+Expected: `False 49518 push_to_talk 800 ''`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add wisprlite/config.py
+git commit -m "feat(mcp): config fields for the agent MCP server"
+```
+
+---
+
+## Task 6: App — bridge lifecycle, dispatch, tray toggle, transcribe handler
+
+**Files:**
+- Modify: `wisprlite/app.py`
+
+Transcribe is the path with no GUI/mic dependency, so it's wired (and bridge-testable) first.
+
+- [ ] **Step 1: Add init state**
+
+In `App.__init__`, after `self._stop = threading.Event()` (line 58), add:
+
+```python
+        self._pending_agent_listen = None   # set while a listen() awaits the user's hotkey
+        self._bridge = None                  # agent_bridge.ControlListener when MCP is on
+```
+
+- [ ] **Step 2: Add the dispatch + transcribe handler + bridge lifecycle**
+
+Add these methods to `App` (e.g. after `toggle_pause`, line 284):
+
+```python
+    # ---- agent MCP -------------------------------------------------------
+    def _agent_dispatch(self, req: dict) -> dict:
+        op = req.get("op")
+        if op == "listen":
+            return self.on_agent_listen(req.get("prompt", ""), req.get("timeout", 45), req.get("mode", ""))
+        if op == "transcribe":
+            return self.on_agent_transcribe(req.get("path", ""), req.get("format", "json"),
+                                            req.get("language", ""), req.get("model_size", ""))
+        return {"status": "error", "error": f"unknown op: {op}"}
+
+    def on_agent_transcribe(self, path="", fmt="json", language="", model_size="") -> dict:
+        import os
+        if not path or not os.path.exists(path):
+            return {"status": "error", "error": f"file not found: {path}"}
+        size = model_size or self.cfg.transcribe_model_size or self.cfg.local_model_size
+        try:
+            from .engines.local_engine import transcribe_file
+            r = transcribe_file(path, language=(language or None), model_size=size)
+        except Exception as exc:
+            log.exception("agent transcribe failed")
+            return {"status": "error", "error": str(exc)}
+        out = {"status": "ok", "text": r["text"], "language": r["language"], "duration": r["duration"]}
+        fmt = (fmt or "json").lower()
+        if fmt in ("srt", "vtt"):
+            from . import captions
+            out["captions"] = captions.to_srt(r["segments"]) if fmt == "srt" else captions.to_vtt(r["segments"])
+        else:
+            out["segments"] = r["segments"]
+        return out
+
+    def _mcp_add_command(self) -> str:
+        if getattr(sys, "frozen", False):
+            return f'claude mcp add pipevoice -- "{sys.executable}" --mcp'
+        return "claude mcp add pipevoice -- python -m wisprlite --mcp"
+
+    def start_mcp_bridge(self) -> None:
+        if self._bridge is not None:
+            return
+        try:
+            from .agent_bridge import ControlListener
+            self._bridge = ControlListener(self.cfg.mcp_port, self._agent_dispatch)
+            self._bridge.start()
+            log.info("MCP control bridge on 127.0.0.1:%s", self.cfg.mcp_port)
+        except Exception as exc:
+            self._bridge = None
+            log.warning("MCP bridge failed to start: %s", exc)
+            self._fail(f"MCP bridge: {exc}")
+
+    def stop_mcp_bridge(self) -> None:
+        if self._bridge is not None:
+            try:
+                self._bridge.stop()
+            except Exception:
+                pass
+            self._bridge = None
+
+    def toggle_mcp(self) -> None:
+        self.cfg.mcp_enabled = not self.cfg.mcp_enabled
+        self.cfg.save()
+        if self.cfg.mcp_enabled:
+            self.start_mcp_bridge()
+            self._notify("Agent MCP on. Register once:\n" + self._mcp_add_command())
+        else:
+            self.stop_mcp_bridge()
+        self.tray.update()
+```
+
+> `on_agent_listen` is added in Task 9; until then `_agent_dispatch` referencing it is fine because the method exists on the class by the time the bridge runs (Tasks 6→9 land before any `listen` call). For Task 8's bridge test we exercise only the `transcribe` and `ping`-style paths.
+
+- [ ] **Step 3: Start/stop the bridge with the app lifecycle**
+
+In `App.run()`, after `self.clip_hotkeys.start()` (line 494), add:
+
+```python
+        if self.cfg.mcp_enabled:
+            self.start_mcp_bridge()
+```
+
+In `App.quit()` (line 386), after `self._stop.set()`, add:
+
+```python
+        self.stop_mcp_bridge()
+```
+
+- [ ] **Step 4: Verify imports resolve (no syntax/name errors)**
+
+Run: `python3 -c "import ast,sys; ast.parse(open('wisprlite/app.py').read()); print('app.py parses')"`
+Expected: `app.py parses`
+
+(The app can't fully launch on Linux — no display/tray — so this is a parse check; behavior is verified in Tasks 7/12.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add wisprlite/app.py
+git commit -m "feat(mcp): bridge lifecycle, dispatch, transcribe handler, tray toggle hook"
+```
+
+---
+
+## Task 7: App — bridge transcribe end-to-end (integration test on Linux)
+
+**Files:**
+- Test: `tests/test_bridge_transcribe.py`
+
+This proves the bridge → dispatch → transcribe wiring without a model by monkeypatching `transcribe_file`, and without the GUI by driving `_agent_dispatch` directly through a real socket round-trip.
+
+- [ ] **Step 1: Write the test**
+
+Create `tests/test_bridge_transcribe.py`:
+
+```python
+import sys, pathlib, tempfile, os
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent))
+from wisprlite import agent_bridge
+from wisprlite.engines import local_engine
+
+# Fake transcribe_file so no model/audio is needed.
+def fake_transcribe_file(path, *, language=None, model_size="base.en", **kw):
+    return {"text": "hello world", "language": "en", "duration": 1.0,
+            "segments": [{"start": 0.0, "end": 1.0, "text": "hello world", "words": []}]}
+
+def make_dispatch():
+    # Minimal stand-in for App._agent_dispatch + on_agent_transcribe, reusing the real captions path.
+    from wisprlite import captions
+    def dispatch(req):
+        if req.get("op") != "transcribe":
+            return {"status": "error", "error": "unexpected op"}
+        path = req["path"]
+        if not os.path.exists(path):
+            return {"status": "error", "error": "file not found"}
+        r = fake_transcribe_file(path)
+        out = {"status": "ok", "text": r["text"], "language": r["language"], "duration": r["duration"]}
+        if req.get("format") == "srt":
+            out["captions"] = captions.to_srt(r["segments"])
+        else:
+            out["segments"] = r["segments"]
+        return out
+    return dispatch
+
+def test_transcribe_json_and_srt():
+    listener = agent_bridge.ControlListener(0, make_dispatch())
+    listener.start()
+    try:
+        with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tf:
+            p = tf.name
+        try:
+            j = agent_bridge.send_request(listener.port, {"op": "transcribe", "path": p, "format": "json"})
+            assert j["status"] == "ok" and j["text"] == "hello world" and "segments" in j, j
+            srt = agent_bridge.send_request(listener.port, {"op": "transcribe", "path": p, "format": "srt"})
+            assert srt["captions"].startswith("1\n00:00:00,000 --> 00:00:01,000"), srt
+            miss = agent_bridge.send_request(listener.port, {"op": "transcribe", "path": "/no/such", "format": "json"})
+            assert miss["status"] == "error", miss
+        finally:
+            os.unlink(p)
+    finally:
+        listener.stop()
+
+if __name__ == "__main__":
+    test_transcribe_json_and_srt()
+    print("OK")
+```
+
+- [ ] **Step 2: Run it**
+
+Run: `python3 tests/test_bridge_transcribe.py`
+Expected: `OK`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_bridge_transcribe.py
+git commit -m "test(mcp): bridge -> transcribe -> captions round-trip"
+```
+
+---
+
+## Task 8: MCP shim (`mcp_shim.py` + `--mcp`)
+
+**Files:**
+- Create: `wisprlite/mcp_shim.py`
+- Modify: `wisprlite/__main__.py`
+- Modify: `requirements.txt`
+- Test: `tests/test_mcp_send.py`
+
+- [ ] **Step 1: Write the failing test (the `_send` forwarder, no SDK needed)**
+
+Create `tests/test_mcp_send.py`:
+
+```python
+import sys, pathlib
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent))
+from wisprlite import agent_bridge, mcp_shim
+
+def test_send_forwards_to_bridge(monkeypatch=None):
+    listener = agent_bridge.ControlListener(0, lambda req: {"status": "ok", "echo": req})
+    listener.start()
+    try:
+        # Point the shim at our ephemeral listener port.
+        import wisprlite.mcp_shim as shim
+        shim._port = lambda: listener.port
+        resp = shim._send("transcribe", path="/x", format="json")
+        assert resp["status"] == "ok", resp
+        assert resp["echo"] == {"op": "transcribe", "path": "/x", "format": "json"}, resp
+    finally:
+        listener.stop()
+
+def test_send_app_not_running():
+    import wisprlite.mcp_shim as shim
+    shim._port = lambda: 1  # nothing listening on port 1
+    resp = shim._send("listen")
+    assert resp["status"] == "app_not_running", resp
+
+if __name__ == "__main__":
+    test_send_forwards_to_bridge(); test_send_app_not_running()
+    print("OK")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python3 tests/test_mcp_send.py`
+Expected: FAIL — `ModuleNotFoundError: No module named 'wisprlite.mcp_shim'`
+
+- [ ] **Step 3: Write the shim**
+
+Create `wisprlite/mcp_shim.py`:
+
+```python
+"""`--mcp`: a stdio MCP server exposing pipevoice.listen + pipevoice.transcribe.
+
+Spawned on demand by an MCP client (Claude Code etc.). It forwards each call to
+the resident tray app over the loopback control bridge, so the heavy MCP
+machinery lives only in this ephemeral process — the resident app stays light.
+"""
+
+from __future__ import annotations
+
+
+def _port() -> int:
+    from . import config
+    return int(getattr(config.Config.load(), "mcp_port", 49518))
+
+
+def _send(op: str, **kw) -> dict:
+    from . import agent_bridge
+    try:
+        return agent_bridge.send_request(_port(), {"op": op, **kw})
+    except (ConnectionRefusedError, OSError):
+        return {"status": "app_not_running", "text": "",
+                "error": "PipeVoice isn't running, or its Agent MCP toggle is off."}
+
+
+def main() -> None:
+    from mcp.server.fastmcp import FastMCP
+
+    mcp = FastMCP("pipevoice")
+
+    @mcp.tool()
+    def listen(prompt: str = "", timeout_seconds: int = 45, mode: str = "") -> dict:
+        """Ask the user to answer by voice and return what they said as text.
+
+        Use when you need information only the user has. PipeVoice shows a prompt,
+        the user speaks (push-to-talk by default), and the transcript is returned.
+        `mode` may be 'push_to_talk' or 'hands_free' (default: the user's setting).
+        """
+        return _send("listen", prompt=prompt, timeout=timeout_seconds, mode=mode)
+
+    @mcp.tool()
+    def transcribe(path: str, format: str = "json", language: str = "", model_size: str = "") -> dict:
+        """Transcribe a local audio or video file to timed text using local whisper.
+
+        `format`: 'json' returns text + segment/word timestamps; 'srt'/'vtt' return
+        a ready-made caption string in `captions`. `language` is an optional ISO
+        code (blank = auto-detect). No API key needed; runs offline.
+        """
+        return _send("transcribe", path=path, format=format, language=language, model_size=model_size)
+
+    mcp.run()  # stdio transport by default
+
+
+if __name__ == "__main__":
+    main()
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python3 tests/test_mcp_send.py`
+Expected: `OK`
+
+- [ ] **Step 5: Wire the `--mcp` flag**
+
+In `wisprlite/__main__.py`, add a branch before the final `else` (after line 9, the `--profiles` branch):
+
+```python
+elif "--mcp" in sys.argv:
+    from .mcp_shim import main
+```
+
+- [ ] **Step 6: Add the dependency**
+
+Append to `requirements.txt`:
+
+```
+mcp>=1.2  # MCP SDK — only imported by the `--mcp` stdio shim
+```
+
+- [ ] **Step 7: Verify the SDK shape (run where `mcp` is installed)**
+
+Run: `python3 -c "from mcp.server.fastmcp import FastMCP; m=FastMCP('x'); print(hasattr(m,'tool') and hasattr(m,'run'))"`
+Expected: `True`
+If the import path differs in the installed `mcp` version, consult the `claude-api` skill / MCP docs and adjust `mcp_shim.main()` accordingly (do not hand-roll the protocol unless the exe-size ceiling in the spec forces it).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add wisprlite/mcp_shim.py wisprlite/__main__.py requirements.txt tests/test_mcp_send.py
+git commit -m "feat(mcp): stdio MCP shim exposing listen + transcribe"
+```
+
+---
+
+## Task 9: App — `listen` push-to-talk path + `_polish` refactor + `_finish` routing
+
+**Files:**
+- Modify: `wisprlite/app.py`
+
+- [ ] **Step 1: Extract `_polish()` (DRY — reused by normal dictation and agent listen)**
+
+Add this method to `App` (e.g. after `_fallback`, line 248):
+
+```python
+    def _polish(self, text: str) -> str:
+        """Optional LLM cleanup ('Flow mode'); returns the input unchanged if off/unavailable."""
+        if not (text and self._eff("ai_cleanup")):
+            return text
+        from . import cleanup
+        if not cleanup.provider_ready(self.cfg.cleanup_provider):
+            return text
+        self.overlay.set_state("transcribing", "Polishing…")
+        polished = cleanup.clean(text, self.cfg.cleanup_provider, self.cfg.cleanup_model,
+                                 self.cfg.language, self.cfg.speech_notes)
+        return polished or text
+```
+
+- [ ] **Step 2: Use `_polish` in `_finish` (replace the inline cleanup block)**
+
+In `_finish`, replace lines 182–190 (the `if text and self._eff("ai_cleanup"):` block through `text = polished`) with:
+
+```python
+            # AI cleanup ("Flow mode") — OpenAI / Gemini / OpenRouter / local Ollama.
+            text = self._polish(text)
+```
+
+- [ ] **Step 3: Add the agent-listen routing branch in `_finish`**
+
+In `_finish`, immediately after `text = (text or "").strip()` (line 163) and **before** the `if not text:` check (line 164), insert:
+
+```python
+            # Agent MCP listen: route the transcript to the caller instead of typing.
+            if self._pending_agent_listen is not None:
+                pending = self._pending_agent_listen
+                self._pending_agent_listen = None
+                if not pending["future"].cancelled():  # not already timed out
+                    answer = apply_replacements(self._polish(text), self.cfg.replacements) if text else ""
+                    pending["future"].set_result({"status": "ok", "text": answer})
+                self.overlay.set_state("done", "↩ sent to agent" if text else "↩ (nothing heard)")
+                self._set_icon("idle")
+                return
+```
+
+(The existing `finally:` block at lines 227–231 still runs — it clears `_session`/`_active`/`_fg_ctx` and releases `_busy`.)
+
+- [ ] **Step 4: Add `on_agent_listen` (push-to-talk)**
+
+Add to `App` (after the `toggle_mcp` method from Task 6):
+
+```python
+    def on_agent_listen(self, prompt="", timeout=45, mode="") -> dict:
+        import concurrent.futures
+        mode = mode or self.cfg.mcp_default_mode
+        if self._busy.locked():
+            return {"status": "busy", "text": ""}
+        if mode == "hands_free":
+            return self._agent_listen_hands_free(prompt, timeout)
+        # push-to-talk: arm, cue the overlay, wait for the user's normal hotkey cycle.
+        fut = concurrent.futures.Future()
+        self._pending_agent_listen = {"future": fut}
+        self.overlay.show("listening", prompt or "🎙 your agent is listening — hold your hotkey & speak")
+        try:
+            return fut.result(timeout=max(1, int(timeout)))
+        except concurrent.futures.TimeoutError:
+            fut.cancel()
+            self._pending_agent_listen = None
+            self.overlay.hide()
+            return {"status": "timeout", "text": ""}
+```
+
+- [ ] **Step 5: Parse check**
+
+Run: `python3 -c "import ast; ast.parse(open('wisprlite/app.py').read()); print('ok')"`
+Expected: `ok`
+
+- [ ] **Step 6: Manual verification (Windows)** — record results inline:
+
+```
+[ ] Start the app from source, enable Agent MCP in the tray (it shows the claude mcp add command).
+[ ] claude mcp add pipevoice -- python -m wisprlite --mcp ; restart Claude Code.
+[ ] In Claude Code: ask it to call pipevoice.listen with prompt "say a test word".
+[ ] Overlay shows "your agent is listening — hold your hotkey & speak".
+[ ] Hold the hotkey, say "banana", release. The tool returns {status:"ok", text:"Banana"} (cleaned).
+[ ] The text is NOT typed into any window, and NOT added to History.
+[ ] Don't press the hotkey for 45s -> tool returns {status:"timeout"}; overlay clears.
+[ ] While mid-dictation (normal hotkey held), a listen() call returns {status:"busy"} immediately.
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add wisprlite/app.py
+git commit -m "feat(mcp): listen push-to-talk path + _polish refactor + _finish routing"
+```
+
+---
+
+## Task 10: App — `listen` hands-free path
+
+**Files:**
+- Modify: `wisprlite/app.py`
+
+- [ ] **Step 1: Add `_agent_listen_hands_free`**
+
+Add to `App` (after `on_agent_listen`):
+
+```python
+    def _agent_listen_hands_free(self, prompt="", timeout=45) -> dict:
+        import time
+        from .vad import SilenceEndpointer
+        if not self._busy.acquire(blocking=False):
+            return {"status": "busy", "text": ""}
+        try:
+            try:
+                engine = self._get_engine()
+                self._session = engine.start_session(on_partial=self.overlay.set_text)
+            except Exception as exc:
+                self._fail(str(exc))
+                return {"status": "error", "text": "", "error": str(exc)}
+            self.overlay.show("listening", prompt or "🎙 your agent is listening…")
+            self._set_icon("recording")
+            self.recorder.start(on_frame=self._session.feed if engine.streaming else None)
+            endpointer = SilenceEndpointer(silence_ms=self.cfg.hands_free_silence_ms)
+            deadline = time.time() + max(1, int(timeout))
+            while time.time() < deadline:
+                time.sleep(0.05)
+                if endpointer.feed(self.recorder.level):
+                    break
+            audio = self.recorder.stop()
+            self._set_icon("transcribing")
+            if not endpointer._speech_started:
+                self.overlay.hide(); self._set_icon("idle")
+                return {"status": "timeout", "text": ""}
+            try:
+                text = self._session.finish(audio) if self._session else ""
+            except Exception as exc:
+                text = self._fallback(audio, exc)
+            text = apply_replacements(self._polish((text or "").strip()), self.cfg.replacements)
+            self.overlay.set_state("done", "↩ sent to agent")
+            self._beep(990, 60); self._set_icon("idle")
+            return {"status": "ok", "text": text}
+        finally:
+            self._session = None
+            self._release()
+```
+
+- [ ] **Step 2: Parse check**
+
+Run: `python3 -c "import ast; ast.parse(open('wisprlite/app.py').read()); print('ok')"`
+Expected: `ok`
+
+- [ ] **Step 3: Manual verification (Windows)**:
+
+```
+[ ] Set mcp_default_mode = "hands_free" in config.json (or pass mode in the tool call).
+[ ] Call pipevoice.listen. Overlay shows "listening…"; mic opens WITHOUT a keypress.
+[ ] Speak "the quick brown fox", then stop. After ~0.8s of silence it auto-stops and returns the text.
+[ ] Call listen and say nothing -> after `timeout` returns {status:"timeout"}.
+[ ] Tune hands_free_silence_ms if it cuts off too early/late.
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add wisprlite/app.py
+git commit -m "feat(mcp): listen hands-free path (VAD auto-stop)"
+```
+
+---
+
+## Task 11: Tray toggle + docs
+
+**Files:**
+- Modify: `wisprlite/tray.py`
+- Modify: `README.md`, `wisprlitevercel/docs/index.html`
+
+- [ ] **Step 1: Add the tray menu item**
+
+In `wisprlite/tray.py`, inside the `menu = Menu(...)` block, after the "Start on login" item (line 97–98), add:
+
+```python
+            Item("Agent MCP (listen + transcribe)", lambda i, it: app.toggle_mcp(),
+                 checked=lambda it: app.cfg.mcp_enabled),
+```
+
+- [ ] **Step 2: Manual verification (Windows)**:
+
+```
+[ ] Tray shows "Agent MCP (listen + transcribe)" with a check reflecting cfg.mcp_enabled.
+[ ] Toggling on starts the bridge (log: "MCP control bridge on 127.0.0.1:49518") and notifies the add command.
+[ ] Toggling off stops it (a subsequent shim call returns app_not_running).
+```
+
+- [ ] **Step 3: Document it**
+
+Add a short "Talk to your AI agent (MCP)" section to `README.md` after the engines section, covering: enable the tray toggle, run the shown `claude mcp add` command, and the two tools (`listen`, `transcribe` with `format=json|srt|vtt`). Mirror a brief note in `wisprlitevercel/docs/index.html`.
+
+Example README block:
+
+```markdown
+## Talk to your AI agent (MCP)
+
+PipeVoice can act as a local MCP server so agents (Claude Code, Cursor) can use your
+voice — no API key, runs on your machine:
+
+- **`listen`** — the agent asks, you answer by voice, it gets the text back.
+- **`transcribe`** — hand it an audio/video file, get text + word/segment timestamps
+  (or `format: "srt"`/`"vtt"` for ready-made captions).
+
+Enable **Agent MCP** in the tray menu, then register it once (the app shows the exact
+command):
+
+    claude mcp add pipevoice -- python -m wisprlite --mcp     # from source
+    claude mcp add pipevoice -- "C:\…\Pipevoice.exe" --mcp    # installed build
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add wisprlite/tray.py README.md wisprlitevercel/docs/index.html
+git commit -m "feat(mcp): tray toggle + docs for the agent MCP"
+```
+
+---
+
+## Task 12: End-to-end verification on Windows + PyInstaller
+
+**Files:** none (verification + any fixes surfaced).
+
+- [ ] **Step 1: Run all pure-unit tests** (Linux or Windows):
+
+Run: `for f in tests/test_captions.py tests/test_vad.py tests/test_agent_bridge.py tests/test_transcribe_shaper.py tests/test_bridge_transcribe.py tests/test_mcp_send.py; do python3 $f || echo "FAIL $f"; done`
+Expected: six `OK` lines, no `FAIL`.
+
+- [ ] **Step 2: `transcribe` end-to-end (Windows, real model):**
+
+```
+[ ] Enable Agent MCP. In Claude Code call pipevoice.transcribe on a short .wav -> JSON with text + segments[].words[].start/end.
+[ ] Call with format:"srt" -> a valid SRT string in `captions`.
+[ ] Call on an .mp4 video -> audio decodes (PyAV) and returns timed text. If it errors, install/confirm ffmpeg and retry; capture the exact error.
+[ ] Call on a missing path -> {status:"error", error:"file not found: …"}.
+[ ] First call downloads the model (~150 MB) once; second call is warm/fast.
+```
+
+- [ ] **Step 3: PyInstaller build check (Windows):**
+
+```
+[ ] build_exe.bat succeeds; note the exe size delta vs the previous build (expect a few MB from the mcp SDK).
+[ ] Pipevoice.exe --mcp starts a stdio server (claude mcp add with the exe path; tools list shows listen + transcribe).
+[ ] If `mcp` isn't bundled, add it to the PyInstaller hiddenimports/spec and rebuild.
+```
+
+- [ ] **Step 4: Bump version + finish the branch**
+
+```
+[ ] Bump wisprlite/__init__.py __version__ (e.g. 2.26.0).
+[ ] git commit -am "chore: bump to 2.26.0 (agent MCP)"
+```
+
+Then use **superpowers:finishing-a-development-branch** to open the PR.
+
+---
+
+## Self-review notes (author)
+
+- **Spec coverage:** `listen` PTT (T9) + hands-free (T10); `transcribe` json/srt/vtt (T4/T6); Approach-B bridge (T3) + stdio shim (T8); config (T5); tray enable (T6/T11); `app_not_running`/`busy`/`timeout`/`error` statuses (T8/T9/T6); video decode + ffmpeg fallback (T12 verification); known ceilings (loopback no-auth, exe size) documented in spec. ✔
+- **No-auth token / loopback** is intentional per spec — not a gap.
+- **`clean` param** from the spec's `listen` table is intentionally dropped from the v1 tool schema (cleanup follows the user's Flow-mode setting); noted here so it's a conscious cut, not an omission.
+- **Type consistency:** response dicts use `status`/`text`/`segments`/`captions`/`error` consistently across `mcp_shim`, `agent_bridge`, and the `app` handlers; `_segments_to_dicts` shape matches what `captions.to_srt/to_vtt` consume (`start`/`end`/`text`).
+- **Ordering:** `_agent_dispatch` (T6) references `on_agent_listen` (T9); safe because no `listen` call occurs until the full feature lands, and T6/T7 exercise only `transcribe`.
+```

--- a/docs/superpowers/specs/2026-06-22-pipevoice-agent-mcp-listen-design.md
+++ b/docs/superpowers/specs/2026-06-22-pipevoice-agent-mcp-listen-design.md
@@ -1,0 +1,184 @@
+# PipeVoice Agent MCP — `listen` tool (design)
+
+_Date: 2026-06-22 · App version at design time: 2.25.0 · Status: approved design, pre-plan_
+
+## Goal
+
+Let an AI agent (Claude Code, Cursor, Cline) ask PipeVoice for a **spoken answer
+on demand**: the agent calls a `listen` tool, PipeVoice captures the user's voice
+through its existing pipeline, and returns the transcript to the agent. This is
+the on-brand inverse of Voicebox's agent-voice *output* — PipeVoice is the voice
+*input* tool, so it exposes voice input as a service.
+
+Hands-free coding flows: the agent asks a question, the user answers by voice,
+the answer comes back as text — no keyboard.
+
+## Non-goals (explicit)
+
+- No `transcribe`-a-file tool (decided: listen-only for v1).
+- No TTS / agent-voice *output* (that's Voicebox's game; off-brand for us).
+- No cloud relay — loopback only.
+- The two local-Whisper wins (Turbo model option + GPU/device toggle) ship as a
+  **separate small PR**, not part of this feature.
+
+## Decisions locked during brainstorming
+
+1. **Use case:** Listen on demand (live mic), not file transcription.
+2. **Interaction:** Push-to-talk is the default; hands-free (auto-stop on silence)
+   is a configurable mode.
+3. **Architecture:** **Approach B** — a lightweight stdio MCP server spawned by the
+   client on demand, plus a tiny stdlib loopback bridge in the resident tray app.
+   Chosen over an in-app HTTP MCP server to keep the **resident footprint near-zero**
+   (no web framework loaded at rest — "light tray app" is our positioning) and to
+   maximize client support (stdio is the most broadly supported MCP transport).
+
+## Architecture (Approach B)
+
+```
+Claude Code ──spawns──▶ `Pipevoice.exe --mcp`  (ephemeral stdio MCP server, the "shim")
+                              │  tool: pipevoice.listen
+                              │  loopback TCP (JSON line protocol)
+                              ▼
+                    resident PipeVoice tray app
+                    ├─ control listener thread (stdlib socket, 127.0.0.1:<mcp_port>)
+                    ├─ existing recorder / overlay / engine / cleanup  ◀── reused
+                    └─ _busy lock                                       ◀── reused
+```
+
+Two processes:
+
+- **The shim** (`Pipevoice.exe --mcp`, or `python -m wisprlite --mcp` from source):
+  a stdio MCP server (official `mcp` Python SDK, stdio transport — no
+  uvicorn/starlette). Registers one tool, `listen`. On a call it opens a loopback
+  TCP connection to the resident app, forwards the request, waits, returns the
+  response. If the app isn't running (connection refused) it returns a clear
+  error so the agent isn't left hanging.
+- **The resident app** gains one new always-on piece: a **control listener thread**
+  bound to `127.0.0.1:<mcp_port>` using only the stdlib `socket` module. It accepts
+  a connection, reads one JSON request line, invokes an app callback, and writes one
+  JSON response line. No web framework. Started/stopped by a tray toggle.
+
+### Why the shim runs as the exe
+
+For a frozen install there is no Python/venv for the client to run `python -m
+wisprlite`. The client is therefore configured to spawn the installed exe with a
+`--mcp` flag, which runs the shim. From source, `python -m wisprlite --mcp` is the
+equivalent. Registration in Claude Code (shown to the user once when they enable
+the feature):
+
+```
+claude mcp add pipevoice -- "<path>\Pipevoice.exe" --mcp     # frozen install
+claude mcp add pipevoice -- python -m wisprlite --mcp        # from source
+```
+
+## The tool: `pipevoice.listen`
+
+| Param | Type | Default | Meaning |
+|---|---|---|---|
+| `prompt` | string? | — | Optional context shown in the overlay so the user knows what to answer ("your agent asks: …"). |
+| `timeout_seconds` | int? | 45 | Hard cap on waiting for the user. |
+| `mode` | enum? | config default (`push_to_talk`) | `push_to_talk` or `hands_free`. |
+| `clean` | bool? | = user's Flow-mode setting | Apply LLM cleanup to the returned text. |
+
+Returns:
+
+```json
+{ "status": "ok" | "timeout" | "busy" | "cancelled" | "app_not_running", "text": "…" }
+```
+
+- `ok` — transcript captured (in `text`).
+- `timeout` — user did not speak within `timeout_seconds`.
+- `busy` — the user is mid-dictation (the `_busy` lock is held); returned immediately, no queueing.
+- `cancelled` — user dismissed the prompt (Esc / cancel).
+- `app_not_running` — shim could not reach the resident app.
+
+## Data flow
+
+1. Agent calls `listen` → shim forwards `{op:"listen", prompt, timeout, mode, clean}`
+   over loopback to the resident app's control listener.
+2. Control listener invokes `App.on_agent_listen(...)`, which:
+   - If `_busy` is held → return `{status:"busy"}` immediately.
+   - Else create a `concurrent.futures.Future`, set a `_pending_agent_listen`
+     routing flag, and arm the capture for the requested mode.
+3. Capture (reuses the existing path; see `app.py` references below):
+   - **push_to_talk:** overlay shows `🎙 your agent is listening` + `prompt`; the
+     next hotkey hold→release records and transcribes exactly as a normal dictation.
+     If no hotkey press within `timeout_seconds` → resolve `{status:"timeout"}`,
+     clear the armed state and overlay.
+   - **hands_free:** start the recorder immediately; run VAD endpointing (below);
+     stop on trailing silence or at `timeout_seconds`; the hotkey acts as a manual
+     stop/cancel.
+4. Transcription + optional cleanup reuse the existing engine `finish()` and
+   `cleanup.py`. Because `_pending_agent_listen` is set, the result is **routed to
+   the Future and returned — not typed, and not written to history** (v1; history
+   opt-in could come later).
+5. Control listener writes the JSON response → shim → agent.
+
+## New / changed code (everything else is reused)
+
+- **NEW `wisprlite/agent_bridge.py`** — the control listener thread + JSON line
+  protocol (encode/decode request/response). Stdlib `socket` + `json` only.
+  Lazy-imported; if it fails to bind, the feature logs and stays off (follows the
+  app's existing fault-tolerant-import pattern).
+- **NEW shim entry** — `wisprlite/__main__.py` (or a small `mcp_shim.py`) handles
+  the `--mcp` flag: builds an `mcp` stdio server exposing `listen`, which round-trips
+  to the resident app over loopback. `mcp` SDK imported **only** in this path.
+- **CHANGED `app.py`** — add `on_agent_listen(...)` and a `_pending_agent_listen`
+  routing flag honored in `_finish()` (route text to the Future instead of
+  typing/history). Start/stop the control listener from the tray toggle. Reuses
+  `_on_start` (`app.py:113`), `_on_stop` (`app.py:140`), `_finish` (`app.py:149`),
+  `_get_engine` (`app.py:91`), and the `_busy` lock.
+- **NEW `wisprlite/vad.py`** (hands-free only) — trailing-silence endpointer over
+  the audio frames. Reuses the per-frame RMS level the overlay VU meter already
+  computes (`audio.py` / overlay); no new DSP. Pure decision logic: "speech started,
+  then level < threshold for `hands_free_silence_ms` → stop."
+- **CHANGED `config.py`** — add `mcp_enabled: bool=False`, `mcp_port: int=49518`,
+  `mcp_default_mode: str="push_to_talk"`, `hands_free_silence_ms: int=800`. Add the
+  engine/`_watch_config` reload list where relevant.
+- **CHANGED `settings.py`** — tray toggle "Agent mic (MCP)" (on/off + show the
+  `claude mcp add` command); settings fields for port, default mode, silence threshold.
+
+Audio format is unchanged: 16 kHz mono, float32 / 16-bit PCM (`audio.py:16`).
+Port `49518` is distinct from the single-instance lock on `49517` (`app.py:475`).
+
+## Concurrency & safety
+
+- One in-flight `listen` at a time, gated by the existing `_busy` lock; concurrent
+  calls get `{status:"busy"}` (no queue).
+- Control listener binds `127.0.0.1` only.
+- The Future bridges the listener thread (waits) and the app/Tk thread (captures);
+  the listener uses a bounded `Future.result(timeout=timeout_seconds + margin)` so a
+  wedged capture can't hang the socket forever.
+
+## Known ceilings (deliberate, documented)
+
+- **No auth token in v1** — any local process can connect to the loopback control
+  port and call `listen` (same posture as Voicebox's loopback MCP). Upgrade path: a
+  shared token in `config.json` that the shim must present. *(// ponytail: loopback +
+  opt-in toggle is the v1 trust boundary; add a token if a real threat appears.)*
+- **No request queueing** — busy = rejected, not queued.
+- **stdio only** — an in-app HTTP MCP transport (Approach A) can be added later for
+  URL-based clients; not built now.
+- **Exe size** — bundling the stdio `mcp` SDK (mcp + pydantic + anyio; *not*
+  uvicorn/starlette) grows the installer by a few MB. The **resident runtime**
+  footprint is unchanged (the SDK loads only in the `--mcp` shim process). If the
+  exe bump ever matters, the fallback is hand-rolling the single-tool MCP stdio
+  JSON-RPC (~150 lines, no SDK) — documented alternative, not the default.
+
+## Testing (one runnable check per non-trivial unit)
+
+- **`vad.py`** — feed synthetic frame levels (speech → silence) and assert the
+  endpointer fires after `hands_free_silence_ms`, and does *not* fire on a leading
+  pause before speech. Assert-based `demo()`/`test_vad.py`.
+- **`agent_bridge.py`** — round-trip the JSON line protocol over a real loopback
+  socket: send a `listen` request to a stub callback, assert the response shape and
+  the `busy`/`timeout` status paths. One small `test_agent_bridge.py`.
+- PTT/hands-free wiring in `app.py` is verified manually on Windows (no test
+  harness exists in the repo; consistent with the project's no-test-suite norm).
+
+## Implementation note for the plan
+
+When wiring the `mcp` SDK in the shim, consult the MCP tool-definition reference
+(and the `claude-api` skill if any Anthropic specifics arise) so the tool schema
+and stdio handshake are correct — do not hand-write the protocol unless we hit the
+exe-size ceiling above.

--- a/docs/superpowers/specs/2026-06-22-pipevoice-agent-mcp-listen-design.md
+++ b/docs/superpowers/specs/2026-06-22-pipevoice-agent-mcp-listen-design.md
@@ -1,184 +1,236 @@
-# PipeVoice Agent MCP — `listen` tool (design)
+# PipeVoice Agent MCP — `listen` + `transcribe` (design)
 
 _Date: 2026-06-22 · App version at design time: 2.25.0 · Status: approved design, pre-plan_
 
 ## Goal
 
-Let an AI agent (Claude Code, Cursor, Cline) ask PipeVoice for a **spoken answer
-on demand**: the agent calls a `listen` tool, PipeVoice captures the user's voice
-through its existing pipeline, and returns the transcript to the agent. This is
-the on-brand inverse of Voicebox's agent-voice *output* — PipeVoice is the voice
-*input* tool, so it exposes voice input as a service.
+Give AI agents (Claude Code, Cursor, Cline) two voice capabilities from PipeVoice,
+locally and without an API key:
 
-Hands-free coding flows: the agent asks a question, the user answers by voice,
-the answer comes back as text — no keyboard.
+1. **`listen`** — ask the user for a **spoken answer on demand**. The agent calls
+   the tool, PipeVoice captures the user's voice through its existing pipeline, and
+   returns the transcript. The on-brand inverse of Voicebox's agent-voice *output*.
+2. **`transcribe`** — turn an **existing audio or video file into timed text** using
+   local whisper. Returns plain text plus **word/segment-level timestamps**, with an
+   optional `format` param for ready-made SRT/VTT captions. This makes PipeVoice the
+   **local, free, offline transcription service any agent on the machine can call** —
+   the exact gap behind "no transcriber or real API key on this box" (e.g. an AI
+   video-editing flow that needs caption timing / cut points).
+
+Positioning: Voicebox gives agents *a voice to speak*; PipeVoice gives agents
+*ears and a timed transcript*.
 
 ## Non-goals (explicit)
 
-- No `transcribe`-a-file tool (decided: listen-only for v1).
 - No TTS / agent-voice *output* (that's Voicebox's game; off-brand for us).
-- No cloud relay — loopback only.
-- The two local-Whisper wins (Turbo model option + GPU/device toggle) ship as a
-  **separate small PR**, not part of this feature.
+- No cloud relay — loopback only. `transcribe` uses **local** whisper specifically
+  (it's the only engine that yields word timestamps with no key), regardless of the
+  user's current dictation engine.
+- The two local-Whisper *dictation* wins (Turbo model option + GPU/device toggle)
+  ship as a **separate small PR**, not part of this feature. (The GPU/device toggle
+  does, however, benefit `transcribe` once it lands.)
 
 ## Decisions locked during brainstorming
 
-1. **Use case:** Listen on demand (live mic), not file transcription.
-2. **Interaction:** Push-to-talk is the default; hands-free (auto-stop on silence)
-   is a configurable mode.
-3. **Architecture:** **Approach B** — a lightweight stdio MCP server spawned by the
+1. **Capabilities:** Two MCP tools — `listen` (live mic) **and** `transcribe`
+   (file → timed text). (Originally listen-only; `transcribe` added after the
+   video-captioning use case surfaced.)
+2. **`listen` interaction:** Push-to-talk is the default; hands-free (auto-stop on
+   silence) is a configurable mode.
+3. **`transcribe` output:** structured JSON (text + segment/word timestamps) **plus**
+   an optional `format` param (`json` | `srt` | `vtt`) so callers can get drop-in
+   caption files from the same tool.
+4. **Architecture:** **Approach B** — a lightweight stdio MCP server spawned by the
    client on demand, plus a tiny stdlib loopback bridge in the resident tray app.
    Chosen over an in-app HTTP MCP server to keep the **resident footprint near-zero**
-   (no web framework loaded at rest — "light tray app" is our positioning) and to
-   maximize client support (stdio is the most broadly supported MCP transport).
+   (no web framework at rest — "light tray app" is our positioning) and to maximize
+   client support (stdio is the most broadly supported MCP transport). Both tools are
+   served by the resident app (it owns the mic for `listen` and keeps the whisper
+   model warm for `transcribe`).
 
 ## Architecture (Approach B)
 
 ```
 Claude Code ──spawns──▶ `Pipevoice.exe --mcp`  (ephemeral stdio MCP server, the "shim")
-                              │  tool: pipevoice.listen
-                              │  loopback TCP (JSON line protocol)
+                              │  tools: pipevoice.listen, pipevoice.transcribe
+                              │  loopback TCP (JSON line protocol: op=listen|transcribe)
                               ▼
                     resident PipeVoice tray app
                     ├─ control listener thread (stdlib socket, 127.0.0.1:<mcp_port>)
-                    ├─ existing recorder / overlay / engine / cleanup  ◀── reused
-                    └─ _busy lock                                       ◀── reused
+                    ├─ existing recorder / overlay / dictation engine / cleanup  ◀── reused (listen)
+                    ├─ dedicated local-whisper model (warm, word_timestamps)     ◀── transcribe
+                    └─ _busy lock                                                 ◀── reused
 ```
-
-Two processes:
 
 - **The shim** (`Pipevoice.exe --mcp`, or `python -m wisprlite --mcp` from source):
   a stdio MCP server (official `mcp` Python SDK, stdio transport — no
-  uvicorn/starlette). Registers one tool, `listen`. On a call it opens a loopback
-  TCP connection to the resident app, forwards the request, waits, returns the
-  response. If the app isn't running (connection refused) it returns a clear
-  error so the agent isn't left hanging.
-- **The resident app** gains one new always-on piece: a **control listener thread**
-  bound to `127.0.0.1:<mcp_port>` using only the stdlib `socket` module. It accepts
-  a connection, reads one JSON request line, invokes an app callback, and writes one
-  JSON response line. No web framework. Started/stopped by a tray toggle.
+  uvicorn/starlette). Registers `listen` and `transcribe`. Each call opens a loopback
+  TCP connection to the resident app, forwards a JSON request, waits, returns the
+  response. If the app isn't running (connection refused) it returns a clear error.
+- **The resident app** gains a **control listener thread** bound to
+  `127.0.0.1:<mcp_port>` using only the stdlib `socket` module — accepts a connection,
+  reads one JSON request line, dispatches by `op`, writes one JSON response line.
+  No web framework. Started/stopped by a tray toggle.
 
 ### Why the shim runs as the exe
 
 For a frozen install there is no Python/venv for the client to run `python -m
-wisprlite`. The client is therefore configured to spawn the installed exe with a
-`--mcp` flag, which runs the shim. From source, `python -m wisprlite --mcp` is the
-equivalent. Registration in Claude Code (shown to the user once when they enable
-the feature):
+wisprlite`. The client spawns the installed exe with `--mcp`. Registration shown to
+the user once when they enable the feature:
 
 ```
 claude mcp add pipevoice -- "<path>\Pipevoice.exe" --mcp     # frozen install
 claude mcp add pipevoice -- python -m wisprlite --mcp        # from source
 ```
 
-## The tool: `pipevoice.listen`
+## Tool: `pipevoice.listen`
 
 | Param | Type | Default | Meaning |
 |---|---|---|---|
-| `prompt` | string? | — | Optional context shown in the overlay so the user knows what to answer ("your agent asks: …"). |
+| `prompt` | string? | — | Optional context shown in the overlay ("your agent asks: …"). |
 | `timeout_seconds` | int? | 45 | Hard cap on waiting for the user. |
 | `mode` | enum? | config default (`push_to_talk`) | `push_to_talk` or `hands_free`. |
 | `clean` | bool? | = user's Flow-mode setting | Apply LLM cleanup to the returned text. |
 
-Returns:
+Returns: `{ "status": "ok"|"timeout"|"busy"|"cancelled"|"app_not_running", "text": "…" }`
 
-```json
-{ "status": "ok" | "timeout" | "busy" | "cancelled" | "app_not_running", "text": "…" }
+- `ok` — transcript in `text`. `timeout` — user didn't speak in time. `busy` —
+  user mid-dictation (the `_busy` lock is held), returned immediately, no queueing.
+  `cancelled` — user dismissed (Esc). `app_not_running` — shim couldn't reach the app.
+
+**Flow:** shim → bridge `{op:"listen",…}` → `App.on_agent_listen(...)`: if `_busy`,
+return busy; else create a `Future`, set `_pending_agent_listen`, arm capture. PTT:
+overlay `🎙 your agent is listening` + `prompt`; next hotkey hold→release records &
+transcribes exactly like a normal dictation; no press within `timeout_seconds` →
+`timeout`. Hands-free: start recorder immediately, stop on trailing silence (VAD) or
+at `timeout_seconds`; hotkey = manual stop/cancel. Transcription + optional cleanup
+reuse the existing engine `finish()` and `cleanup.py`; because `_pending_agent_listen`
+is set, the result is **returned to the Future — not typed, not written to history**
+(v1). Then bridge writes the response.
+
+## Tool: `pipevoice.transcribe`
+
+| Param | Type | Default | Meaning |
+|---|---|---|---|
+| `path` | string | — (required) | Absolute path to a local audio **or video** file. |
+| `format` | enum? | `json` | `json` (timestamps), `srt`, or `vtt`. |
+| `language` | string? | auto | ISO code to force the language; blank = auto-detect. |
+| `model_size` | string? | config `transcribe_model_size` | Override whisper model size for this call. |
+
+Returns (always includes `text`; the timing payload depends on `format`):
+
+```jsonc
+// format = "json"
+{
+  "status": "ok" | "error" | "app_not_running",
+  "text": "full transcript",
+  "language": "en",
+  "duration": 73.4,
+  "segments": [
+    { "start": 0.0, "end": 3.2, "text": "…",
+      "words": [ { "start": 0.0, "end": 0.4, "word": "Hello" }, … ] }
+  ],
+  "error": "…"            // only when status=error (e.g. file not found / decode failed)
+}
+// format = "srt" | "vtt"
+{ "status": "ok", "text": "…", "language": "en", "duration": 73.4, "captions": "<SRT or VTT string>" }
 ```
 
-- `ok` — transcript captured (in `text`).
-- `timeout` — user did not speak within `timeout_seconds`.
-- `busy` — the user is mid-dictation (the `_busy` lock is held); returned immediately, no queueing.
-- `cancelled` — user dismissed the prompt (Esc / cancel).
-- `app_not_running` — shim could not reach the resident app.
+**Flow:** shim → bridge `{op:"transcribe", path, format, language, model_size}` →
+`App.on_agent_transcribe(...)` runs on a worker thread. It uses a **dedicated local
+faster-whisper model** (lazy-created and kept warm), independent of the user's
+dictation engine, calling `model.transcribe(path, word_timestamps=True, language=…)`.
+Segments+words are collected into the JSON shape; if `format` is `srt`/`vtt`, the
+captions string is produced by `captions.py`. Errors (missing file, decode failure)
+return `{status:"error", error:…}`.
 
-## Data flow
+**Video input:** faster-whisper decodes audio from many container formats via its
+bundled PyAV/ffmpeg. If decoding a video path fails, fall back to extracting audio
+with a bundled/located `ffmpeg` to a temp WAV, then transcribe that. (See ceilings.)
 
-1. Agent calls `listen` → shim forwards `{op:"listen", prompt, timeout, mode, clean}`
-   over loopback to the resident app's control listener.
-2. Control listener invokes `App.on_agent_listen(...)`, which:
-   - If `_busy` is held → return `{status:"busy"}` immediately.
-   - Else create a `concurrent.futures.Future`, set a `_pending_agent_listen`
-     routing flag, and arm the capture for the requested mode.
-3. Capture (reuses the existing path; see `app.py` references below):
-   - **push_to_talk:** overlay shows `🎙 your agent is listening` + `prompt`; the
-     next hotkey hold→release records and transcribes exactly as a normal dictation.
-     If no hotkey press within `timeout_seconds` → resolve `{status:"timeout"}`,
-     clear the armed state and overlay.
-   - **hands_free:** start the recorder immediately; run VAD endpointing (below);
-     stop on trailing silence or at `timeout_seconds`; the hotkey acts as a manual
-     stop/cancel.
-4. Transcription + optional cleanup reuse the existing engine `finish()` and
-   `cleanup.py`. Because `_pending_agent_listen` is set, the result is **routed to
-   the Future and returned — not typed, and not written to history** (v1; history
-   opt-in could come later).
-5. Control listener writes the JSON response → shim → agent.
+**Concurrency:** `transcribe` does not touch the mic, so it does **not** take the
+`_busy` lock; it runs on its own worker. Only one `transcribe` at a time (a dedicated
+`threading.Lock` around the shared transcribe model) to avoid double-loading / GPU
+contention; a second concurrent call waits or returns busy (plan picks one — default:
+serialize behind the lock with the request's own timeout).
 
 ## New / changed code (everything else is reused)
 
-- **NEW `wisprlite/agent_bridge.py`** — the control listener thread + JSON line
-  protocol (encode/decode request/response). Stdlib `socket` + `json` only.
-  Lazy-imported; if it fails to bind, the feature logs and stays off (follows the
-  app's existing fault-tolerant-import pattern).
-- **NEW shim entry** — `wisprlite/__main__.py` (or a small `mcp_shim.py`) handles
-  the `--mcp` flag: builds an `mcp` stdio server exposing `listen`, which round-trips
-  to the resident app over loopback. `mcp` SDK imported **only** in this path.
-- **CHANGED `app.py`** — add `on_agent_listen(...)` and a `_pending_agent_listen`
-  routing flag honored in `_finish()` (route text to the Future instead of
-  typing/history). Start/stop the control listener from the tray toggle. Reuses
-  `_on_start` (`app.py:113`), `_on_stop` (`app.py:140`), `_finish` (`app.py:149`),
-  `_get_engine` (`app.py:91`), and the `_busy` lock.
-- **NEW `wisprlite/vad.py`** (hands-free only) — trailing-silence endpointer over
-  the audio frames. Reuses the per-frame RMS level the overlay VU meter already
-  computes (`audio.py` / overlay); no new DSP. Pure decision logic: "speech started,
-  then level < threshold for `hands_free_silence_ms` → stop."
+- **NEW `wisprlite/agent_bridge.py`** — control listener thread + JSON line protocol
+  (encode/decode, dispatch by `op`). Stdlib `socket` + `json` only. Lazy-imported;
+  if it can't bind, log and stay off (matches the app's fault-tolerant-import pattern).
+- **NEW `wisprlite/captions.py`** — pure `to_srt(segments)` / `to_vtt(segments)` and a
+  `format_timestamp(seconds, vtt: bool)` helper. No deps.
+- **NEW `wisprlite/vad.py`** — trailing-silence endpointer for `listen` hands-free
+  mode. Pure decision logic over the per-frame RMS level the recorder already exposes
+  (`Recorder.level`, `audio.py:24`). `SilenceEndpointer(threshold, silence_ms,
+  block_ms).feed(level) -> bool`.
+- **NEW shim** — `wisprlite/mcp_shim.py` + a `--mcp` branch in `wisprlite/__main__.py`.
+  Builds an `mcp` stdio server exposing `listen` + `transcribe`, each forwarding to the
+  resident app over loopback via a small `_send(op, **kw)` helper. `mcp` SDK imported
+  **only** in this path.
+- **NEW transcribe model accessor** — a `transcribe_file(path, *, language, model_size,
+  want_words=True)` function returning `(text, language, duration, segments)`. Lives
+  next to the local engine (e.g. `engines/local_engine.py` adds a module-level
+  `transcribe_file(...)` that owns a cached `WhisperModel` with `word_timestamps`),
+  separate from the dictation `Session` so it can run while the dictation engine is
+  something else.
+- **CHANGED `app.py`** — add `on_agent_listen(...)` (+ `_pending_agent_listen` routing
+  honored in `_finish()`), `on_agent_transcribe(...)`, and start/stop the control
+  listener from the tray toggle. Reuses `_on_start` (`app.py:113`), `_on_stop`
+  (`app.py:140`), `_finish` (`app.py:149`), `_get_engine` (`app.py:91`), the `_busy`
+  lock, the `Recorder` (`audio.py`), and the overlay.
 - **CHANGED `config.py`** — add `mcp_enabled: bool=False`, `mcp_port: int=49518`,
-  `mcp_default_mode: str="push_to_talk"`, `hands_free_silence_ms: int=800`. Add the
-  engine/`_watch_config` reload list where relevant.
-- **CHANGED `settings.py`** — tray toggle "Agent mic (MCP)" (on/off + show the
-  `claude mcp add` command); settings fields for port, default mode, silence threshold.
+  `mcp_default_mode: str="push_to_talk"`, `hands_free_silence_ms: int=800`,
+  `transcribe_model_size: str=""` (blank = reuse `local_model_size`).
+- **CHANGED `settings.py`** — tray toggle "Agent MCP (listen + transcribe)" (on/off +
+  show the `claude mcp add` command); settings fields for port, default listen mode,
+  hands-free silence threshold, transcribe model size.
 
-Audio format is unchanged: 16 kHz mono, float32 / 16-bit PCM (`audio.py:16`).
-Port `49518` is distinct from the single-instance lock on `49517` (`app.py:475`).
-
-## Concurrency & safety
-
-- One in-flight `listen` at a time, gated by the existing `_busy` lock; concurrent
-  calls get `{status:"busy"}` (no queue).
-- Control listener binds `127.0.0.1` only.
-- The Future bridges the listener thread (waits) and the app/Tk thread (captures);
-  the listener uses a bounded `Future.result(timeout=timeout_seconds + margin)` so a
-  wedged capture can't hang the socket forever.
+Audio format unchanged: 16 kHz mono float32 / 16-bit PCM (`audio.py:16`). Control port
+`49518` is distinct from the single-instance lock on `49517` (`app.py:475`).
 
 ## Known ceilings (deliberate, documented)
 
-- **No auth token in v1** — any local process can connect to the loopback control
-  port and call `listen` (same posture as Voicebox's loopback MCP). Upgrade path: a
-  shared token in `config.json` that the shim must present. *(// ponytail: loopback +
+- **No auth token in v1** — any local process can hit the loopback control port and
+  call `listen`/`transcribe` (same posture as Voicebox's loopback MCP). Upgrade path:
+  a shared token in `config.json` the shim must present. *(// ponytail: loopback +
   opt-in toggle is the v1 trust boundary; add a token if a real threat appears.)*
-- **No request queueing** — busy = rejected, not queued.
-- **stdio only** — an in-app HTTP MCP transport (Approach A) can be added later for
-  URL-based clients; not built now.
+- **`transcribe` requires the resident app running** (warm model, light shim). If the
+  tray app is off, `transcribe` returns `app_not_running`. (Acceptable: the feature is
+  an opt-in toggle in the running app.)
+- **Video decode depends on PyAV/ffmpeg** — faster-whisper's bundled PyAV usually
+  handles video audio; the ffmpeg fallback needs an `ffmpeg` binary available. If
+  neither can decode, return `{status:"error"}` with a clear message.
+- **No request queueing for `listen`** — busy = rejected. `transcribe` serializes
+  behind a model lock.
+- **stdio only** — an in-app HTTP MCP transport (Approach A) can be added later; not now.
 - **Exe size** — bundling the stdio `mcp` SDK (mcp + pydantic + anyio; *not*
-  uvicorn/starlette) grows the installer by a few MB. The **resident runtime**
-  footprint is unchanged (the SDK loads only in the `--mcp` shim process). If the
-  exe bump ever matters, the fallback is hand-rolling the single-tool MCP stdio
-  JSON-RPC (~150 lines, no SDK) — documented alternative, not the default.
+  uvicorn/starlette) grows the installer a few MB. Resident runtime footprint is
+  unchanged (SDK loads only in the `--mcp` shim). Fallback if it ever bites: hand-roll
+  the small MCP stdio JSON-RPC (~150 lines, no SDK).
 
-## Testing (one runnable check per non-trivial unit)
+## Testing (one runnable check per non-trivial unit; assert-based, no framework — the
+repo has no pytest config, so tests run via `python <file>` with `assert`)
 
-- **`vad.py`** — feed synthetic frame levels (speech → silence) and assert the
-  endpointer fires after `hands_free_silence_ms`, and does *not* fire on a leading
-  pause before speech. Assert-based `demo()`/`test_vad.py`.
-- **`agent_bridge.py`** — round-trip the JSON line protocol over a real loopback
-  socket: send a `listen` request to a stub callback, assert the response shape and
-  the `busy`/`timeout` status paths. One small `test_agent_bridge.py`.
-- PTT/hands-free wiring in `app.py` is verified manually on Windows (no test
-  harness exists in the repo; consistent with the project's no-test-suite norm).
+- **`captions.py`** — given fixed segments, assert `to_srt` / `to_vtt` produce exact
+  expected strings (index numbering, `,`/`.` ms separators, `WEBVTT` header, 00:00:00
+  formatting). Pure, fully testable on Linux.
+- **`vad.py`** — feed synthetic level sequences: leading silence does NOT trigger;
+  speech-then-silence triggers after `silence_ms`; sustained speech never triggers.
+- **`agent_bridge.py`** — start the listener on an ephemeral port with a stub
+  dispatcher, connect a client, round-trip a `listen` and a `transcribe` request;
+  assert response shapes and malformed-input handling.
+- **`mcp_shim.py`** — unit-test the `_send(op, **kw)` forwarding against the Task-2
+  listener with a stub dispatcher (no MCP SDK needed for this part).
+- **App wiring (`on_agent_listen`/`on_agent_transcribe`, PTT/hands-free, model load)**
+  and the end-to-end `claude mcp add` handshake are **verified manually on Windows**
+  (no test harness for the GUI/mic/Tk layer; consistent with the repo's no-test norm).
+  Each such task carries an explicit manual-verification checklist.
 
 ## Implementation note for the plan
 
-When wiring the `mcp` SDK in the shim, consult the MCP tool-definition reference
-(and the `claude-api` skill if any Anthropic specifics arise) so the tool schema
-and stdio handshake are correct — do not hand-write the protocol unless we hit the
-exe-size ceiling above.
+When wiring the `mcp` SDK in the shim, consult the MCP tool-definition reference (and
+the `claude-api` skill if any Anthropic specifics arise) so the tool schemas and stdio
+handshake are correct — do not hand-write the protocol unless we hit the exe-size
+ceiling above.

--- a/launch.py
+++ b/launch.py
@@ -13,6 +13,8 @@ elif "--about" in sys.argv:
     from wisprlite.about import main
 elif "--profiles" in sys.argv:
     from wisprlite.profiles import main
+elif "--mcp" in sys.argv:
+    from wisprlite.mcp_shim import main
 else:
     from wisprlite.app import main
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ Pillow>=10.0          # renders the tray icon
 pyperclip>=1.8        # "Paste" output mode
 
 # tkinter (the overlay HUD) ships with the standard Windows Python installer.
+mcp>=1.2  # MCP SDK — only imported by the --mcp stdio shim

--- a/tests/test_agent_bridge.py
+++ b/tests/test_agent_bridge.py
@@ -1,0 +1,38 @@
+import sys, pathlib, time
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent))
+from wisprlite import agent_bridge
+
+def test_roundtrip_and_dispatch():
+    seen = {}
+    def dispatch(req):
+        seen["req"] = req
+        if req["op"] == "ping":
+            return {"status": "ok", "text": "pong"}
+        return {"status": "error", "error": "unknown op"}
+
+    listener = agent_bridge.ControlListener(0, dispatch)
+    listener.start()
+    port = listener.port
+    try:
+        resp = agent_bridge.send_request(port, {"op": "ping", "x": 1}, timeout=5.0)
+        assert resp == {"status": "ok", "text": "pong"}, resp
+        assert seen["req"] == {"op": "ping", "x": 1}, seen
+        bad = agent_bridge.send_request(port, {"op": "nope"}, timeout=5.0)
+        assert bad["status"] == "error", bad
+    finally:
+        listener.stop()
+
+def test_dispatch_exception_becomes_error():
+    def dispatch(req):
+        raise ValueError("boom")
+    listener = agent_bridge.ControlListener(0, dispatch)
+    listener.start()
+    try:
+        resp = agent_bridge.send_request(listener.port, {"op": "x"}, timeout=5.0)
+        assert resp["status"] == "error" and "boom" in resp["error"], resp
+    finally:
+        listener.stop()
+
+if __name__ == "__main__":
+    test_roundtrip_and_dispatch(); test_dispatch_exception_becomes_error()
+    print("OK")

--- a/tests/test_bridge_transcribe.py
+++ b/tests/test_bridge_transcribe.py
@@ -1,0 +1,45 @@
+import sys, pathlib, tempfile, os
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent))
+from wisprlite import agent_bridge, captions
+
+def fake_transcribe_file(path, *, language=None, model_size="base.en", **kw):
+    return {"text": "hello world", "language": "en", "duration": 1.0,
+            "segments": [{"start": 0.0, "end": 1.0, "text": "hello world", "words": []}]}
+
+def make_dispatch():
+    def dispatch(req):
+        if req.get("op") != "transcribe":
+            return {"status": "error", "error": "unexpected op"}
+        path = req["path"]
+        if not os.path.exists(path):
+            return {"status": "error", "error": "file not found"}
+        r = fake_transcribe_file(path)
+        out = {"status": "ok", "text": r["text"], "language": r["language"], "duration": r["duration"]}
+        if req.get("format") == "srt":
+            out["captions"] = captions.to_srt(r["segments"])
+        else:
+            out["segments"] = r["segments"]
+        return out
+    return dispatch
+
+def test_transcribe_json_and_srt():
+    listener = agent_bridge.ControlListener(0, make_dispatch())
+    listener.start()
+    try:
+        with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tf:
+            p = tf.name
+        try:
+            j = agent_bridge.send_request(listener.port, {"op": "transcribe", "path": p, "format": "json"})
+            assert j["status"] == "ok" and j["text"] == "hello world" and "segments" in j, j
+            srt = agent_bridge.send_request(listener.port, {"op": "transcribe", "path": p, "format": "srt"})
+            assert srt["captions"].startswith("1\n00:00:00,000 --> 00:00:01,000"), srt
+            miss = agent_bridge.send_request(listener.port, {"op": "transcribe", "path": "/no/such", "format": "json"})
+            assert miss["status"] == "error", miss
+        finally:
+            os.unlink(p)
+    finally:
+        listener.stop()
+
+if __name__ == "__main__":
+    test_transcribe_json_and_srt()
+    print("OK")

--- a/tests/test_captions.py
+++ b/tests/test_captions.py
@@ -1,0 +1,31 @@
+import sys, pathlib
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent))
+from wisprlite import captions
+
+SEGS = [
+    {"start": 0.0, "end": 1.5, "text": "Hello there.", "words": []},
+    {"start": 1.5, "end": 3.25, "text": "General Kenobi.", "words": []},
+]
+
+def test_format_timestamp():
+    assert captions.format_timestamp(0) == "00:00:00,000"
+    assert captions.format_timestamp(3.25) == "00:00:03,250"
+    assert captions.format_timestamp(3661.5, vtt=True) == "01:01:01.500"
+    assert captions.format_timestamp(-2) == "00:00:00,000"
+
+def test_to_srt():
+    out = captions.to_srt(SEGS)
+    assert out == (
+        "1\n00:00:00,000 --> 00:00:01,500\nHello there.\n\n"
+        "2\n00:00:01,500 --> 00:00:03,250\nGeneral Kenobi.\n"
+    )
+
+def test_to_vtt():
+    out = captions.to_vtt(SEGS)
+    assert out.startswith("WEBVTT\n\n")
+    assert "00:00:00.000 --> 00:00:01.500\nHello there." in out
+    assert "00:00:01.500 --> 00:00:03.250\nGeneral Kenobi." in out
+
+if __name__ == "__main__":
+    test_format_timestamp(); test_to_srt(); test_to_vtt()
+    print("OK")

--- a/tests/test_mcp_send.py
+++ b/tests/test_mcp_send.py
@@ -1,0 +1,25 @@
+import sys, pathlib
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent))
+from wisprlite import agent_bridge, mcp_shim
+
+def test_send_forwards_to_bridge():
+    listener = agent_bridge.ControlListener(0, lambda req: {"status": "ok", "echo": req})
+    listener.start()
+    try:
+        import wisprlite.mcp_shim as shim
+        shim._port = lambda: listener.port
+        resp = shim._send("transcribe", path="/x", format="json")
+        assert resp["status"] == "ok", resp
+        assert resp["echo"] == {"op": "transcribe", "path": "/x", "format": "json"}, resp
+    finally:
+        listener.stop()
+
+def test_send_app_not_running():
+    import wisprlite.mcp_shim as shim
+    shim._port = lambda: 1
+    resp = shim._send("listen")
+    assert resp["status"] == "app_not_running", resp
+
+if __name__ == "__main__":
+    test_send_forwards_to_bridge(); test_send_app_not_running()
+    print("OK")

--- a/tests/test_transcribe_shaper.py
+++ b/tests/test_transcribe_shaper.py
@@ -1,0 +1,24 @@
+import sys, pathlib
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent))
+from wisprlite.engines.transcribe import _segments_to_dicts
+
+class W:
+    def __init__(self, start, end, word): self.start, self.end, self.word = start, end, word
+
+class S:
+    def __init__(self, start, end, text, words): self.start, self.end, self.text, self.words = start, end, text, words
+
+def test_shaping_with_words():
+    segs = [S(0.0, 1.234567, " Hello ", [W(0.0, 0.5, "Hello")])]
+    out = _segments_to_dicts(segs)
+    assert out == [{"start": 0.0, "end": 1.235, "text": "Hello",
+                    "words": [{"start": 0.0, "end": 0.5, "word": "Hello"}]}], out
+
+def test_shaping_without_words():
+    segs = [S(1.0, 2.0, "no words", None)]
+    out = _segments_to_dicts(segs)
+    assert out[0]["words"] == [], out
+
+if __name__ == "__main__":
+    test_shaping_with_words(); test_shaping_without_words()
+    print("OK")

--- a/tests/test_vad.py
+++ b/tests/test_vad.py
@@ -1,0 +1,30 @@
+import sys, pathlib
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent))
+from wisprlite.vad import SilenceEndpointer
+
+def feed_seq(ep, levels):
+    return [ep.feed(x) for x in levels]
+
+def test_leading_silence_never_triggers():
+    ep = SilenceEndpointer(threshold=0.02, silence_ms=200, block_ms=50)
+    assert not any(feed_seq(ep, [0.0] * 50))
+
+def test_speech_then_silence_triggers():
+    ep = SilenceEndpointer(threshold=0.02, silence_ms=200, block_ms=50)
+    results = feed_seq(ep, [0.1, 0.1, 0.0, 0.0, 0.0, 0.0])
+    assert results[-1] is True
+    assert results[:4] == [False, False, False, False]
+
+def test_sustained_speech_never_triggers():
+    ep = SilenceEndpointer(threshold=0.02, silence_ms=200, block_ms=50)
+    assert not any(feed_seq(ep, [0.1] * 50))
+
+def test_silence_resets_on_new_speech():
+    ep = SilenceEndpointer(threshold=0.02, silence_ms=200, block_ms=50)
+    feed_seq(ep, [0.1, 0.0, 0.0, 0.1])
+    assert ep.feed(0.0) is False
+
+if __name__ == "__main__":
+    test_leading_silence_never_triggers(); test_speech_then_silence_triggers()
+    test_sustained_speech_never_triggers(); test_silence_resets_on_new_speech()
+    print("OK")

--- a/wisprlite/__init__.py
+++ b/wisprlite/__init__.py
@@ -1,3 +1,3 @@
 """Pipevoice — push-to-talk voice typing for Windows."""
 
-__version__ = "2.25.0"
+__version__ = "2.26.0"

--- a/wisprlite/__main__.py
+++ b/wisprlite/__main__.py
@@ -8,6 +8,8 @@ elif "--about" in sys.argv:
     from .about import main
 elif "--profiles" in sys.argv:
     from .profiles import main
+elif "--mcp" in sys.argv:
+    from .mcp_shim import main
 else:
     from .app import main
 

--- a/wisprlite/agent_bridge.py
+++ b/wisprlite/agent_bridge.py
@@ -1,0 +1,90 @@
+"""Loopback control bridge: lets the `--mcp` shim drive the running tray app.
+
+Stdlib socket + newline-delimited JSON. Binds 127.0.0.1 only. Lazy/optional:
+if it can't bind, the caller logs and the feature stays off. This keeps the
+resident app's footprint to a single stdlib socket listener — no web framework.
+"""
+
+from __future__ import annotations
+
+import json
+import socket
+import threading
+from typing import Callable
+
+
+def encode(obj) -> bytes:
+    return (json.dumps(obj) + "\n").encode("utf-8")
+
+
+def decode(line: bytes) -> dict:
+    return json.loads(line.decode("utf-8"))
+
+
+def send_request(port: int, obj: dict, timeout: float = 120.0) -> dict:
+    """Client side (used by the shim). Connect, send one request, read one reply."""
+    with socket.create_connection(("127.0.0.1", port), timeout=5.0) as s:
+        s.settimeout(timeout)
+        s.sendall(encode(obj))
+        f = s.makefile("rb")
+        line = f.readline()
+        return decode(line) if line else {"status": "error", "error": "no response"}
+
+
+class ControlListener:
+    """Accepts one JSON request per connection, calls ``dispatch(req) -> resp``."""
+
+    def __init__(self, port: int, dispatch: Callable[[dict], dict]) -> None:
+        self.port = port
+        self.dispatch = dispatch
+        self._sock = None
+        self._thread = None
+        self._stop = threading.Event()
+
+    def start(self) -> None:
+        self._sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self._sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self._sock.bind(("127.0.0.1", self.port))
+        self.port = self._sock.getsockname()[1]  # resolve ephemeral (port 0)
+        self._sock.listen(4)
+        self._sock.settimeout(0.5)
+        self._stop.clear()
+        self._thread = threading.Thread(target=self._serve, daemon=True)
+        self._thread.start()
+
+    def _serve(self) -> None:
+        while not self._stop.is_set():
+            try:
+                conn, _ = self._sock.accept()
+            except socket.timeout:
+                continue
+            except OSError:
+                break
+            threading.Thread(target=self._handle, args=(conn,), daemon=True).start()
+
+    def _handle(self, conn) -> None:
+        try:
+            f = conn.makefile("rwb")
+            line = f.readline()
+            if not line:
+                return
+            try:
+                resp = self.dispatch(decode(line))
+            except Exception as exc:  # never crash the bridge on a bad request
+                resp = {"status": "error", "error": str(exc)}
+            f.write(encode(resp))
+            f.flush()
+        finally:
+            try:
+                conn.close()
+            except Exception:
+                pass
+
+    def stop(self) -> None:
+        self._stop.set()
+        if self._sock is not None:
+            try:
+                self._sock.close()
+            except Exception:
+                pass
+            self._sock = None

--- a/wisprlite/app.py
+++ b/wisprlite/app.py
@@ -353,8 +353,13 @@ class App:
             return fut.result(timeout=max(1, int(timeout)))
         except concurrent.futures.TimeoutError:
             fut.cancel()
-            self._pending_agent_listen = None
-            self.overlay.hide()
+            # If the user is mid-utterance when we time out, KEEP _pending_agent_listen
+            # set so _finish() routes (and discards) that utterance instead of typing it
+            # into the foreground app. If nothing is in flight, disarm so the next normal
+            # dictation behaves normally.
+            if not self._busy.locked():
+                self._pending_agent_listen = None
+                self.overlay.hide()
             return {"status": "timeout", "text": ""}
 
     def _agent_listen_hands_free(self, prompt="", timeout=45) -> dict:

--- a/wisprlite/app.py
+++ b/wisprlite/app.py
@@ -166,11 +166,18 @@ class App:
 
             # Agent MCP listen: route the transcript to the caller instead of typing.
             if self._pending_agent_listen is not None:
+                import concurrent.futures
                 pending = self._pending_agent_listen
                 self._pending_agent_listen = None
-                if not pending["future"].cancelled():  # not already timed out
+                try:
                     answer = apply_replacements(self._polish(text), self.cfg.replacements) if text else ""
+                except Exception:
+                    log.exception("agent-listen polish failed")
+                    answer = text  # fall back to the raw transcript so the caller still gets it
+                try:
                     pending["future"].set_result({"status": "ok", "text": answer})
+                except concurrent.futures.InvalidStateError:
+                    pass  # caller already timed out / cancelled
                 self.overlay.set_state("done", "↩ sent to agent" if text else "↩ (nothing heard)")
                 self._set_icon("idle")
                 return
@@ -334,7 +341,7 @@ class App:
     def on_agent_listen(self, prompt="", timeout=45, mode="") -> dict:
         import concurrent.futures
         mode = mode or self.cfg.mcp_default_mode
-        if self._busy.locked():
+        if self._busy.locked() or self._pending_agent_listen is not None:
             return {"status": "busy", "text": ""}
         if mode == "hands_free":
             return self._agent_listen_hands_free(prompt, timeout)
@@ -373,7 +380,7 @@ class App:
                     break
             audio = self.recorder.stop()
             self._set_icon("transcribing")
-            if not endpointer._speech_started:
+            if not endpointer.heard_speech:
                 self.overlay.hide(); self._set_icon("idle")
                 return {"status": "timeout", "text": ""}
             try:

--- a/wisprlite/app.py
+++ b/wisprlite/app.py
@@ -56,6 +56,8 @@ class App:
         self._started_at = 0.0
         self._busy = threading.Lock()
         self._stop = threading.Event()
+        self._pending_agent_listen = None   # set while a listen() awaits the user's hotkey
+        self._bridge = None                  # agent_bridge.ControlListener when MCP is on
 
     # ---- engine -----------------------------------------------------------
     def _build_engine(self, name: str | None = None):
@@ -161,6 +163,18 @@ class App:
                 text = self._fallback(audio, exc)
 
             text = (text or "").strip()
+
+            # Agent MCP listen: route the transcript to the caller instead of typing.
+            if self._pending_agent_listen is not None:
+                pending = self._pending_agent_listen
+                self._pending_agent_listen = None
+                if not pending["future"].cancelled():  # not already timed out
+                    answer = apply_replacements(self._polish(text), self.cfg.replacements) if text else ""
+                    pending["future"].set_result({"status": "ok", "text": answer})
+                self.overlay.set_state("done", "↩ sent to agent" if text else "↩ (nothing heard)")
+                self._set_icon("idle")
+                return
+
             if not text:
                 self.overlay.hide()
                 self._set_icon("idle")
@@ -178,16 +192,8 @@ class App:
                 return
             text = cmd.text
 
-            # AI cleanup ("Flow mode") — OpenAI / Gemini / OpenRouter / local Ollama; falls back to raw.
-            if text and self._eff("ai_cleanup"):
-                from . import cleanup
-
-                if cleanup.provider_ready(self.cfg.cleanup_provider):
-                    self.overlay.set_state("transcribing", "Polishing…")
-                    polished = cleanup.clean(text, self.cfg.cleanup_provider, self.cfg.cleanup_model,
-                                             self.cfg.language, self.cfg.speech_notes)
-                    if polished:
-                        text = polished
+            # AI cleanup ("Flow mode") — OpenAI / Gemini / OpenRouter / local Ollama.
+            text = self._polish(text)
 
             # inline formatting commands ("new line") — after cleanup so newlines survive
             text = commands.inline(text, self.cfg.voice_commands)
@@ -281,6 +287,141 @@ class App:
 
     def toggle_pause(self) -> None:
         self.paused = not self.paused
+        self.tray.update()
+
+    # ---- agent MCP -------------------------------------------------------
+    def _polish(self, text: str) -> str:
+        """Optional LLM cleanup ('Flow mode'); returns the input unchanged if off/unavailable."""
+        if not (text and self._eff("ai_cleanup")):
+            return text
+        from . import cleanup
+        if not cleanup.provider_ready(self.cfg.cleanup_provider):
+            return text
+        self.overlay.set_state("transcribing", "Polishing…")
+        polished = cleanup.clean(text, self.cfg.cleanup_provider, self.cfg.cleanup_model,
+                                 self.cfg.language, self.cfg.speech_notes)
+        return polished or text
+
+    def _agent_dispatch(self, req: dict) -> dict:
+        op = req.get("op")
+        if op == "listen":
+            return self.on_agent_listen(req.get("prompt", ""), req.get("timeout", 45), req.get("mode", ""))
+        if op == "transcribe":
+            return self.on_agent_transcribe(req.get("path", ""), req.get("format", "json"),
+                                            req.get("language", ""), req.get("model_size", ""))
+        return {"status": "error", "error": f"unknown op: {op}"}
+
+    def on_agent_transcribe(self, path="", fmt="json", language="", model_size="") -> dict:
+        import os
+        if not path or not os.path.exists(path):
+            return {"status": "error", "error": f"file not found: {path}"}
+        size = model_size or self.cfg.transcribe_model_size or self.cfg.local_model_size
+        try:
+            from .engines.transcribe import transcribe_file
+            r = transcribe_file(path, language=(language or None), model_size=size)
+        except Exception as exc:
+            log.exception("agent transcribe failed")
+            return {"status": "error", "error": str(exc)}
+        out = {"status": "ok", "text": r["text"], "language": r["language"], "duration": r["duration"]}
+        fmt = (fmt or "json").lower()
+        if fmt in ("srt", "vtt"):
+            from . import captions
+            out["captions"] = captions.to_srt(r["segments"]) if fmt == "srt" else captions.to_vtt(r["segments"])
+        else:
+            out["segments"] = r["segments"]
+        return out
+
+    def on_agent_listen(self, prompt="", timeout=45, mode="") -> dict:
+        import concurrent.futures
+        mode = mode or self.cfg.mcp_default_mode
+        if self._busy.locked():
+            return {"status": "busy", "text": ""}
+        if mode == "hands_free":
+            return self._agent_listen_hands_free(prompt, timeout)
+        # push-to-talk: arm, cue the overlay, wait for the user's normal hotkey cycle.
+        fut = concurrent.futures.Future()
+        self._pending_agent_listen = {"future": fut}
+        self.overlay.show("listening", prompt or "🎙 your agent is listening — hold your hotkey & speak")
+        try:
+            return fut.result(timeout=max(1, int(timeout)))
+        except concurrent.futures.TimeoutError:
+            fut.cancel()
+            self._pending_agent_listen = None
+            self.overlay.hide()
+            return {"status": "timeout", "text": ""}
+
+    def _agent_listen_hands_free(self, prompt="", timeout=45) -> dict:
+        import time
+        from .vad import SilenceEndpointer
+        if not self._busy.acquire(blocking=False):
+            return {"status": "busy", "text": ""}
+        try:
+            try:
+                engine = self._get_engine()
+                self._session = engine.start_session(on_partial=self.overlay.set_text)
+            except Exception as exc:
+                self._fail(str(exc))
+                return {"status": "error", "text": "", "error": str(exc)}
+            self.overlay.show("listening", prompt or "🎙 your agent is listening…")
+            self._set_icon("recording")
+            self.recorder.start(on_frame=self._session.feed if engine.streaming else None)
+            endpointer = SilenceEndpointer(silence_ms=self.cfg.hands_free_silence_ms)
+            deadline = time.time() + max(1, int(timeout))
+            while time.time() < deadline:
+                time.sleep(0.05)
+                if endpointer.feed(self.recorder.level):
+                    break
+            audio = self.recorder.stop()
+            self._set_icon("transcribing")
+            if not endpointer._speech_started:
+                self.overlay.hide(); self._set_icon("idle")
+                return {"status": "timeout", "text": ""}
+            try:
+                text = self._session.finish(audio) if self._session else ""
+            except Exception as exc:
+                text = self._fallback(audio, exc)
+            text = apply_replacements(self._polish((text or "").strip()), self.cfg.replacements)
+            self.overlay.set_state("done", "↩ sent to agent")
+            self._beep(990, 60); self._set_icon("idle")
+            return {"status": "ok", "text": text}
+        finally:
+            self._session = None
+            self._release()
+
+    def _mcp_add_command(self) -> str:
+        if getattr(sys, "frozen", False):
+            return f'claude mcp add pipevoice -- "{sys.executable}" --mcp'
+        return "claude mcp add pipevoice -- python -m wisprlite --mcp"
+
+    def start_mcp_bridge(self) -> None:
+        if self._bridge is not None:
+            return
+        try:
+            from .agent_bridge import ControlListener
+            self._bridge = ControlListener(self.cfg.mcp_port, self._agent_dispatch)
+            self._bridge.start()
+            log.info("MCP control bridge on 127.0.0.1:%s", self.cfg.mcp_port)
+        except Exception as exc:
+            self._bridge = None
+            log.warning("MCP bridge failed to start: %s", exc)
+            self._fail(f"MCP bridge: {exc}")
+
+    def stop_mcp_bridge(self) -> None:
+        if self._bridge is not None:
+            try:
+                self._bridge.stop()
+            except Exception:
+                pass
+            self._bridge = None
+
+    def toggle_mcp(self) -> None:
+        self.cfg.mcp_enabled = not self.cfg.mcp_enabled
+        self.cfg.save()
+        if self.cfg.mcp_enabled:
+            self.start_mcp_bridge()
+            self._notify("Agent MCP on. Register once:\n" + self._mcp_add_command())
+        else:
+            self.stop_mcp_bridge()
         self.tray.update()
 
     def open_settings(self) -> None:
@@ -385,6 +526,7 @@ class App:
 
     def quit(self) -> None:
         self._stop.set()
+        self.stop_mcp_bridge()
         self.hotkeys.stop()
         self.overlay.stop()
         self.tray.stop()
@@ -492,6 +634,8 @@ class App:
         self.tray.start()
         self.hotkeys.start()
         self.clip_hotkeys.start()
+        if self.cfg.mcp_enabled:
+            self.start_mcp_bridge()
         self._prewarm()
         threading.Thread(target=self._watch_config, daemon=True).start()
         try:

--- a/wisprlite/captions.py
+++ b/wisprlite/captions.py
@@ -1,0 +1,37 @@
+"""Pure SRT / WebVTT formatting from segment dicts.
+
+A segment dict is {"start": float, "end": float, "text": str, "words": [...]}.
+No dependencies, no I/O — trivially testable.
+"""
+
+from __future__ import annotations
+
+
+def format_timestamp(seconds: float, vtt: bool = False) -> str:
+    if seconds is None or seconds < 0:
+        seconds = 0.0
+    ms_total = int(round(seconds * 1000))
+    h, ms_total = divmod(ms_total, 3_600_000)
+    m, ms_total = divmod(ms_total, 60_000)
+    s, ms = divmod(ms_total, 1000)
+    sep = "." if vtt else ","
+    return f"{h:02d}:{m:02d}:{s:02d}{sep}{ms:03d}"
+
+
+def to_srt(segments) -> str:
+    lines = []
+    for i, seg in enumerate(segments, 1):
+        lines.append(str(i))
+        lines.append(f"{format_timestamp(seg['start'])} --> {format_timestamp(seg['end'])}")
+        lines.append((seg.get("text") or "").strip())
+        lines.append("")
+    return ("\n".join(lines).strip() + "\n") if lines else ""
+
+
+def to_vtt(segments) -> str:
+    out = ["WEBVTT", ""]
+    for seg in segments:
+        out.append(f"{format_timestamp(seg['start'], vtt=True)} --> {format_timestamp(seg['end'], vtt=True)}")
+        out.append((seg.get("text") or "").strip())
+        out.append("")
+    return "\n".join(out).strip() + "\n"

--- a/wisprlite/config.py
+++ b/wisprlite/config.py
@@ -84,6 +84,12 @@ class Config:
     paste_speed: str = "normal"       # fast | normal | slow — clipboard-paste timing
     last_version: str = ""            # app version last run, to detect a fresh update
     profiles: list = field(default_factory=list)  # per-app behaviour overrides
+    # Agent MCP server (listen + transcribe). Off by default; opt-in via the tray.
+    mcp_enabled: bool = False
+    mcp_port: int = 49518             # loopback control bridge (distinct from the 49517 lock)
+    mcp_default_mode: str = "push_to_talk"  # push_to_talk | hands_free  (for `listen`)
+    hands_free_silence_ms: int = 800  # trailing silence that ends a hands-free capture
+    transcribe_model_size: str = ""   # blank = reuse local_model_size
 
     @classmethod
     def load(cls) -> "Config":

--- a/wisprlite/engines/transcribe.py
+++ b/wisprlite/engines/transcribe.py
@@ -1,0 +1,61 @@
+"""File transcription with word-level timestamps (for the agent MCP).
+
+Separate from the streaming dictation Session: takes a file *path* (not an
+audio array), so it needs no numpy and is import-light / unit-testable.
+faster-whisper is imported lazily inside the functions.
+"""
+
+from __future__ import annotations
+
+import threading as _threading
+
+_TRANSCRIBE_MODEL = None
+_TRANSCRIBE_KEY = None
+_TRANSCRIBE_LOCK = _threading.Lock()
+
+
+def _segments_to_dicts(segments) -> list:
+    """Shape faster-whisper segments into plain JSON-able dicts. Pure."""
+    out = []
+    for seg in segments:
+        words = []
+        for w in (getattr(seg, "words", None) or []):
+            words.append({"start": round(float(w.start), 3),
+                          "end": round(float(w.end), 3),
+                          "word": w.word})
+        out.append({"start": round(float(seg.start), 3),
+                    "end": round(float(seg.end), 3),
+                    "text": (seg.text or "").strip(),
+                    "words": words})
+    return out
+
+
+def _get_transcribe_model(model_size: str, device: str = "auto", compute_type: str = "int8"):
+    global _TRANSCRIBE_MODEL, _TRANSCRIBE_KEY
+    key = (model_size, device, compute_type)
+    if _TRANSCRIBE_MODEL is None or _TRANSCRIBE_KEY != key:
+        from faster_whisper import WhisperModel
+        _TRANSCRIBE_MODEL = WhisperModel(model_size, device=device, compute_type=compute_type)
+        _TRANSCRIBE_KEY = key
+    return _TRANSCRIBE_MODEL
+
+
+def transcribe_file(path: str, *, language=None, model_size: str = "base.en",
+                    device: str = "auto", compute_type: str = "int8") -> dict:
+    """Transcribe an audio/video file to text + word/segment timestamps.
+
+    Serialized behind a lock (one shared warm model). faster-whisper decodes
+    audio from many container formats via its bundled PyAV/ffmpeg.
+    """
+    with _TRANSCRIBE_LOCK:
+        model = _get_transcribe_model(model_size, device, compute_type)
+        segments, info = model.transcribe(
+            path, language=language or None, word_timestamps=True,
+            vad_filter=True, beam_size=1,
+        )
+        seg_dicts = _segments_to_dicts(segments)  # consume the generator inside the lock
+    text = " ".join(s["text"] for s in seg_dicts).strip()
+    return {"text": text,
+            "language": getattr(info, "language", None),
+            "duration": round(float(getattr(info, "duration", 0.0) or 0.0), 3),
+            "segments": seg_dicts}

--- a/wisprlite/mcp_shim.py
+++ b/wisprlite/mcp_shim.py
@@ -1,0 +1,54 @@
+"""`--mcp`: a stdio MCP server exposing pipevoice.listen + pipevoice.transcribe.
+
+Spawned on demand by an MCP client (Claude Code etc.). It forwards each call to
+the resident tray app over the loopback control bridge, so the heavy MCP
+machinery lives only in this ephemeral process — the resident app stays light.
+"""
+
+from __future__ import annotations
+
+
+def _port() -> int:
+    from . import config
+    return int(getattr(config.Config.load(), "mcp_port", 49518))
+
+
+def _send(op: str, **kw) -> dict:
+    from . import agent_bridge
+    try:
+        return agent_bridge.send_request(_port(), {"op": op, **kw})
+    except (ConnectionRefusedError, OSError):
+        return {"status": "app_not_running", "text": "",
+                "error": "PipeVoice isn't running, or its Agent MCP toggle is off."}
+
+
+def main() -> None:
+    from mcp.server.fastmcp import FastMCP
+
+    mcp = FastMCP("pipevoice")
+
+    @mcp.tool()
+    def listen(prompt: str = "", timeout_seconds: int = 45, mode: str = "") -> dict:
+        """Ask the user to answer by voice and return what they said as text.
+
+        Use when you need information only the user has. PipeVoice shows a prompt,
+        the user speaks (push-to-talk by default), and the transcript is returned.
+        `mode` may be 'push_to_talk' or 'hands_free' (default: the user's setting).
+        """
+        return _send("listen", prompt=prompt, timeout=timeout_seconds, mode=mode)
+
+    @mcp.tool()
+    def transcribe(path: str, format: str = "json", language: str = "", model_size: str = "") -> dict:
+        """Transcribe a local audio or video file to timed text using local whisper.
+
+        `format`: 'json' returns text + segment/word timestamps; 'srt'/'vtt' return
+        a ready-made caption string in `captions`. `language` is an optional ISO
+        code (blank = auto-detect). No API key needed; runs offline.
+        """
+        return _send("transcribe", path=path, format=format, language=language, model_size=model_size)
+
+    mcp.run()  # stdio transport by default
+
+
+if __name__ == "__main__":
+    main()

--- a/wisprlite/mcp_shim.py
+++ b/wisprlite/mcp_shim.py
@@ -13,11 +13,16 @@ def _port() -> int:
     return int(getattr(config.Config.load(), "mcp_port", 49518))
 
 
-def _send(op: str, **kw) -> dict:
+def _send(op: str, read_timeout: float = 130.0, **kw) -> dict:
+    import socket
     from . import agent_bridge
     try:
-        return agent_bridge.send_request(_port(), {"op": op, **kw})
-    except (ConnectionRefusedError, OSError):
+        return agent_bridge.send_request(_port(), {"op": op, **kw}, timeout=read_timeout)
+    except socket.timeout:
+        # connected, but no reply in time (e.g. the user never spoke)
+        return {"status": "timeout", "text": "", "error": "no response in time"}
+    except OSError:
+        # connection refused / reset -> app not running or MCP toggle off
         return {"status": "app_not_running", "text": "",
                 "error": "PipeVoice isn't running, or its Agent MCP toggle is off."}
 
@@ -35,7 +40,8 @@ def main() -> None:
         the user speaks (push-to-talk by default), and the transcript is returned.
         `mode` may be 'push_to_talk' or 'hands_free' (default: the user's setting).
         """
-        return _send("listen", prompt=prompt, timeout=timeout_seconds, mode=mode)
+        return _send("listen", read_timeout=float(timeout_seconds) + 60.0,
+                     prompt=prompt, timeout=timeout_seconds, mode=mode)
 
     @mcp.tool()
     def transcribe(path: str, format: str = "json", language: str = "", model_size: str = "") -> dict:
@@ -45,7 +51,8 @@ def main() -> None:
         a ready-made caption string in `captions`. `language` is an optional ISO
         code (blank = auto-detect). No API key needed; runs offline.
         """
-        return _send("transcribe", path=path, format=format, language=language, model_size=model_size)
+        return _send("transcribe", read_timeout=900.0,
+                     path=path, format=format, language=language, model_size=model_size)
 
     mcp.run()  # stdio transport by default
 

--- a/wisprlite/tray.py
+++ b/wisprlite/tray.py
@@ -96,6 +96,8 @@ class Tray:
                  checked=lambda it: app.cfg.sounds),
             Item("Start on login", lambda i, it: app.toggle_autostart(),
                  checked=lambda it: app.autostart_enabled()),
+            Item("Agent MCP (listen + transcribe)", lambda i, it: app.toggle_mcp(),
+                 checked=lambda it: app.cfg.mcp_enabled),
             Item("Paused", lambda i, it: app.toggle_pause(),
                  checked=lambda it: app.paused),
             Menu.SEPARATOR,

--- a/wisprlite/vad.py
+++ b/wisprlite/vad.py
@@ -1,0 +1,28 @@
+"""Trailing-silence endpointer for hands-free capture.
+
+Pure decision logic over the recorder's smoothed RMS level (audio.py:24).
+Stop only after speech has started AND the level has stayed below `threshold`
+for `silence_ms`. No DSP, no deps.
+"""
+
+from __future__ import annotations
+
+
+class SilenceEndpointer:
+    def __init__(self, threshold: float = 0.02, silence_ms: int = 800, block_ms: int = 50) -> None:
+        self.threshold = threshold
+        self.silence_blocks_needed = max(1, int(round(silence_ms / max(1, block_ms))))
+        self._speech_started = False
+        self._silent_blocks = 0
+
+    def feed(self, level: float) -> bool:
+        """Return True when the capture should stop."""
+        if level >= self.threshold:
+            self._speech_started = True
+            self._silent_blocks = 0
+            return False
+        if self._speech_started:
+            self._silent_blocks += 1
+            if self._silent_blocks >= self.silence_blocks_needed:
+                return True
+        return False

--- a/wisprlite/vad.py
+++ b/wisprlite/vad.py
@@ -15,6 +15,11 @@ class SilenceEndpointer:
         self._speech_started = False
         self._silent_blocks = 0
 
+    @property
+    def heard_speech(self) -> bool:
+        """True once any above-threshold audio has been seen this capture."""
+        return self._speech_started
+
     def feed(self, level: float) -> bool:
         """Return True when the capture should stop."""
         if level >= self.threshold:

--- a/wisprlitevercel/docs/index.html
+++ b/wisprlitevercel/docs/index.html
@@ -133,6 +133,16 @@
   <h3>Nothing happens when I hold the key</h3>
   <p>Confirm the hotkey in Settings, and that an engine is selected (the tray tooltip shows the current engine). For cloud engines, make sure a valid key is saved.</p>
 
+  <h2 id="mcp">Talk to your AI agent (MCP)</h2>
+  <p>PipeVoice can act as a local MCP server so agents (Claude Code, Cursor, Cline) can use your voice — no API key, everything runs on your machine.</p>
+  <ul>
+    <li><b><code>listen</code></b> — the agent asks a question, you answer by voice, and it gets the text back.</li>
+    <li><b><code>transcribe</code></b> — hand it a local audio or video file and get a transcript with timestamps, or ready-made captions (<code>format: "srt"</code> / <code>"vtt"</code>).</li>
+  </ul>
+  <p>Enable <b>Agent MCP (listen + transcribe)</b> in the tray menu, then register it once with your client:</p>
+  <div class="card"><code>claude mcp add pipevoice -- python -m wisprlite --mcp</code></div>
+  <p>The server is loopback-only and off by default.</p>
+
   <footer>
     <span>Pipevoice — free, private voice typing for Windows.</span>
     <span><a href="/">Home</a> · <a href="https://github.com/Powleads/PipeVoice">GitHub ↗</a></span>


### PR DESCRIPTION
Makes PipeVoice a local MCP server so AI agents (Claude Code, Cursor, Cline) get voice **input** and a **key-free transcription** service — the on-brand inverse of Voicebox's agent-voice *output*. Spec + plan in `docs/superpowers/`.

## Two tools
- **`pipevoice.listen`** — agent asks, the user answers by voice, transcript returned (not typed). Push-to-talk default + optional hands-free (VAD auto-stop).
- **`pipevoice.transcribe`** — a local audio/**video** file → text + word/segment timestamps via local whisper, `format: json|srt|vtt`. No API key, offline. (This is what makes it usable as the "no transcriber on this box" fix for an AI video-captioning flow.)

## Architecture (Approach B — keeps the resident app light)
An MCP client spawns `Pipevoice.exe --mcp` (or `python -m wisprlite --mcp`) — a stdio MCP server that forwards each call over a **stdlib loopback TCP bridge** to the running tray app. The resident app gains only a socket listener (no web framework); the `mcp` SDK loads only in the ephemeral shim. Enable via the tray **"Agent MCP (listen + transcribe)"** toggle (off by default, loopback-only); it prints the one-time `claude mcp add` command.

## New / changed
- New: `captions.py`, `vad.py`, `agent_bridge.py`, `engines/transcribe.py`, `mcp_shim.py`
- Changed: `app.py` (dispatch, `on_agent_listen`/`on_agent_transcribe`, bridge lifecycle, `_polish` refactor, `_finish` routing), `config.py` (5 fields), `tray.py` (toggle), `__main__.py` + `launch.py` (`--mcp`), `requirements.txt` (`mcp`), README + docs. Version → 2.26.0.

## Tested
6 pure-unit test files (`tests/`), all green on Linux: captions SRT/VTT, VAD endpointing, bridge JSON round-trip, transcribe-shaper, bridge→transcribe→captions integration, shim `_send`.

## Reviewed (two passes, all findings fixed)
- **Opus quality review:** hardened the listen Future across threads (InvalidStateError + polish-failure), reject concurrent `listen` (busy), timeout-aware shim `_send` (distinguish app-down vs slow), public VAD property.
- **Codex cross-model:** **P1** frozen `--mcp` now routes via `launch.py` (was dead for packaged builds); **P2** a listen timeout *while the user is mid-answer* no longer types their answer into the foreground app (stays armed → `_finish` discards).

## ⚠️ Needs manual verification on Windows (can't run the GUI/mic/model/SDK on the Linux dev box)
- [ ] `build_exe.bat` bundles the `mcp` SDK (add to PyInstaller hiddenimports if missing); note exe size delta.
- [ ] `Pipevoice.exe --mcp` runs the stdio server; `claude mcp add` lists both tools.
- [ ] `listen` PTT + hands-free end-to-end; busy + timeout paths; answer is returned, not typed/logged.
- [ ] `transcribe` on a .wav (json + srt) and an .mp4 (PyAV decode); missing-path error.

## Deferred (documented ceilings, not blockers)
- ffmpeg fallback for videos PyAV can't decode (errors cleanly today).
- `listen.clean` per-call cleanup override (uses the user's Flow-mode setting).
- Settings-window fields for port / default mode / silence threshold (tray toggle + `config.json` cover v1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)