### PR TITLE
GTM: star-optimized README + homepage demo video

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,145 +1,221 @@
-# Pipevoice
+<div align="center">
 
-A Wispr-Flow-style voice typing tool for Windows. Hold a hotkey, talk, release —
-your speech is transcribed and typed into whatever window is focused (terminal,
-editor, browser). Built for dictating to Claude in a terminal.
+<!--
+  SEO / discovery keywords (not visible copy, no stuffing):
+  free voice typing windows, wispr flow alternative, open source dictation, offline speech to text,
+  push to talk dictation, voice coding, dictate into claude code, cursor voice input, deepgram windows,
+  whisper dictation, local speech to text windows, no-gpu voice typing, voicebox alternative, free dictation app
+-->
 
-- **Three engines, switchable from the tray:**
-  - **OpenAI Whisper** (cloud) — most accurate, near-zero setup. *Default.*
-  - **Deepgram** (streaming) — lowest latency; words appear live as you talk.
-  - **Local Whisper** (offline) — fully private, free per-use, no internet.
-- **Live overlay HUD** — a sleek pill near the bottom of the screen with a
-  pulsing status dot, a real-time mic VU meter, and the live transcript.
-- **System tray icon** — switch engine / mode / output, pause, autostart, quit.
-- **Settings window** — edit the hotkey (with a "Capture" button), engine,
-  models, mic, language and toggles in a GUI; no JSON editing. Changes apply
-  live to the running app.
-- **Auto-start on login** — one click in the tray menu or the installer.
-- **Push-to-talk or toggle**, **type or paste** output — all switchable.
-- **Automatic offline fallback** — if a cloud engine fails (no internet), it
-  retries the utterance with local Whisper.
+# PipeVoice
 
-## Quick start (Windows)
+### Talk faster than you type.
 
-1. Install [Python 3.10+](https://www.python.org/downloads/) — tick
-   **"Add Python to PATH"** during install.
-2. Put this folder somewhere, e.g. `C:\Tools\wisprlite`.
-3. Copy `.env.example` to `.env` and add your `OPENAI_API_KEY`.
-4. Double-click **`run.bat`**. First run builds a venv and installs everything,
-   then starts listening. A microphone icon appears in your system tray.
-5. Hold **Right Ctrl**, speak, release. Text appears at your cursor.
+**Free, open-source, push-to-talk voice typing for Windows that lands in any app — your terminal, editor, browser, chat box.**
+Cloud with your own key, free AI polish with Gemini, or go 100% offline so nothing leaves your PC.
 
-Right-click the tray icon to change anything — no config files to edit.
+**No account. No subscription. Ever.**
 
-## Engines
+<p>
+  <a href="https://github.com/Powleads/PipeVoice/stargazers"><img alt="GitHub stars" src="https://img.shields.io/github/stars/Powleads/PipeVoice?style=for-the-badge&logo=github&color=ff5fa2"></a>
+  <a href="https://github.com/Powleads/PipeVoice/releases/latest"><img alt="Latest release" src="https://img.shields.io/github/v/release/Powleads/PipeVoice?style=for-the-badge&color=ff5fa2"></a>
+  <a href="LICENSE"><img alt="License: MIT" src="https://img.shields.io/badge/license-MIT-blue?style=for-the-badge"></a>
+  <img alt="Platform: Windows 10 & 11" src="https://img.shields.io/badge/platform-Windows%2010%20%26%2011-0078D6?style=for-the-badge&logo=windows">
+  <a href="https://github.com/Powleads/PipeVoice/pulls"><img alt="PRs welcome" src="https://img.shields.io/badge/PRs-welcome-brightgreen?style=for-the-badge"></a>
+</p>
 
-| Engine | Latency | Cost | Internet | Notes |
+**Windows 10 & 11 · free forever · open source**
+
+[**↓ Download for Windows**](https://github.com/Powleads/PipeVoice/releases/latest) · [**View source**](https://github.com/Powleads/PipeVoice) · [**pipevoice.app**](https://pipevoice.app)
+
+<br/>
+
+<!-- Video hero: clickable YouTube thumbnail (README can't iframe) -->
+[![Watch PipeVoice in action](https://img.youtube.com/vi/3DZJbwTmcGU/maxresdefault.jpg)](https://youtu.be/3DZJbwTmcGU)
+
+*▶ Watch the 3-minute demo — dictating a full Remotion video build into Claude Code, by voice.*
+
+</div>
+
+---
+
+## What is PipeVoice?
+
+PipeVoice is a tiny tray app for Windows. **Hold a hotkey, talk, release** — your speech is transcribed and typed straight into whatever window is focused: a terminal, a code editor, a browser, a chat box. It was built for one thing above all: **dictating to AI coding agents** like Claude Code and Cursor without lifting your hands off the flow.
+
+It's the **free, open-source, Windows-first alternative to paid dictation SaaS like Wispr Flow** — but with a twist most tools force you to choose between: you pick the trade-off, per moment.
+
+- **Bring your own key** (Deepgram / OpenAI) for fast, accurate cloud transcription at pennies a day, **or**
+- **Polish free with Gemini** — clean up filler words and punctuation with Google's free tier, **or**
+- **Run 100% offline** with local Whisper + Ollama, so nothing ever leaves your PC.
+
+> *"The tool hears what I'm saying exactly, but the AI will take over in a sec and make sense of it."* — from the demo
+
+One-click install · auto-updates itself · bring your own key, polish free with Gemini, or run 100% offline.
+
+---
+
+## ⚡ Why PipeVoice?
+
+- 🪶 **No GPU. No gigabyte downloads.** The cloud path needs no GPU and downloads nothing. The local path is a single ~150 MB Whisper model on CPU. Most "local AI voice" tools make Windows users fight a CUDA/GPU gauntlet first — PipeVoice doesn't.
+- ⚡ **Words appear live as you speak.** With Deepgram, the transcript forms word-by-word in the overlay in real time — true streaming, not "wait until you stop talking."
+- 🎯 **Focused, not a kitchen sink.** A quiet tray app that does *one thing* well: talk and type. No voice cloning, no DAW, no studio you didn't ask for.
+- 🪟 **Windows-native, today.** First-class Windows 10 & 11 support, end to end — installer, tray, auto-updates.
+- 🤖 **Built for voice coding.** Dictate prompts straight into Claude Code, Cursor, or any terminal. Per-app profiles mean *"Terminal: raw + Enter. Chat: polished + auto-send. Editor: no AI cleanup."*
+- 🔒 **Your keys, your machine.** API keys are stored locally in your `.env`, never uploaded. Or go fully offline and skip the cloud entirely.
+
+---
+
+## ✨ Features
+
+- 🎙️ **Push-to-talk voice typing into any app** — terminal, editor, browser, chat box.
+- 🔀 **Three transcription engines, switchable at runtime:** Deepgram (live, fastest), OpenAI Whisper (accurate), Local Whisper (private/offline).
+- ⌨️ **Two capture modes:** Push-to-talk (hold) or Toggle (tap on / tap off).
+- 📋 **Two output modes:** Type keystrokes, or Clipboard + Ctrl+V (paste).
+- 🎛️ **Configurable hotkeys** — a dedicated push-to-talk key (`ctrl+\`) *and* a separate clipboard hotkey (`right ctrl+right shift`).
+- 🌏 **Accent / language selection** for better accuracy — *pick yours, including non-native accents* (US / GB / AU / IN / NZ).
+- 🧩 **Per-engine model picker** — OpenAI `whisper-1`, Deepgram `nova-3`, Local `base.en` (bigger = more accurate but slower).
+- ✨ **AI Polish (Flow mode)** — *"Tidies filler words, punctuation and casing after transcription."*
+- 🧠 **Cleanup providers:** OpenAI, **free Google Gemini**, OpenRouter (free models), or **fully offline Ollama**.
+- 🗣️ **Spoken commands:** say *"new line"*, *"scratch that"*, or end with *"send it"*.
+- ↵ **Press Enter after typing (auto-send)** — handy for chat apps, leave off for editors.
+- 📚 **Vocabulary list** — teach it names and jargon for correct recognition and spelling.
+- 🔧 **Word fixes** — auto-corrections as `wrong=right`, comma-separated.
+- 🩹 **Speech notes** — *"Describe your accent, stutter or fillers to guide AI cleanup."*
+- 🟢 **Live overlay HUD** — a pill that shows it's listening, with a real-time VU meter and live transcript.
+- 🔔 **Start/stop sounds** and **Start on Windows login**.
+- 🔄 **Automatic silent updates** on startup (SHA-256 verified GitHub Releases).
+- 🕘 **Local dictation history** (last 50, saved on your PC, opened from the tray) with Copy per entry.
+- 🗂️ **Per-app profiles** — give a specific app its own engine, cleanup, output and Enter behaviour. *Terminal: raw + Enter. Chat: polished + auto-send. Editor: no AI cleanup.*
+- 🎚️ **Advanced tuning** — Min seconds, Deepgram wait, Paste speed.
+- 🔓 **Open source (MIT).** No account, no telemetry, no lock-in.
+
+---
+
+## 🎚️ Transcription engines
+
+| Engine | Latency | Cost | Internet | Best for |
 |---|---|---|---|---|
-| OpenAI Whisper | ~1–2s after release | ~$0.006/min | Required | Best accuracy, default. Needs `OPENAI_API_KEY`. |
-| Deepgram | Live (streaming) | ~$0.0043/min | Required | Words show live in the overlay. Needs `DEEPGRAM_API_KEY`. |
-| Local Whisper | ~1–4s (CPU) | Free | None | Private. First use downloads a ~150 MB model. Model size via `local_model_size`. |
+| **Deepgram** | Live (streaming) | ~$0.0043/min | Required | Words appear as you talk. Fastest. Needs `DEEPGRAM_API_KEY`. |
+| **OpenAI Whisper** | ~1–2s after release | ~$0.006/min | Required | Highest accuracy. Needs `OPENAI_API_KEY`. |
+| **Local Whisper** | ~1–4s (CPU) | Free | None | 100% private/offline. ~150 MB model, no GPU needed (auto-uses CUDA if present). |
 
-Switch engines anytime in **Tray → Engine**. Your choice persists.
+> *"Deepgram streams live (fastest). Local and OpenAI transcribe after your release."* — and if a cloud engine fails (no internet), PipeVoice automatically retries that utterance on Local Whisper.
 
-### Picking a local model size
-`base.en` (default) is fast and good for English. For more accuracy edit
-`local_model_size` in `%APPDATA%\Pipevoice\config.json` to `small.en`,
-`medium.en`, or multilingual `small` / `medium` / `large-v3`. Bigger = slower
-but more accurate; a GPU helps a lot (it auto-detects CUDA).
+---
 
-## The overlay HUD
+## 🚀 Quickstart (Windows)
 
-The pill shows what's happening:
+**The easy way:** [**Download the installer**](https://github.com/Powleads/PipeVoice/releases/latest), run it (per-user, no admin), and you're done — it auto-updates itself from then on.
 
-- 🟢 **Listening** — pulsing green dot + a live VU meter reacting to your voice.
-  With Deepgram you also see the transcript forming in real time.
-- 🟡 **Transcribing** — animated, while the final text is produced.
-- 🔵 **Done** — flashes the text it just typed (so you get confirmation).
-- 🔴 **Error** — shows what went wrong.
+**From source:**
 
-Toggle it via **Tray → Show overlay**.
+1. Install [Python 3.10+](https://www.python.org/downloads/) — tick **"Add Python to PATH"**.
+2. Clone the repo: `git clone https://github.com/Powleads/PipeVoice.git`
+3. Copy `.env.example` to `.env` and add a key (`DEEPGRAM_API_KEY` or `OPENAI_API_KEY`) — *or skip keys entirely and use Local Whisper offline.*
+4. Double-click **`run.bat`**. First run builds a venv and installs everything, then starts listening. A pink mic icon appears in your system tray.
+5. **Hold `Ctrl+\`, speak, release.** Text appears at your cursor.
 
-## Settings window
+Right-click the tray icon for **Settings** — engine, hotkeys, AI polish, per-app profiles, history. No JSON to edit.
 
-Right-click the tray icon → **Settings…** for a GUI covering everything:
-engine, mode, output, push-to-talk key (with a **Capture** button — click it and
-press your desired key/combo), microphone picker, language, the three model
-names, and the overlay/sounds/autostart toggles. Hit **Save** and the running
-app picks up the changes within a second (it watches `config.json`) — no restart.
+### 🤖 The dev hook: talk into Claude Code, Cursor, or any app
 
-The settings window runs as its own small process, so it never clashes with the
-overlay's UI thread.
+Open your AI coding agent, hold the hotkey, and dictate:
 
-## Settings (quick toggles in the tray menu)
+> *"Hey Claude, make me a new video using Remotion based around how PipeVoice works, add some motion graphics in, then send it to the PWA app..."*
 
-| Menu | Options |
-|---|---|
-| Engine | OpenAI Whisper / Deepgram / Local Whisper |
-| Mode | Push-to-talk (hold) / Toggle (tap on, tap off) |
-| Output | Type (keystrokes) / Paste (clipboard + Ctrl+V) |
-| Show overlay | on / off |
-| Sounds | on / off (the start/stop beeps) |
-| Start on login | adds/removes an HKCU autostart entry |
-| Paused | temporarily ignore the hotkey |
-| Quit | exit |
+PipeVoice transcribes exactly what you said; turn on **Flow mode** and the AI cleans it into a tidy prompt before it lands. Set a **per-app profile** for your terminal (raw + Enter) and your chat app (polished + auto-send), and each window behaves the way it should.
 
-Settings persist to `%APPDATA%\Pipevoice\config.json`. API keys live only in
-`.env` and are never written there.
+---
 
-## Packaging: .exe and a real installer
+## 🆚 PipeVoice vs the alternatives
 
-Want it to feel like a real app? Two options, both after `run.bat` has created
-`.venv`:
+An honest comparison. Different tools win for different people — here's where each one shines.
 
-1. **Single .exe** — run **`build_exe.bat`** → `dist\Pipevoice.exe` (PyInstaller,
-   no console window, custom icon). It bundles all three engines including the
-   local Whisper runtime (`faster-whisper` + `ctranslate2`). Double-click to run.
-   The icon is generated by `assets/make_icon.py` if you want to tweak it.
-2. **Full installer** — install [Inno Setup 6](https://jrsoftware.org/isdl.php),
-   then run **`build_installer.bat`**. It builds the exe and compiles
-   `installer\Output\Pipevoice-Setup.exe`: a per-user install (no admin /UAC),
-   Start Menu shortcuts, an optional "start at login" checkbox, and it pops open
-   `.env` after install so you can paste your API key. Uninstalls cleanly,
-   including `%APPDATA%\Pipevoice`.
+| | **PipeVoice** | **Wispr Flow** | **Voicebox** |
+|---|---|---|---|
+| **What it is** | Focused Windows voice typing | Paid dictation SaaS | Full AI voice studio (cloning + TTS + dictation) |
+| **Price** | **Free, open source (MIT)** | Paid subscription | Free, open source (MIT) |
+| **Account required** | **No** | Yes | No |
+| **Platform** | **Windows-native, first-class** | macOS / Windows | macOS + Windows (Linux = build from source) |
+| **GPU required** | **No** — cloud needs none; local runs on CPU | N/A (cloud) | Built around a local GPU; CPU fallback is slow |
+| **Downloads to start** | **Nothing** (cloud) / ~150 MB (local) | — | Whisper models + TTS models (GBs) |
+| **Live streaming transcript** | **Yes (Deepgram, word-by-word)** | Yes | No — batch only |
+| **Engine choice** | **Cloud OR offline, switchable** | Cloud only | Local Whisper only |
+| **AI cleanup** | **OpenAI / free Gemini / OpenRouter / offline Ollama** | Built-in | On-device LLM |
+| **Per-app profiles** | **Yes** | Limited | No |
+| **Voice commands** | **Yes** ("new line", "send it", "scratch that") | Some | No |
+| **Offline option** | **Yes — 100% local** | No | Yes (local-only) |
 
-Only one copy runs at a time (a single-instance lock), so the installer's
-startup shortcut and the tray autostart toggle can't double-launch it.
+**Bottom line:** want a beautiful AI voice *studio* (cloning, TTS) and have a GPU? Voicebox is excellent. Want a paid, polished cross-platform SaaS? Wispr Flow. Want **the simplest, lightest way to talk and type on any Windows PC — no GPU, no gigabyte downloads, cloud-or-offline, words live as you speak, straight into any app including your terminal**? That's PipeVoice.
 
-## Tips & gotchas
+---
 
-- **Dedicated PTT key.** `Right Ctrl` is the default because you almost never
-  use it otherwise. Avoid keys you actually type with.
-- **Elevated terminals.** Windows blocks keystroke injection from a normal
-  process into an *administrator* window. If your terminal runs as admin, run
-  Pipevoice as admin too.
-- **No Enter is sent.** Text lands at your cursor so you can review/edit before
-  submitting — ideal for composing Claude prompts.
-- **Wrong mic?** `python -m sounddevice` lists devices; set `device` in the
-  config (index or name substring).
-- **Latency** with OpenAI/local is the transcription time after you release.
-  Want instant feedback? Use the **Deepgram** engine.
+## ❓ FAQ
 
-## Architecture (so you can hack on it)
+**Is PipeVoice really free?**
+Yes — free forever, MIT-licensed, open source. No account, no subscription, no trial wall. If you use the Deepgram or OpenAI engines you pay those providers directly (pennies a day) with your own key. Use Local Whisper and it's free end-to-end.
 
-```
-wisprlite/
-  app.py        orchestrator + state machine (idle -> recording -> transcribing)
-  config.py     persisted settings (%APPDATA%) + secrets from .env
-  audio.py      mic capture: float32 buffer + int16 stream feed + VU level
-  hotkey.py     PTT/toggle detection (poll loop, supports combos, runtime swap)
-  typer.py      keystroke / clipboard output
-  overlay.py    tkinter HUD pill (own thread, queue-driven, ~30fps)
-  tray.py       pystray icon + menu (dynamic state-colored icon)
-  settings.py   standalone Tk settings window (separate process)
-  autostart.py  HKCU Run key management (source + frozen exe)
-  engines/
-    base.py            unified Session interface
-    openai_engine.py   batch Whisper API
-    deepgram_engine.py streaming websocket
-    local_engine.py    faster-whisper, offline
-```
+**Is this a free dictation app for Windows / a free Wispr Flow alternative?**
+Yes. PipeVoice is a free, open-source voice typing tool for Windows that types into any app. It's a strong alternative if you want dictation without a subscription or account.
 
-Every engine implements the same `start_session(on_partial) -> Session` with
-`feed(pcm)` / `finish(audio) -> text`, so the app drives all three identically.
-Heavy/optional dependencies are imported lazily — a missing one disables just
-that feature instead of crashing the app.
+**Does it work offline?**
+Yes — choose the **Local Whisper** engine and (optionally) **Ollama** for AI cleanup, and nothing leaves your PC. No internet, no cloud, no API key.
+
+**Do I need a GPU?**
+No. The cloud engines need no GPU at all and download nothing. Local Whisper runs on CPU out of the box (and auto-uses CUDA if you happen to have it).
+
+**Can I dictate into Claude Code / Cursor / a terminal? (voice coding)**
+That's exactly what it was built for. PipeVoice injects real keystrokes into the focused window — terminals included — so you can talk your prompts into AI coding agents. Per-app profiles let your terminal get raw text + Enter while your chat app gets polished, auto-sent text.
+
+**Does it send Enter automatically?**
+Only if you want it to. By default text lands at your cursor so you can review/edit before submitting. Turn on **auto-send** (globally or per app) for chat-style apps.
+
+**What about accents and non-native speakers?**
+Pick your accent/language for better accuracy, and use **Speech notes** to describe your accent, stutter or fillers — the AI cleanup uses it to make sense of your speech. *If you talk like the creator: always use AI cleanup. 😄*
+
+**Is my data private?**
+API keys are stored locally in your `.env` and never uploaded. Dictation history is saved only on your PC. Go fully offline with Local Whisper + Ollama for zero cloud involvement.
+
+**Which Windows versions?**
+Windows 10 and Windows 11.
+
+---
+
+## ⭐ Star this repo
+
+If PipeVoice saves your wrists (or your sleep), **[star the repo](https://github.com/Powleads/PipeVoice)** — it's the single biggest thing you can do to help other people find a free, no-account voice typing tool for Windows.
+
+[![Star on GitHub](https://img.shields.io/github/stars/Powleads/PipeVoice?style=social)](https://github.com/Powleads/PipeVoice/stargazers)
+
+---
+
+## 🤝 Contributing
+
+PRs welcome — this is built in public and shipped fast.
+
+- 🐛 Found a bug or have an idea? [Open an issue](https://github.com/Powleads/PipeVoice/issues).
+- 🔧 Want to add an engine or feature? Every transcription engine implements the same small `start_session(on_partial) -> Session` interface, so adding one is a single new file plus a branch. See the architecture notes in the repo.
+- 📦 Local dev: `run.bat` (source), `build_exe.bat` (single .exe), `build_installer.bat` (full installer).
+
+There's no required test suite, linter, or formatter — keep changes focused and the tray app light.
+
+---
+
+## 🔗 Links
+
+- 🌐 **Website:** [pipevoice.app](https://pipevoice.app) — *voice typing for Windows that types into any app.*
+- ⬇️ **Download:** [latest release](https://github.com/Powleads/PipeVoice/releases/latest)
+- ▶️ **Demo video:** [youtu.be/3DZJbwTmcGU](https://youtu.be/3DZJbwTmcGU)
+- 💬 **Issues & ideas:** [github.com/Powleads/PipeVoice/issues](https://github.com/Powleads/PipeVoice/issues)
+- 📰 **Blog:** [pipevoice.app/blog](https://pipevoice.app/blog)
+
+---
+
+<div align="center">
+
+**Talk faster than you type.** · Free forever · Open source · Windows 10 & 11
+
+Made with ☕ and not much sleep. **MIT licensed.**
+
+</div>

--- a/wisprlitevercel/index.html
+++ b/wisprlitevercel/index.html
@@ -21,6 +21,7 @@
   <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"Pipevoice","operatingSystem":"Windows 10, Windows 11","applicationCategory":"UtilitiesApplication","applicationSubCategory":"Voice typing / dictation","description":"Free, open-source push-to-talk voice typing for Windows. Hold a key, talk, release, and your words type into any app. Cloud engines or a fully offline local option.","url":"https://pipevoice.app/","downloadUrl":"https://github.com/Powleads/PipeVoice/releases/latest/download/Pipevoice-Setup.exe","image":"https://pipevoice.app/og-image.png","screenshot":"https://pipevoice.app/og-image.png","isAccessibleForFree":true,"offers":{"@type":"Offer","price":"0","priceCurrency":"USD"},"publisher":{"@type":"Organization","name":"Pipevoice","url":"https://pipevoice.app/","logo":"https://pipevoice.app/apple-touch-icon.png"}}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebSite","name":"Pipevoice","url":"https://pipevoice.app/"}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"VideoObject","name":"PipeVoice — talk faster than you type (3-minute demo)","description":"A walkthrough of PipeVoice, the free open-source push-to-talk voice typing app for Windows: dictating into Claude Code by voice, the settings tour, per-app profiles, and 100% offline mode.","thumbnailUrl":"https://img.youtube.com/vi/3DZJbwTmcGU/maxresdefault.jpg","uploadDate":"2026-06-22","contentUrl":"https://youtu.be/3DZJbwTmcGU","embedUrl":"https://www.youtube.com/embed/3DZJbwTmcGU"}</script>
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 <link href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700;800&family=Geist+Mono:wght@400;500&display=swap" rel="stylesheet" />
@@ -301,6 +302,38 @@
       <span class="p"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="9"/><path d="M9 12l2 2 4-4"/></svg> Open source</span>
     </div>
   </div>
+
+  <!-- SEE IT IN ACTION / demo video -->
+  <section id="demo">
+    <p class="eyebrow">See it in action</p>
+    <h2>Watch it work — in 3 minutes.</h2>
+    <p class="lead">A real walkthrough: dictating a full build into Claude Code by voice, the settings tour, per-app profiles, and going 100% offline.</p>
+    <style>
+      .vid{position:relative;max-width:760px;margin:38px auto 0;aspect-ratio:16/9;border-radius:14px;overflow:hidden;
+        border:1px solid var(--border);box-shadow:0 24px 70px rgba(0,0,0,.5);cursor:pointer;background:var(--deep)}
+      .vid img{width:100%;height:100%;object-fit:cover;display:block;opacity:.82;transition:opacity .2s}
+      .vid:hover img{opacity:1}
+      .vid .vplay{position:absolute;inset:0;margin:auto;width:74px;height:74px;border:none;border-radius:50%;
+        display:flex;align-items:center;justify-content:center;background:var(--accent);color:#1a0c0d;
+        font-size:24px;padding-left:5px;cursor:pointer;box-shadow:var(--glow);transition:transform .15s}
+      .vid:hover .vplay{transform:scale(1.06)}
+      .vid iframe{width:100%;height:100%;border:0;display:block}
+      .vid:focus-visible{outline:2px solid var(--accent);outline-offset:3px}
+    </style>
+    <div class="vid" id="pv-demo" role="button" tabindex="0"
+         aria-label="Play the 3-minute PipeVoice demo video"
+         onclick="pvPlayDemo()" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();pvPlayDemo()}">
+      <img src="https://img.youtube.com/vi/3DZJbwTmcGU/maxresdefault.jpg"
+           onerror="this.onerror=null;this.src='https://img.youtube.com/vi/3DZJbwTmcGU/hqdefault.jpg'"
+           alt="Watch the PipeVoice demo" loading="lazy" width="760" height="428" />
+      <span class="vplay" aria-hidden="true">▶</span>
+    </div>
+    <script>
+      function pvPlayDemo(){var d=document.getElementById('pv-demo');
+        d.innerHTML='<iframe src="https://www.youtube.com/embed/3DZJbwTmcGU?autoplay=1&rel=0" title="PipeVoice demo" allow="autoplay; encrypted-media; picture-in-picture; fullscreen" allowfullscreen></iframe>';
+        d.style.cursor='default';}
+    </script>
+  </section>
 
   <!-- WHY / honest comparison -->
   <section id="why">

--- a/wisprlitevercel/index.html
+++ b/wisprlitevercel/index.html
@@ -330,7 +330,7 @@
     </div>
     <script>
       function pvPlayDemo(){var d=document.getElementById('pv-demo');
-        d.innerHTML='<iframe src="https://www.youtube.com/embed/3DZJbwTmcGU?autoplay=1&rel=0" title="PipeVoice demo" allow="autoplay; encrypted-media; picture-in-picture; fullscreen" allowfullscreen></iframe>';
+        d.innerHTML='<iframe src="https://www.youtube-nocookie.com/embed/3DZJbwTmcGU?autoplay=1&rel=0" title="PipeVoice demo" allow="autoplay; encrypted-media; picture-in-picture; fullscreen" allowfullscreen></iframe>';
         d.style.cursor='default';}
     </script>
   </section>

--- a/wisprlitevercel/vercel.json
+++ b/wisprlitevercel/vercel.json
@@ -11,7 +11,7 @@
         { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
         { "key": "Strict-Transport-Security", "value": "max-age=63072000; includeSubDomains; preload" },
         { "key": "Permissions-Policy", "value": "geolocation=(), microphone=(), camera=(), interest-cohort=()" },
-        { "key": "Content-Security-Policy", "value": "default-src 'self'; base-uri 'self'; object-src 'none'; img-src 'self' data:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; script-src 'self' 'unsafe-inline'; connect-src 'self'; frame-ancestors 'none'; form-action 'self'" }
+        { "key": "Content-Security-Policy", "value": "default-src 'self'; base-uri 'self'; object-src 'none'; img-src 'self' data: https://img.youtube.com https://i.ytimg.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; script-src 'self' 'unsafe-inline'; connect-src 'self'; frame-src https://www.youtube-nocookie.com; frame-ancestors 'none'; form-action 'self'" }
       ]
     }
   ]


### PR DESCRIPTION
Applies the competitor-research GTM learnings to the two surfaces that convert visitors → stars/downloads, and embeds the new 3-min explainer ([youtu.be/3DZJbwTmcGU](https://youtu.be/3DZJbwTmcGU)).

## README (complete rewrite for stars + SEO)
Drafted from a **frame-by-frame read of the explainer video** (10 agents transcribed all 60 frames' on-screen text → timeline → draft), so it mirrors your actual taglines, then corrected to the *shipped defaults* (the video showed your personal config):
- Video thumbnail hero + shields badges (stars/release/MIT/Windows/PRs).
- "Free, open-source, Windows-first **alternative to Wispr Flow**" star-bait framing.
- Scannable feature list, engines table, **honest 3-way comparison** (PipeVoice / Wispr Flow / Voicebox — leads on no-GPU/streaming/light/focused; does **not** repeat the refuted "Voicebox Windows paste is weak" claim).
- Dead-simple quickstart, a "**dictate into Claude Code / Cursor**" dev hook, keyword-rich FAQ (Google + GitHub search), a clear **⭐ Star** CTA, contributing.
- Corrected: clipboard hotkey `right ctrl+right shift`, local model `base.en` (not the video's `ctrl+shift`/`small.en`). **No fabricated stars/testimonials/ratings.**
- Suggested repo topics (to add in repo settings): `voice-typing, speech-to-text, dictation, windows, wispr-flow-alternative, whisper, deepgram, voice-coding, claude-code, offline-speech-to-text, ...`

## Homepage (`index.html`)
- New **"See it in action"** section right after the hero: **lazy click-to-play** YouTube embed (poster image → iframe only on click, so zero YouTube JS on load = no LCP hit; accessible button/keyboard; thumbnail fallback if `maxresdefault` 404s).
- **VideoObject JSON-LD** added (video rich-result eligibility — an SEO win).
- Embed uses **`youtube-nocookie.com`** (no cookies until play — fits the privacy brand).

## ⚠️ Codex caught a production-only bug (fixed in this PR)
The site CSP in `vercel.json` (`img-src 'self' data:`, no `frame-src`) would have **blocked the YouTube thumbnail + iframe on the live site** — the section worked locally but would've been broken in prod. Fixed: CSP now allows `img.youtube.com`/`i.ytimg.com` (img-src) + `youtube-nocookie.com` (frame-src).

## Verify after deploy
- [ ] On the live site, the demo poster loads and clicking it plays the video (CSP allows it now).
- [ ] Confirm `maxresdefault.jpg` exists for the video (else the `hqdefault` fallback kicks in).
- [ ] Add the suggested topics in GitHub repo settings (topics aren't set via README).

Site changes deploy on merge (git-connected Vercel `pipevoice` project → pipevoice.app). README is just the repo file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)