### PR TITLE
Local Whisper: large-v3-turbo model + GPU/device & compute-type settings

### DIFF
--- a/wisprlite/app.py
+++ b/wisprlite/app.py
@@ -85,7 +85,8 @@ class App:
             from .engines.local_engine import LocalEngine
 
             return LocalEngine(model_size=self.cfg.local_model_size,
-                               language=(self.cfg.language or "").split("-")[0] or None, prompt=vocab)
+                               language=(self.cfg.language or "").split("-")[0] or None, prompt=vocab,
+                               device=self.cfg.local_device, compute_type=self.cfg.local_compute_type)
         raise RuntimeError(f"Unknown engine: {name}")
 
     def _get_engine(self, name: str | None = None):
@@ -241,7 +242,8 @@ class App:
             self.overlay.set_state("transcribing", "Cloud failed — using local…")
             from .engines.local_engine import LocalEngine
 
-            local = LocalEngine(model_size=self.cfg.local_model_size, language=(self.cfg.language or "").split("-")[0] or None)
+            local = LocalEngine(model_size=self.cfg.local_model_size, language=(self.cfg.language or "").split("-")[0] or None,
+                                device=self.cfg.local_device, compute_type=self.cfg.local_compute_type)
             return local.start_session(on_partial=self.overlay.set_text).finish(audio)
         except Exception as exc:
             self._fail(f"{err} (local fallback: {exc})")
@@ -424,7 +426,8 @@ class App:
         self.cfg = new  # hotkey/mode/output read live via lambdas
 
         engine_keys = ("engine", "openai_model", "deepgram_model",
-                       "local_model_size", "language", "device", "vocabulary",
+                       "local_model_size", "local_device", "local_compute_type",
+                       "language", "device", "vocabulary",
                        "deepgram_finish_timeout")
         if any(getattr(old, k) != getattr(new, k) for k in engine_keys):
             self._engines = {}

--- a/wisprlite/config.py
+++ b/wisprlite/config.py
@@ -65,6 +65,8 @@ class Config:
     openai_model: str = "whisper-1"
     deepgram_model: str = "nova-3"
     local_model_size: str = "base.en"
+    local_device: str = "auto"        # auto | cpu | cuda  (faster-whisper device)
+    local_compute_type: str = "int8"  # int8 | int8_float16 | float16 | float32
     overlay: bool = True
     sounds: bool = False
     auto_update: bool = True         # check GitHub for a newer release on startup and install it

--- a/wisprlite/settings.py
+++ b/wisprlite/settings.py
@@ -22,7 +22,10 @@ PASTE_SPEEDS = [("fast", "Fast"), ("normal", "Normal"), ("slow", "Slow")]
 CLEANUP_PROVIDERS = [("openai", "OpenAI"), ("gemini", "Google Gemini (free tier)"),
                      ("openrouter", "OpenRouter (free models)"), ("ollama", "Local — Ollama (offline)")]
 LOCAL_SIZES = ["tiny.en", "base.en", "small.en", "medium.en",
-               "tiny", "base", "small", "medium", "large-v3"]
+               "tiny", "base", "small", "medium", "large-v3", "large-v3-turbo"]
+LOCAL_DEVICES = [("auto", "Auto-detect"), ("cpu", "CPU"), ("cuda", "GPU (NVIDIA CUDA)")]
+LOCAL_COMPUTE_TYPES = [("int8", "int8 — fastest on CPU"), ("int8_float16", "int8_float16 — GPU"),
+                       ("float16", "float16 — GPU"), ("float32", "float32 — most accurate")]
 LANGUAGES = [
     ("", "Auto-detect"),
     ("en-US", "English — US"),
@@ -361,6 +364,8 @@ def main(first_run: bool = False) -> None:
     oai_var = tk.StringVar(value=cfg.openai_model)
     dg_var = tk.StringVar(value=cfg.deepgram_model)
     local_var = tk.StringVar(value=cfg.local_model_size)
+    local_device_var = tk.StringVar(value=dict(LOCAL_DEVICES).get(cfg.local_device, LOCAL_DEVICES[0][1]))
+    local_compute_var = tk.StringVar(value=dict(LOCAL_COMPUTE_TYPES).get(cfg.local_compute_type, LOCAL_COMPUTE_TYPES[0][1]))
     oai_key_var = tk.StringVar()
     dg_key_var = tk.StringVar()
     gem_key_var = tk.StringVar()
@@ -465,6 +470,10 @@ def main(first_run: bool = False) -> None:
     entry(row(c, "OpenAI model"), oai_var, width=22)
     entry(row(c, "Deepgram model"), dg_var, width=22)
     combo(row(c, "Local model size", "Bigger is more accurate but slower."), local_var, LOCAL_SIZES)
+    combo(row(c, "Local: device", "Auto picks GPU if available, else CPU."),
+          local_device_var, [l for _, l in LOCAL_DEVICES])
+    combo(row(c, "Local: compute type", "int8 is fastest on CPU; float16/int8_float16 for GPU."),
+          local_compute_var, [l for _, l in LOCAL_COMPUTE_TYPES], width=26)
 
     # --- API keys ---
     c = card("API keys", "Stored locally in your .env, never uploaded. Leave a field blank to keep its current key.")
@@ -568,6 +577,8 @@ def main(first_run: bool = False) -> None:
         cfg.openai_model = oai_var.get().strip() or "whisper-1"
         cfg.deepgram_model = dg_var.get().strip() or "nova-2"
         cfg.local_model_size = local_var.get().strip() or "base.en"
+        cfg.local_device = value_for(local_device_var, LOCAL_DEVICES)
+        cfg.local_compute_type = value_for(local_compute_var, LOCAL_COMPUTE_TYPES)
         cfg.overlay = bool(overlay_var.get())
         cfg.sounds = bool(sounds_var.get())
         cfg.auto_update = bool(auto_update_var.get())


### PR DESCRIPTION
The two quick local-Whisper dictation wins from the Voicebox analysis — closes their "faster locally" edge for users who have a GPU, while keeping CPU + cloud as the defaults.

## What
- **`large-v3-turbo`** added to the local-model dropdown (`settings.py` `LOCAL_SIZES`) — the fast, accurate turbo model `faster-whisper` already supports.
- **Device + compute-type settings**: two new config fields (`local_device` = auto/cpu/cuda, `local_compute_type` = int8/int8_float16/float16/float32) and matching tray-settings dropdowns. They're passed into `LocalEngine(...)` (which already accepted `device`/`compute_type` — previously hardcoded `auto`/`int8`) at both build sites, and added to the live-reload `engine_keys` so changing them rebuilds the engine.

## Files
`config.py` (2 fields), `app.py` (`_build_engine` + `_fallback` pass-through, `_watch_config` keys), `settings.py` (turbo model + 2 dropdowns via the existing `value_for(var, table)` save helper, mirroring the engine/mode/output controls). Defaults unchanged (`auto`/`int8`), so existing users see no behavior change.

## Independent of #43
Touches `config.py`/`app.py` in different regions than the Agent-MCP PR and never touches `local_engine.py` — merges cleanly in either order.

## ⚠️ Windows manual-verify (can't render Tk / load a model on the Linux dev box)
- [ ] Settings window shows the new "Local: device" + "Local: compute type" dropdowns; selecting + saving persists to `config.json`.
- [ ] `large-v3-turbo` selectable; first use downloads the model; transcribes correctly.
- [ ] On a CUDA box, device=`cuda` + a GPU compute type (`float16`/`int8_float16`) actually uses the GPU and is faster; `auto` still works everywhere.
- [ ] Verified by AST parse + config load + codex review on the Linux side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)