### PR TITLE
feat: screen recorder — record a bug, narrate it, land it in an agent's inbox

### DIFF
--- a/build_exe.bat
+++ b/build_exe.bat
@@ -12,6 +12,7 @@ pyinstaller --noconfirm --clean --noconsole --onedir --noupx --name Pipevoice ^
     --collect-all deepgram ^
     --collect-all faster_whisper ^
     --collect-all ctranslate2 ^
+    --collect-all mss ^
     --collect-all pystray ^
     --collect-all PIL ^
     --collect-all mcp ^

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,11 @@ openai>=1.30          # OpenAI Whisper API (default engine)
 deepgram-sdk>=3,<4     # Deepgram streaming (v4+ changed the API; pin to v3)
 faster-whisper>=1.0   # Local/offline Whisper (no internet needed)
 
+# --- Screen recorder ---
+mss>=9.0              # grabs a screen region; ~0.1 MB
+# H.264 encoding uses PyAV, which faster-whisper already pulls in (av>=11) and
+# whose wheels ship libx264 — so the encoder costs nothing extra in the build.
+
 # --- UI niceties ---
 pystray>=0.19         # system tray icon + menu
 Pillow>=10.0          # renders the tray icon

--- a/tests/test_meeting.py
+++ b/tests/test_meeting.py
@@ -213,6 +213,32 @@ def test_late_checkpoint_does_not_overwrite_final_meta():
         assert meta["duration_seconds"] == 1800.0
 
 
+def test_meta_records_the_dropped_block_count():
+    """The count is the only on-disk proof the writer kept up.
+
+    A recording whose wav ends short of the clock is ambiguous — device-open
+    latency and dropped audio look identical — unless this number is saved.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        session = pathlib.Path(tmp) / "meeting-drops"
+        session.mkdir()
+        recorder = MeetingRecorder(pathlib.Path(tmp))
+        recorder.session_dir = session
+        recorder._started_at = "2026-07-27T12:00:00+00:00"
+
+        recorder._write_meta(stopped_at=None, duration=1.0)
+        assert json.loads((session / "meta.json").read_text(encoding="utf-8"))[
+            "dropped_blocks"
+        ] == 0
+
+        for _ in range(meeting.PCM_QUEUE_LIMIT + 3):
+            recorder._enqueue("mic", np.zeros((1, 1), dtype=np.float32))
+        recorder._write_meta(stopped_at="2026-07-27T12:00:02+00:00", duration=2.0)
+
+        meta = json.loads((session / "meta.json").read_text(encoding="utf-8"))
+        assert meta["dropped_blocks"] == 3
+
+
 def test_recoverable_overflow_is_not_persisted_as_session_error():
     with tempfile.TemporaryDirectory() as tmp:
         session = pathlib.Path(tmp) / "meeting-overflow"

--- a/tests/test_screenrec.py
+++ b/tests/test_screenrec.py
@@ -467,3 +467,18 @@ def test_a_long_recording_does_not_hold_every_frame_in_memory():
             f"grew {peak_growth/1e6:.1f} MB over 240 frames; "
             f"buffering them all would be {raw_size/1e6:.1f} MB")
         rec._mux()
+
+
+@pytest.mark.parametrize("value,expected", [(0, "+0"), (1920, "+1920"), (-1920, "-1920")])
+def test_a_negative_monitor_origin_makes_valid_tk_geometry(value, expected):
+    """f"+{-1920}" gives "+-1920", which Tk rejects — so the selector would not
+    open at all on a monitor placed left of the primary."""
+    assert screenrec._offset(value) == expected
+
+
+def test_shutdown_waits_longer_than_an_upload_can_take():
+    from wisprlite import app as app_module
+
+    source = pathlib.Path(app_module.__file__).read_text()
+    assert "screenrec.UPLOAD_TIMEOUT + 60.0" in source
+    assert screenrec.UPLOAD_TIMEOUT >= 300.0

--- a/tests/test_screenrec.py
+++ b/tests/test_screenrec.py
@@ -1,0 +1,326 @@
+"""Screen recorder: the mp4 it produces, and the scp that delivers it.
+
+No display is needed for any of this. Frame grabbing is the one part that needs
+a real screen, so these tests hand the muxer frames directly — which is also the
+part that would silently produce an unplayable file.
+"""
+
+import pathlib
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import wave
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent))
+
+from wisprlite import screenrec
+
+av = pytest.importorskip("av", reason="PyAV ships with faster-whisper")
+
+REGION = (0, 0, 320, 240)
+
+
+def _recording(tmp, **kwargs):
+    return screenrec.ScreenRecording(REGION, pathlib.Path(tmp), **kwargs)
+
+
+def _frames(count, width=320, height=240):
+    """Frames that actually differ, so a broken encoder cannot look fine."""
+    out = []
+    for index in range(count):
+        frame = np.zeros((height, width, 3), dtype=np.uint8)
+        frame[:, :, index % 3] = 40 + (index * 7) % 200
+        out.append(frame)
+    return out
+
+
+def _write_wav(path, seconds=1.0):
+    samples = (np.sin(np.linspace(0, 220 * 2 * np.pi, int(screenrec.AUDIO_RATE * seconds)))
+               * 12000).astype("<i2")
+    with wave.open(str(path), "wb") as handle:
+        handle.setparams((1, 2, screenrec.AUDIO_RATE, 0, "NONE", "not compressed"))
+        handle.writeframes(samples.tobytes())
+
+
+# -- the mp4 ----------------------------------------------------------------
+
+def test_it_produces_an_mp4_that_decodes_back_to_the_frames_put_in():
+    """"It wrote a file" is not the bar. It has to decode."""
+    with tempfile.TemporaryDirectory() as tmp:
+        rec = _recording(tmp, fps=10)
+        rec._frames = _frames(20)
+        rec.frames_written = 20
+        _write_wav(rec.audio_path, seconds=2.0)
+
+        out = rec._mux()
+
+        assert out is not None and out.exists(), rec.errors
+        with av.open(str(out)) as container:
+            video = container.streams.video[0]
+            assert (video.codec_context.width, video.codec_context.height) == (320, 240)
+            decoded = sum(1 for _ in container.decode(video=0))
+        assert decoded == 20, f"put in 20 frames, got {decoded} back"
+
+
+def test_the_narration_survives_into_the_mp4():
+    with tempfile.TemporaryDirectory() as tmp:
+        rec = _recording(tmp, fps=10)
+        rec._frames = _frames(10)
+        rec.frames_written = 10
+        _write_wav(rec.audio_path, seconds=1.0)
+
+        out = rec._mux()
+
+        with av.open(str(out)) as container:
+            assert container.streams.audio, "no audio stream — the narration is the feedback"
+            samples = sum(f.samples for f in container.decode(audio=0))
+        # AAC pads, so this is "roughly a second of audio", not an exact count.
+        assert samples > screenrec.AUDIO_RATE * 0.8, samples
+
+
+def test_a_recording_with_no_audio_still_produces_a_playable_video():
+    """A muted mic must not cost you the recording."""
+    with tempfile.TemporaryDirectory() as tmp:
+        rec = _recording(tmp, fps=10)
+        rec._frames = _frames(8)
+        rec.frames_written = 8
+
+        out = rec._mux()
+
+        assert out is not None and out.exists(), rec.errors
+        with av.open(str(out)) as container:
+            assert sum(1 for _ in container.decode(video=0)) == 8
+
+
+def test_an_odd_sized_region_is_rounded_down_not_up():
+    """yuv420p needs even dimensions, and rounding UP would capture pixels
+    outside the box the user drew."""
+    with tempfile.TemporaryDirectory() as tmp:
+        rec = screenrec.ScreenRecording((10, 20, 321, 241), pathlib.Path(tmp))
+        assert rec.region == (10, 20, 320, 240)
+
+
+def test_capturing_nothing_reports_it_instead_of_writing_a_broken_file():
+    with tempfile.TemporaryDirectory() as tmp:
+        rec = _recording(tmp)
+        rec._stop.set()
+        assert rec.stop() is None
+        assert any("no frames" in e for e in rec.errors), rec.errors
+        assert not rec.video_path.exists()
+
+
+# -- the audio callback -----------------------------------------------------
+
+def test_the_mic_callback_does_not_block_on_the_held_wave_lock():
+    """Same rule as meeting capture: whatever the callback does not finish in
+    time is audio Windows throws away."""
+    with tempfile.TemporaryDirectory() as tmp:
+        rec = _recording(tmp)
+        block = np.full((800, 1), 0.25, dtype=np.float32)
+
+        holding, release = threading.Event(), threading.Event()
+
+        def hold():
+            with rec._wave_lock:
+                holding.set()
+                release.wait(2.0)
+
+        holder = threading.Thread(target=hold, daemon=True)
+        holder.start()
+        assert holding.wait(2.0)
+
+        started = time.monotonic()
+        for _ in range(20):
+            rec._on_mic_block(block, 800, None, None)
+        elapsed = time.monotonic() - started
+
+        release.set()
+        holder.join(timeout=2.0)
+        assert elapsed < 0.25, f"callback blocked for {elapsed:.3f}s"
+
+
+def test_the_mic_callback_copies_the_buffer_it_is_handed():
+    with tempfile.TemporaryDirectory() as tmp:
+        rec = _recording(tmp)
+        rec.start_wave_for_test = None
+        rec._wave = wave.open(str(rec.audio_path), "wb")
+        rec._wave.setparams((1, 2, screenrec.AUDIO_RATE, 0, "NONE", "not compressed"))
+
+        reused = np.full((800, 1), 0.5, dtype=np.float32)
+        rec._on_mic_block(reused, 800, None, None)
+        reused[:] = -0.5                     # PortAudio refilling its buffer
+        rec._drain_audio()
+        rec._wave.close()
+
+        with wave.open(str(rec.audio_path), "rb") as handle:
+            first = np.frombuffer(handle.readframes(1), dtype="<i2")[0]
+        assert first > 0, f"queued a live view, not a copy (got {first})"
+
+
+def test_a_full_queue_drops_a_block_rather_than_stalling_the_callback():
+    with tempfile.TemporaryDirectory() as tmp:
+        rec = _recording(tmp)
+        block = np.full((800, 1), 0.25, dtype=np.float32)
+        for _ in range(screenrec.AUDIO_QUEUE_LIMIT + 3):
+            rec._on_mic_block(block, 800, None, None)
+        assert rec.dropped_audio_blocks == 3
+
+
+# -- delivery ---------------------------------------------------------------
+
+def _touch(tmp, name):
+    path = pathlib.Path(tmp) / name
+    path.write_bytes(b"x")
+    return path
+
+
+def test_it_refuses_to_send_with_no_destination_configured():
+    with tempfile.TemporaryDirectory() as tmp:
+        ok, message = screenrec.send([_touch(tmp, "a.mp4")], "")
+        assert not ok and "destination" in message
+
+
+def test_it_reports_a_failed_upload_instead_of_claiming_success():
+    """The recording must never be presented as delivered when it was not."""
+    with tempfile.TemporaryDirectory() as tmp:
+        result = subprocess.CompletedProcess(
+            [], 255, stdout="", stderr="ssh: connect to host x port 22: No route to host")
+        with patch.object(screenrec.shutil, "which", return_value="/usr/bin/scp"), \
+             patch.object(screenrec.subprocess, "run", return_value=result):
+            ok, message = screenrec.send([_touch(tmp, "a.mp4")], "root@x:/inbox/")
+        assert not ok
+        assert "No route to host" in message
+
+
+def test_a_hung_upload_gives_up_rather_than_blocking_forever():
+    with tempfile.TemporaryDirectory() as tmp:
+        with patch.object(screenrec.shutil, "which", return_value="/usr/bin/scp"), \
+             patch.object(screenrec.subprocess, "run",
+                          side_effect=subprocess.TimeoutExpired("scp", 300)):
+            ok, message = screenrec.send([_touch(tmp, "a.mp4")], "root@x:/inbox/", timeout=300)
+        assert not ok and "timed out" in message
+
+
+def test_it_sends_batch_mode_so_a_missing_key_fails_instead_of_hanging():
+    """Without -B, scp prompts for a password that a tray app cannot show."""
+    with tempfile.TemporaryDirectory() as tmp:
+        seen = {}
+
+        def fake_run(cmd, **kwargs):
+            seen["cmd"] = cmd
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        with patch.object(screenrec.shutil, "which", return_value="/usr/bin/scp"), \
+             patch.object(screenrec.subprocess, "run", side_effect=fake_run):
+            ok, _ = screenrec.send([_touch(tmp, "a.mp4")], "root@x:/inbox/")
+
+        assert ok
+        assert "-B" in seen["cmd"], seen["cmd"]
+        assert seen["cmd"][-1] == "root@x:/inbox/"
+
+
+def test_it_sends_the_transcript_alongside_the_video():
+    with tempfile.TemporaryDirectory() as tmp:
+        sent = {}
+
+        def fake_run(cmd, **kwargs):
+            sent["files"] = [c for c in cmd if c.endswith((".mp4", ".txt"))]
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        with patch.object(screenrec.shutil, "which", return_value="/usr/bin/scp"), \
+             patch.object(screenrec.subprocess, "run", side_effect=fake_run):
+            screenrec.send(
+                [_touch(tmp, "a.mp4"), _touch(tmp, "a.txt")], "root@x:/inbox/")
+
+        assert len(sent["files"]) == 2
+
+
+def test_the_colours_that_go_in_are_the_colours_that_come_out():
+    """A BGR/RGB mix-up still decodes 20 frames and still passes a frame count.
+    So check the pixels: red in must not come back blue."""
+    with tempfile.TemporaryDirectory() as tmp:
+        rec = _recording(tmp, fps=10)
+        red = np.zeros((240, 320, 3), dtype=np.uint8); red[:, :, 0] = 220
+        green = np.zeros((240, 320, 3), dtype=np.uint8); green[:, :, 1] = 220
+        rec._frames = [red] * 5 + [green] * 5
+        rec.frames_written = 10
+
+        out = rec._mux()
+
+        with av.open(str(out)) as container:
+            decoded = [f.to_ndarray(format="rgb24") for f in container.decode(video=0)]
+        first = decoded[0].reshape(-1, 3).mean(axis=0)
+        last = decoded[-1].reshape(-1, 3).mean(axis=0)
+        assert first[0] > 200 and first[1] < 20, f"red came back as {first}"
+        assert last[1] > 200 and last[0] < 20, f"green came back as {last}"
+
+
+# -- region selection (needs a display) --------------------------------------
+
+import uistub  # noqa: E402
+
+
+@pytest.mark.skipif(not uistub.have_display(), reason="no display")
+def test_dragging_a_box_returns_that_box():
+    import tkinter as tk
+
+    root = tk.Tk()
+    root.geometry("800x600")
+    root.update_idletasks()
+
+    result = {}
+
+    def drive():
+        top = [w for w in root.winfo_children() if isinstance(w, tk.Toplevel)][0]
+        canvas = top.winfo_children()[0]
+        canvas.event_generate("<Button-1>", x=100, y=80)
+        canvas.event_generate("<B1-Motion>", x=340, y=260)
+        canvas.event_generate("<ButtonRelease-1>", x=340, y=260)
+
+    root.after(300, drive)
+    result["box"] = screenrec.select_region(root)
+    root.destroy()
+
+    assert result["box"] == (100, 80, 240, 180)
+
+
+@pytest.mark.skipif(not uistub.have_display(), reason="no display")
+def test_escape_records_nothing():
+    import tkinter as tk
+
+    root = tk.Tk()
+    root.update_idletasks()
+
+    def drive():
+        top = [w for w in root.winfo_children() if isinstance(w, tk.Toplevel)][0]
+        top.event_generate("<Escape>")
+
+    root.after(300, drive)
+    box = screenrec.select_region(root)
+    root.destroy()
+    assert box is None
+
+
+@pytest.mark.skipif(not uistub.have_display(), reason="no display")
+def test_a_stray_click_is_a_cancel_not_a_tiny_recording():
+    import tkinter as tk
+
+    root = tk.Tk()
+    root.update_idletasks()
+
+    def drive():
+        top = [w for w in root.winfo_children() if isinstance(w, tk.Toplevel)][0]
+        canvas = top.winfo_children()[0]
+        canvas.event_generate("<Button-1>", x=200, y=200)
+        canvas.event_generate("<ButtonRelease-1>", x=203, y=201)
+
+    root.after(300, drive)
+    box = screenrec.select_region(root)
+    root.destroy()
+    assert box is None

--- a/tests/test_screenrec.py
+++ b/tests/test_screenrec.py
@@ -324,3 +324,117 @@ def test_a_stray_click_is_a_cancel_not_a_tiny_recording():
     box = screenrec.select_region(root)
     root.destroy()
     assert box is None
+
+
+# -- naming ------------------------------------------------------------------
+
+def test_the_timestamp_always_leads_so_an_inbox_sorts():
+    assert screenrec.stamped_stem("2026-08-12 10-33-25", "login bug") == \
+        "2026-08-12 10-33-25 login bug"
+
+
+def test_no_name_still_gives_a_timestamped_file():
+    assert screenrec.stamped_stem("2026-08-12 10-33-25", "") == "2026-08-12 10-33-25"
+    assert screenrec.stamped_stem("2026-08-12 10-33-25", "   ") == "2026-08-12 10-33-25"
+
+
+@pytest.mark.parametrize("typed", ['a/b', 'a\\b', 'a:b', 'a*b', 'a?b', 'a"b', 'a<b>', 'a|b'])
+def test_characters_windows_and_scp_reject_are_stripped(typed):
+    cleaned = screenrec.safe_name(typed)
+    assert not (set(cleaned) & set('<>:"/\\|?*')), cleaned
+    assert cleaned
+
+
+def test_a_name_that_windows_would_silently_mangle_is_cleaned():
+    """A trailing dot or space is dropped by Windows, making the file
+    unfindable by the name you typed."""
+    assert screenrec.safe_name("report. ") == "report"
+    assert screenrec.safe_name("...") == ""
+    assert screenrec.safe_name("a\tb\nc") == "a b c"
+
+
+def test_a_very_long_name_is_capped():
+    assert len(screenrec.safe_name("x" * 500)) <= 60
+
+
+def test_renaming_moves_every_file_of_the_recording():
+    with tempfile.TemporaryDirectory() as tmp:
+        rec = _recording(tmp)
+        for suffix in (".mp4", ".wav", ".txt"):
+            (rec.out_dir / f"{rec.stem}{suffix}").write_bytes(b"x")
+
+        rec.rename("2026-08-12 10-33-25 login bug")
+
+        assert rec.video_path.name == "2026-08-12 10-33-25 login bug.mp4"
+        for suffix in (".mp4", ".wav", ".txt"):
+            assert (rec.out_dir / f"2026-08-12 10-33-25 login bug{suffix}").exists()
+
+
+def test_renaming_never_overwrites_an_earlier_recording():
+    with tempfile.TemporaryDirectory() as tmp:
+        rec = _recording(tmp)
+        (rec.out_dir / f"{rec.stem}.mp4").write_bytes(b"new")
+        (rec.out_dir / "login bug.mp4").write_bytes(b"older recording")
+
+        rec.rename("login bug")
+
+        assert (rec.out_dir / "login bug.mp4").read_bytes() == b"older recording"
+        assert rec.video_path.read_bytes() == b"new"
+
+
+def _click(parent, label):
+    """Press the button a user would press."""
+    import tkinter as tk
+
+    def walk(widget):
+        for child in widget.winfo_children():
+            if isinstance(child, tk.Button) and child.cget("text") == label:
+                child.invoke()
+                return True
+            if walk(child):
+                return True
+        return False
+
+    assert walk(parent), f"no {label!r} button"
+
+
+@pytest.mark.skipif(not uistub.have_display(), reason="no display")
+@pytest.mark.parametrize("typed,expected", [("log", "log"), (None, "")])
+def test_the_name_dialog_returns_what_was_typed(typed, expected):
+    """A failsafe closes the dialog no matter what, so a broken driver fails
+    this test instead of hanging the whole run."""
+    import tkinter as tk
+
+    root = tk.Tk()
+    root.update_idletasks()
+
+    def dialogs():
+        return [w for w in root.winfo_children() if isinstance(w, tk.Toplevel)]
+
+    def drive():
+        top = dialogs()[0]
+        if typed is None:
+            _click(top, "Skip")
+            return
+        entries = []
+
+        def walk(widget):
+            for child in widget.winfo_children():
+                if isinstance(child, tk.Entry):
+                    entries.append(child)
+                walk(child)
+
+        walk(top)
+        entries[0].insert("end", typed)
+        _click(top, "Save & send")
+
+    def failsafe():
+        for top in dialogs():
+            top.destroy()
+
+    root.after(300, drive)
+    root.after(4000, failsafe)
+    got = screenrec.ask_name("2026-08-12 10-33-25", root)
+    root.destroy()
+
+    assert got == expected

--- a/tests/test_screenrec.py
+++ b/tests/test_screenrec.py
@@ -376,6 +376,48 @@ def test_renaming_moves_every_file_of_the_recording():
             assert (rec.out_dir / f"2026-08-12 10-33-25 login bug{suffix}").exists()
 
 
+def test_a_failed_rename_puts_every_file_back():
+    """All three files or none.
+
+    A half-rename splits one recording across two names, and video_path is
+    derived from stem, so it would point at a file that is not there.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        rec = _recording(tmp)
+        for suffix in (".mp4", ".wav", ".txt"):
+            (rec.out_dir / f"{rec.stem}{suffix}").write_bytes(b"x")
+        original = rec.stem
+        real_rename = pathlib.Path.rename
+
+        def fail_on_the_wav(self, target):
+            if self.suffix == ".wav":
+                raise OSError("locked by another process")
+            return real_rename(self, target)
+
+        with patch.object(pathlib.Path, "rename", fail_on_the_wav):
+            rec.rename("login bug")
+
+        assert rec.stem == original
+        for suffix in (".mp4", ".wav", ".txt"):
+            assert (rec.out_dir / f"{original}{suffix}").exists()
+            assert not (rec.out_dir / f"login bug{suffix}").exists()
+        assert rec.video_path.exists()
+
+
+def test_renaming_will_not_clobber_a_wav_whose_mp4_is_gone():
+    """The collision check has to cover every suffix, not just the video."""
+    with tempfile.TemporaryDirectory() as tmp:
+        rec = _recording(tmp)
+        (rec.out_dir / f"{rec.stem}.mp4").write_bytes(b"new")
+        (rec.out_dir / f"{rec.stem}.wav").write_bytes(b"new audio")
+        (rec.out_dir / "login bug.wav").write_bytes(b"older narration")
+
+        rec.rename("login bug")
+
+        assert (rec.out_dir / "login bug.wav").read_bytes() == b"older narration"
+        assert rec.video_path.exists()
+
+
 def test_renaming_never_overwrites_an_earlier_recording():
     with tempfile.TemporaryDirectory() as tmp:
         rec = _recording(tmp)

--- a/tests/test_screenrec.py
+++ b/tests/test_screenrec.py
@@ -40,6 +40,16 @@ def _frames(count, width=320, height=240):
     return out
 
 
+def _feed(rec, frames):
+    """Push frames through the real streaming encoder, as the grab loop does."""
+    for frame in frames:
+        with rec._encode_lock:
+            if rec._container is None:
+                rec._open_container(frame.shape[1], frame.shape[0])
+            rec._encode_frame(np.ascontiguousarray(frame))
+        rec.frames_written += 1
+
+
 def _write_wav(path, seconds=1.0):
     samples = (np.sin(np.linspace(0, 220 * 2 * np.pi, int(screenrec.AUDIO_RATE * seconds)))
                * 12000).astype("<i2")
@@ -54,8 +64,7 @@ def test_it_produces_an_mp4_that_decodes_back_to_the_frames_put_in():
     """"It wrote a file" is not the bar. It has to decode."""
     with tempfile.TemporaryDirectory() as tmp:
         rec = _recording(tmp, fps=10)
-        rec._frames = _frames(20)
-        rec.frames_written = 20
+        _feed(rec, _frames(20))
         _write_wav(rec.audio_path, seconds=2.0)
 
         out = rec._mux()
@@ -71,8 +80,7 @@ def test_it_produces_an_mp4_that_decodes_back_to_the_frames_put_in():
 def test_the_narration_survives_into_the_mp4():
     with tempfile.TemporaryDirectory() as tmp:
         rec = _recording(tmp, fps=10)
-        rec._frames = _frames(10)
-        rec.frames_written = 10
+        _feed(rec, _frames(10))
         _write_wav(rec.audio_path, seconds=1.0)
 
         out = rec._mux()
@@ -88,8 +96,7 @@ def test_a_recording_with_no_audio_still_produces_a_playable_video():
     """A muted mic must not cost you the recording."""
     with tempfile.TemporaryDirectory() as tmp:
         rec = _recording(tmp, fps=10)
-        rec._frames = _frames(8)
-        rec.frames_written = 8
+        _feed(rec, _frames(8))
 
         out = rec._mux()
 
@@ -248,8 +255,7 @@ def test_the_colours_that_go_in_are_the_colours_that_come_out():
         rec = _recording(tmp, fps=10)
         red = np.zeros((240, 320, 3), dtype=np.uint8); red[:, :, 0] = 220
         green = np.zeros((240, 320, 3), dtype=np.uint8); green[:, :, 1] = 220
-        rec._frames = [red] * 5 + [green] * 5
-        rec.frames_written = 10
+        _feed(rec, [red] * 5 + [green] * 5)
 
         out = rec._mux()
 
@@ -438,3 +444,26 @@ def test_the_name_dialog_returns_what_was_typed(typed, expected):
     root.destroy()
 
     assert got == expected
+
+
+def test_a_long_recording_does_not_hold_every_frame_in_memory():
+    """A 1080p raw frame is 6 MB. Buffering a minute at 12 fps is ~4.5 GB, so
+    the recording dies before producing anything. Memory must stay flat."""
+    import tracemalloc
+
+    with tempfile.TemporaryDirectory() as tmp:
+        rec = _recording(tmp, fps=12)
+        frame = np.random.randint(0, 255, (480, 854, 3), dtype=np.uint8)
+
+        _feed(rec, [frame] * 12)          # warm the encoder
+        tracemalloc.start()
+        base = tracemalloc.get_traced_memory()[0]
+        _feed(rec, [frame] * 240)         # 20 more seconds
+        peak_growth = tracemalloc.get_traced_memory()[0] - base
+        tracemalloc.stop()
+
+        raw_size = frame.nbytes * 240     # what buffering them would have cost
+        assert peak_growth < raw_size / 10, (
+            f"grew {peak_growth/1e6:.1f} MB over 240 frames; "
+            f"buffering them all would be {raw_size/1e6:.1f} MB")
+        rec._mux()

--- a/tests/test_ui_smoke.py
+++ b/tests/test_ui_smoke.py
@@ -531,3 +531,52 @@ def test_export_with_empty_transcript_reports_status_not_silent_noop():
             assert not errors, f"invoking Export raised: {errors}"
     finally:
         tk.Tk.report_callback_exception = real_report
+
+
+def test_the_screen_recorder_settings_are_actually_on_screen():
+    """A card that exists in the source but never gets packed is invisible.
+
+    build_window destroys the root before returning, so this walks the tree
+    from inside its own stub mainloop, while the widgets still exist.
+    """
+    _skip_if_headless()
+    install_platform_stubs()
+    import os
+    import tkinter as tk
+    from wisprlite import settings
+
+    os.environ["PV_TAB"] = "Settings"
+    found: list[str] = []
+    real_mainloop = tk.Misc.mainloop
+
+    def walk(widget):
+        for child in widget.winfo_children():
+            try:
+                text = child.cget("text")
+            except Exception:
+                text = ""
+            if text:
+                found.append(str(text))
+            walk(child)
+
+    def stub_mainloop(self, _n=0):
+        try:
+            self.update_idletasks()
+            self.update()
+            walk(self)
+        finally:
+            try:
+                self.destroy()
+            except Exception:
+                pass
+
+    tk.Misc.mainloop = stub_mainloop
+    try:
+        settings.main()
+    finally:
+        tk.Misc.mainloop = real_mainloop
+
+    joined = " | ".join(found)
+    for wanted in ("Screen recording hotkey", "Screen recordings", "Send to",
+                   "Keep a local copy after sending"):
+        assert wanted in joined, f"{wanted!r} was never mounted"

--- a/tests/test_ui_smoke.py
+++ b/tests/test_ui_smoke.py
@@ -582,6 +582,58 @@ def test_the_screen_recorder_settings_are_actually_on_screen():
         assert wanted in joined, f"{wanted!r} was never mounted"
 
 
+def test_quitting_does_not_open_the_naming_dialog():
+    """Quit must still finish the recording, but never wait on a modal.
+
+    ask_name() blocks on wait_window. On the shutdown path nobody is looking at
+    a window that is already closing, so the dialog would hold the quit open
+    until it was hunted down and dismissed.
+    """
+    import types
+    from unittest import mock
+    from wisprlite.app import App
+    from wisprlite import screenrec
+
+    app = App.__new__(App)
+    recording = types.SimpleNamespace(
+        stem="2026-08-12 10-33-25",
+        errors=[],
+        stop=lambda: pathlib.Path("2026-08-12 10-33-25.mp4"),
+        audio_path=pathlib.Path("nope.wav"),
+    )
+    app._screenrec = recording
+    app.overlay = mock.Mock()
+    app.cfg = types.SimpleNamespace(screenrec_destination="", screenrec_keep_local=True)
+    app._fail = mock.Mock()
+    app._transcribe_recording = mock.Mock(return_value=None)
+
+    with mock.patch.object(screenrec, "ask_name") as ask:
+        App._finish_screen_recording(app, ask=False)
+        assert not ask.called, "shutdown must not open a modal that waits for input"
+
+    app._screenrec = recording
+    with mock.patch.object(screenrec, "ask_name", return_value="") as ask:
+        App._finish_screen_recording(app)
+        assert ask.called, "the normal stop path still asks for a name"
+
+    # And prove quit() is the caller that passes it — asserting on the method
+    # in isolation would pass just as happily if quit() never set the flag.
+    quitting = App.__new__(App)
+    quitting._screenrec = recording
+    quitting._screenrec_finishing = None
+    quitting._stop = mock.Mock()
+    quitting._voice_mgrs, quitting._picker_mgr = [], None
+    quitting._meeting_active = False
+    for name in ("stop_mcp_bridge", "hotkeys", "clip_hotkeys", "meeting_hotkeys",
+                 "screenrec_hotkeys", "bookmark_hotkeys", "overlay", "tray"):
+        setattr(quitting, name, mock.Mock())
+    quitting._finish_screen_recording = mock.Mock()
+
+    App.quit(quitting)
+
+    quitting._finish_screen_recording.assert_called_once_with(ask=False)
+
+
 def test_pausing_pipevoice_also_stops_screen_recording():
     """Screen + mic is the most invasive capture in the app. Pausing must block
     a new one — while still letting a running one be stopped.

--- a/tests/test_ui_smoke.py
+++ b/tests/test_ui_smoke.py
@@ -580,3 +580,23 @@ def test_the_screen_recorder_settings_are_actually_on_screen():
     for wanted in ("Screen recording hotkey", "Screen recordings", "Send to",
                    "Keep a local copy after sending"):
         assert wanted in joined, f"{wanted!r} was never mounted"
+
+
+def test_pausing_pipevoice_also_stops_screen_recording():
+    """Screen + mic is the most invasive capture in the app. Pausing must block
+    a new one — while still letting a running one be stopped.
+
+    Calls the REAL predicate the HotkeyManager is given, not a copy of it.
+    """
+    from wisprlite.app import App
+
+    app = App.__new__(App)
+
+    app.paused, app._screenrec = True, None
+    assert App._screen_recording_paused(app) is True, "paused must block a new recording"
+
+    app.paused, app._screenrec = True, object()
+    assert App._screen_recording_paused(app) is False, "a running one must still stop"
+
+    app.paused, app._screenrec = False, None
+    assert App._screen_recording_paused(app) is False

--- a/wisprlite/__init__.py
+++ b/wisprlite/__init__.py
@@ -1,3 +1,3 @@
 """Pipevoice — push-to-talk voice typing for Windows."""
 
-__version__ = "2.36.0"
+__version__ = "2.37.0"

--- a/wisprlite/app.py
+++ b/wisprlite/app.py
@@ -515,7 +515,14 @@ class App:
         finally:
             self._screenrec_selecting = False
 
-    def _finish_screen_recording(self) -> None:
+    def _finish_screen_recording(self, ask: bool = True) -> None:
+        """Mux, transcribe and send. `ask=False` skips the naming dialog.
+
+        Shutdown passes ask=False: a modal that waits for input is the one
+        thing quitting must not do. Nobody is looking at a window that is in
+        the middle of closing, so it would hang the quit until the dialog is
+        found and dismissed. The recording keeps its timestamp name.
+        """
         from . import screenrec
 
         recording, self._screenrec = self._screenrec, None
@@ -531,7 +538,7 @@ class App:
             # Named AFTER the fact: the moment you want to hit record is the
             # wrong moment to be filling in a form. The timestamp always leads
             # so an inbox full of these still sorts.
-            typed = screenrec.ask_name(recording.stem)
+            typed = screenrec.ask_name(recording.stem) if ask else ""
             if typed:
                 recording.rename(screenrec.stamped_stem(recording.stem, typed))
                 video = recording.video_path
@@ -994,7 +1001,7 @@ class App:
             # capture threads are daemons, so without this they die with no
             # mux step and leave no playable file at all.
             try:
-                self._finish_screen_recording()
+                self._finish_screen_recording(ask=False)
             except Exception:
                 pass
         finishing = self._screenrec_finishing

--- a/wisprlite/app.py
+++ b/wisprlite/app.py
@@ -987,6 +987,8 @@ class App:
         self.clip_hotkeys.stop()
         self.meeting_hotkeys.stop()
         self.screenrec_hotkeys.stop()
+        from . import screenrec
+
         if self._screenrec is not None:
             # Quitting must not throw away what was already recorded: the
             # capture threads are daemons, so without this they die with no
@@ -999,7 +1001,9 @@ class App:
         if finishing is not None and finishing.is_alive():
             # Already muxing, transcribing or uploading. That work is on a
             # daemon thread, so returning here would kill it mid-file.
-            finishing.join(timeout=120.0)
+            # Must exceed the scp timeout in screenrec.send, or quitting
+            # kills a slow upload that was still perfectly on track.
+            finishing.join(timeout=screenrec.UPLOAD_TIMEOUT + 60.0)
         self.bookmark_hotkeys.stop()
         for m in self._voice_mgrs:
             m.stop()

--- a/wisprlite/app.py
+++ b/wisprlite/app.py
@@ -77,7 +77,7 @@ class App:
             get_mode=lambda: "toggle",
             on_start=self.toggle_screen_recording,
             on_stop=self.toggle_screen_recording,
-            is_paused=lambda: False,
+            is_paused=self._screen_recording_paused,
         )
         self.bookmark_hotkeys = HotkeyManager(
             get_hotkey=lambda: self.cfg.bookmark_hotkey,
@@ -89,6 +89,7 @@ class App:
 
         self._screenrec = None        # the live ScreenRecording, None when idle
         self._screenrec_selecting = False   # the region selector is open
+        self._screenrec_finishing = None    # the thread muxing/sending, if any
         self._armed_voice = None      # a Voice armed by the picker, consumed by the next utterance
         self._voice_mgrs = []         # dedicated voice HotkeyManagers
         self._picker_mgr = None       # the picker HotkeyManager
@@ -461,11 +462,24 @@ class App:
 
     # ---- screen recording ------------------------------------------------
 
+    def _screen_recording_paused(self) -> bool:
+        """Paused means paused.
+
+        Screen + microphone is the most invasive capture this app performs, so
+        it must not be the one that ignores the switch. A recording that is
+        already running can still be STOPPED while paused — otherwise pausing
+        mid-recording would strand it with no way to finish the file.
+        """
+        return bool(self.paused) and self._screenrec is None
+
+
     def toggle_screen_recording(self) -> None:
         """Hotkey once: pick a region and record. Again: stop, transcribe, send."""
         if self._screenrec is not None:
-            threading.Thread(target=self._finish_screen_recording,
-                             name="screenrec-finish", daemon=True).start()
+            thread = threading.Thread(target=self._finish_screen_recording,
+                                      name="screenrec-finish", daemon=True)
+            self._screenrec_finishing = thread
+            thread.start()
             return
         if self._screenrec_selecting:
             # The region selector is already open. A second press is the user
@@ -525,6 +539,10 @@ class App:
             transcript = self._transcribe_recording(recording)
             if transcript is not None:
                 files.append(transcript)
+            # Say so. The transcript is the thing that makes the clip cheap for
+            # an agent to read, and silently shipping without it looks
+            # identical to shipping with it.
+            note = "" if transcript is not None else " (no transcript — check the mic)"
 
             destination = (self.cfg.screenrec_destination or "").strip()
             if destination:
@@ -539,9 +557,9 @@ class App:
                             Path(path).unlink()
                         except OSError:
                             pass
-                self.overlay.show("done", f"\u2713 sent to {destination}")
+                self.overlay.show("done", f"\u2713 sent to {destination}{note}")
             else:
-                self.overlay.show("done", f"\u2713 saved to {video.parent}")
+                self.overlay.show("done", f"\u2713 saved to {video.parent}{note}")
         except Exception as exc:
             self._fail(f"screen recording: {exc}")
 
@@ -977,6 +995,11 @@ class App:
                 self._finish_screen_recording()
             except Exception:
                 pass
+        finishing = self._screenrec_finishing
+        if finishing is not None and finishing.is_alive():
+            # Already muxing, transcribing or uploading. That work is on a
+            # daemon thread, so returning here would kill it mid-file.
+            finishing.join(timeout=120.0)
         self.bookmark_hotkeys.stop()
         for m in self._voice_mgrs:
             m.stop()

--- a/wisprlite/app.py
+++ b/wisprlite/app.py
@@ -505,6 +505,14 @@ class App:
             if video is None:
                 self._fail("screen recording: " + "; ".join(recording.errors[:2]))
                 return
+
+            # Named AFTER the fact: the moment you want to hit record is the
+            # wrong moment to be filling in a form. The timestamp always leads
+            # so an inbox full of these still sorts.
+            typed = screenrec.ask_name(recording.stem)
+            if typed:
+                recording.rename(screenrec.stamped_stem(recording.stem, typed))
+                video = recording.video_path
             files = [video]
             transcript = self._transcribe_recording(recording)
             if transcript is not None:

--- a/wisprlite/app.py
+++ b/wisprlite/app.py
@@ -8,6 +8,7 @@ import logging
 import sys
 import threading
 import time
+from pathlib import Path
 
 from . import autostart, config
 from .audio import Recorder
@@ -71,6 +72,13 @@ class App:
             on_stop=self.toggle_meeting,
             is_paused=lambda: self.paused and not self._meeting_active,
         )
+        self.screenrec_hotkeys = HotkeyManager(
+            get_hotkey=lambda: self.cfg.screenrec_hotkey,
+            get_mode=lambda: "toggle",
+            on_start=self.toggle_screen_recording,
+            on_stop=self.toggle_screen_recording,
+            is_paused=lambda: False,
+        )
         self.bookmark_hotkeys = HotkeyManager(
             get_hotkey=lambda: self.cfg.bookmark_hotkey,
             get_mode=lambda: "ptt",
@@ -79,6 +87,7 @@ class App:
             is_paused=lambda: not self._meeting_active,
         )
 
+        self._screenrec = None        # the live ScreenRecording, None when idle
         self._armed_voice = None      # a Voice armed by the picker, consumed by the next utterance
         self._voice_mgrs = []         # dedicated voice HotkeyManagers
         self._picker_mgr = None       # the picker HotkeyManager
@@ -448,6 +457,100 @@ class App:
             "errors": self._meeting.fatal_errors,
             "bleed": self._meeting.bleed_suspected,
         }
+
+    # ---- screen recording ------------------------------------------------
+
+    def toggle_screen_recording(self) -> None:
+        """Hotkey once: pick a region and record. Again: stop, transcribe, send."""
+        if self._screenrec is not None:
+            threading.Thread(target=self._finish_screen_recording,
+                             name="screenrec-finish", daemon=True).start()
+            return
+        threading.Thread(target=self._begin_screen_recording,
+                         name="screenrec-begin", daemon=True).start()
+
+    def _begin_screen_recording(self) -> None:
+        from . import screenrec
+
+        try:
+            # The overlay would otherwise sit on top of the very thing being
+            # framed, and end up inside the recording.
+            self.overlay.hide()
+            region = screenrec.select_region()
+            if not region:
+                return
+            out_dir = (self.cfg.screenrec_dir or "").strip()
+            recording = screenrec.ScreenRecording(
+                region,
+                Path(out_dir) if out_dir else screenrec.default_output_dir(),
+                fps=self.cfg.screenrec_fps,
+                device=config.device_arg(self.cfg),
+            )
+            recording.start()
+            self._screenrec = recording
+            self.overlay.show("recording", "\u23fa recording — press the hotkey again to stop")
+        except Exception as exc:
+            self._screenrec = None
+            self._fail(f"screen recording: {exc}")
+
+    def _finish_screen_recording(self) -> None:
+        from . import screenrec
+
+        recording, self._screenrec = self._screenrec, None
+        if recording is None:
+            return
+        try:
+            self.overlay.show("thinking", "\u23f9 finishing the recording\u2026")
+            video = recording.stop()
+            if video is None:
+                self._fail("screen recording: " + "; ".join(recording.errors[:2]))
+                return
+            files = [video]
+            transcript = self._transcribe_recording(recording)
+            if transcript is not None:
+                files.append(transcript)
+
+            destination = (self.cfg.screenrec_destination or "").strip()
+            if destination:
+                ok, message = screenrec.send(files, destination)
+                if not ok:
+                    # Never delete on failure, and never claim it arrived.
+                    self._fail(f"kept locally — send failed: {message}")
+                    return
+                if not self.cfg.screenrec_keep_local:
+                    for path in [*files, recording.audio_path]:
+                        try:
+                            Path(path).unlink()
+                        except OSError:
+                            pass
+                self.overlay.show("done", f"\u2713 sent to {destination}")
+            else:
+                self.overlay.show("done", f"\u2713 saved to {video.parent}")
+        except Exception as exc:
+            self._fail(f"screen recording: {exc}")
+
+    def _transcribe_recording(self, recording) -> Path | None:
+        """Narration as text, so the agent reads it instead of decoding frames."""
+        try:
+            from .engines import transcribe as T
+
+            if not recording.audio_path.exists():
+                return None
+            # transcribe_file returns a dict, not a string.
+            result = T.transcribe_file(
+                str(recording.audio_path),
+                model_size=(self.cfg.transcribe_model_size or self.cfg.local_model_size),
+                device=self.cfg.local_device,
+                compute_type=self.cfg.local_compute_type,
+            )
+            text = str((result or {}).get("text") or "").strip()
+            if not text:
+                return None
+            recording.transcript_path.write_text(text, encoding="utf-8")
+            return recording.transcript_path
+        except Exception as exc:
+            log.info("screenrec: transcript failed: %s", exc)
+            return None
 
     def toggle_meeting(self) -> None:
         if self._meeting_active:
@@ -849,6 +952,7 @@ class App:
         self.hotkeys.stop()
         self.clip_hotkeys.stop()
         self.meeting_hotkeys.stop()
+        self.screenrec_hotkeys.stop()
         self.bookmark_hotkeys.stop()
         for m in self._voice_mgrs:
             m.stop()
@@ -1001,6 +1105,7 @@ class App:
         self.hotkeys.start()
         self.clip_hotkeys.start()
         self.meeting_hotkeys.start()
+        self.screenrec_hotkeys.start()
         self.bookmark_hotkeys.start()
         self._start_voice_hotkeys()
         if self.cfg.mcp_enabled:

--- a/wisprlite/app.py
+++ b/wisprlite/app.py
@@ -88,6 +88,7 @@ class App:
         )
 
         self._screenrec = None        # the live ScreenRecording, None when idle
+        self._screenrec_selecting = False   # the region selector is open
         self._armed_voice = None      # a Voice armed by the picker, consumed by the next utterance
         self._voice_mgrs = []         # dedicated voice HotkeyManagers
         self._picker_mgr = None       # the picker HotkeyManager
@@ -466,6 +467,11 @@ class App:
             threading.Thread(target=self._finish_screen_recording,
                              name="screenrec-finish", daemon=True).start()
             return
+        if self._screenrec_selecting:
+            # The region selector is already open. A second press is the user
+            # trying again, not asking for a second selector on top.
+            return
+        self._screenrec_selecting = True
         threading.Thread(target=self._begin_screen_recording,
                          name="screenrec-begin", daemon=True).start()
 
@@ -492,6 +498,8 @@ class App:
         except Exception as exc:
             self._screenrec = None
             self._fail(f"screen recording: {exc}")
+        finally:
+            self._screenrec_selecting = False
 
     def _finish_screen_recording(self) -> None:
         from . import screenrec
@@ -961,6 +969,14 @@ class App:
         self.clip_hotkeys.stop()
         self.meeting_hotkeys.stop()
         self.screenrec_hotkeys.stop()
+        if self._screenrec is not None:
+            # Quitting must not throw away what was already recorded: the
+            # capture threads are daemons, so without this they die with no
+            # mux step and leave no playable file at all.
+            try:
+                self._finish_screen_recording()
+            except Exception:
+                pass
         self.bookmark_hotkeys.stop()
         for m in self._voice_mgrs:
             m.stop()

--- a/wisprlite/config.py
+++ b/wisprlite/config.py
@@ -191,6 +191,12 @@ class Config:
     meetings_dir: str = ""            # where recordings are stored; blank = machine-local default
     update_channel: str = "stable"    # stable | beta — beta also sees prereleases
     pipefocus: bool = False           # live focus nudges during a meeting (Deepgram only)
+    # Screen recorder — off until a hotkey is set, like meeting capture.
+    screenrec_hotkey: str = ""        # drag a region, record it with narration
+    screenrec_destination: str = ""   # scp target, e.g. root@host:/path/inbox-files/
+    screenrec_keep_local: bool = True # keep the files after a successful send
+    screenrec_dir: str = ""           # blank = %USERPROFILE%\\Videos\\PipeVoice
+    screenrec_fps: int = 12           # pure-python capture; 10-15 is realistic at 1080p
 
     @property
     def meetings_keep(self) -> int:

--- a/wisprlite/meeting.py
+++ b/wisprlite/meeting.py
@@ -1358,6 +1358,11 @@ class MeetingRecorder:
             "duration_seconds": duration,
             "stop_reason": self._stop_reason,
             "recording_pid": os.getpid(),
+            # Blocks the writer could not keep up with. 0 is the whole point:
+            # without it a wav that ends a second short of the clock cannot be
+            # told apart from a second of device-open latency, and "did the
+            # overflow fix hold?" stays an inference instead of a fact.
+            "dropped_blocks": self.dropped_blocks,
             "sample_rate": SAMPLE_RATE,
             "channels": CHANNELS,
             "mic": {

--- a/wisprlite/screenrec.py
+++ b/wisprlite/screenrec.py
@@ -1,0 +1,407 @@
+"""Record a region of the screen with narration, then hand it to an agent.
+
+The point is a bug report you can SHOW: drag a box round the thing, say what is
+wrong, and have the clip land in the working directory of whatever coding agent
+is on the other end of your SSH session.
+
+Nothing here runs unless the user sets a hotkey.
+
+Two writers, muxed at the end, deliberately: one container fed by a frame
+grabber and an audio callback on two different clocks is where this class of
+feature goes wrong, and a crash mid-record still leaves both raw files on disk.
+
+Spec: docs/specs/2026-08-12-screen-recorder.md
+"""
+
+from __future__ import annotations
+
+import logging
+import queue
+import shutil
+import subprocess
+import threading
+import time
+import wave
+from datetime import datetime
+from pathlib import Path
+
+log = logging.getLogger("wisprlite")
+
+AUDIO_RATE = 16_000
+AUDIO_CHANNELS = 1
+AUDIO_WIDTH = 2
+DEFAULT_FPS = 12
+# ~30s of audio in hand before dropping. The mic callback must never block —
+# see feedback_audio_callback_must_not_touch_disk.
+AUDIO_QUEUE_LIMIT = 2_000
+
+
+def default_output_dir() -> Path:
+    return Path.home() / "Videos" / "PipeVoice"
+
+
+def _stamp() -> str:
+    return datetime.now().strftime("%Y-%m-%d %H-%M-%S")
+
+
+class ScreenRecording:
+    """One recording: grabs frames, records the mic, muxes an mp4 at stop.
+
+    `region` is (left, top, width, height) in virtual-desktop coordinates.
+    """
+
+    def __init__(self, region: tuple[int, int, int, int], out_dir: Path,
+                 *, fps: int = DEFAULT_FPS, device=None) -> None:
+        left, top, width, height = region
+        # x264 requires even dimensions for yuv420p. Round DOWN so the capture
+        # never reaches outside the box the user actually drew.
+        self.region = (left, top, width - (width % 2), height - (height % 2))
+        self.fps = max(1, int(fps))
+        self.device = device
+        self.out_dir = Path(out_dir)
+        self.stem = _stamp()
+
+        self._stop = threading.Event()
+        self._threads: list[threading.Thread] = []
+        self._audio_queue: queue.Queue = queue.Queue(maxsize=AUDIO_QUEUE_LIMIT)
+        self._wave: wave.Wave_write | None = None
+        self._wave_lock = threading.Lock()
+        self._mic_stream = None
+        self.errors: list[str] = []
+        self.dropped_audio_blocks = 0
+        self.frames_written = 0
+
+    # -- paths ---------------------------------------------------------------
+
+    @property
+    def video_path(self) -> Path:
+        return self.out_dir / f"{self.stem}.mp4"
+
+    @property
+    def audio_path(self) -> Path:
+        return self.out_dir / f"{self.stem}.wav"
+
+    @property
+    def transcript_path(self) -> Path:
+        return self.out_dir / f"{self.stem}.txt"
+
+    # -- lifecycle -----------------------------------------------------------
+
+    def start(self) -> None:
+        self.out_dir.mkdir(parents=True, exist_ok=True)
+        self._wave = wave.open(str(self.audio_path), "wb")
+        self._wave.setparams(
+            (AUDIO_CHANNELS, AUDIO_WIDTH, AUDIO_RATE, 0, "NONE", "not compressed")
+        )
+        self._threads = [
+            threading.Thread(target=self._grab_loop, name="screenrec-video", daemon=True),
+            threading.Thread(target=self._audio_writer, name="screenrec-audio", daemon=True),
+            threading.Thread(target=self._capture_mic, name="screenrec-mic", daemon=True),
+        ]
+        for thread in self._threads:
+            thread.start()
+
+    def stop(self, timeout: float = 5.0) -> Path | None:
+        """Stop, mux, and return the finished mp4 (None if nothing was captured)."""
+        self._stop.set()
+        for thread in self._threads:
+            thread.join(timeout=timeout)
+        self._close_mic()
+        self._drain_audio()
+        with self._wave_lock:
+            if self._wave is not None:
+                try:
+                    self._wave.close()
+                except Exception as exc:
+                    self._record_error(exc)
+                self._wave = None
+        if not self.frames_written:
+            self._record_error(RuntimeError("no frames captured"))
+            return None
+        return self._mux()
+
+    def _record_error(self, exc: Exception) -> None:
+        message = f"{type(exc).__name__}: {exc}"
+        self.errors.append(message)
+        log.info("screenrec: %s", message)
+
+    # -- video ---------------------------------------------------------------
+
+    def _grab_loop(self) -> None:
+        try:
+            import mss
+            import numpy as np
+
+            left, top, width, height = self.region
+            box = {"left": left, "top": top, "width": width, "height": height}
+            interval = 1.0 / self.fps
+            with mss.mss() as sct:
+                self._frames: list = []
+                next_at = time.monotonic()
+                while not self._stop.is_set():
+                    shot = sct.grab(box)
+                    # BGRA -> RGB, dropping alpha. np.asarray on the raw buffer
+                    # is a view, so copy: the next grab reuses it.
+                    frame = np.array(shot, dtype=np.uint8)[:, :, :3][:, :, ::-1]
+                    self._frames.append(frame.copy())
+                    self.frames_written += 1
+                    next_at += interval
+                    sleep_for = next_at - time.monotonic()
+                    if sleep_for > 0:
+                        if self._stop.wait(sleep_for):
+                            return
+                    else:
+                        # Falling behind: give up the missed slots rather than
+                        # sprinting to catch up and stealing the CPU from the
+                        # thing being demonstrated.
+                        next_at = time.monotonic()
+        except Exception as exc:
+            self._record_error(exc)
+
+    # -- audio ---------------------------------------------------------------
+
+    def _capture_mic(self) -> None:
+        stream = None
+        try:
+            import sounddevice as sd
+
+            stream = sd.InputStream(
+                samplerate=AUDIO_RATE,
+                channels=AUDIO_CHANNELS,
+                dtype="float32",
+                blocksize=800,
+                callback=self._on_mic_block,
+                device=self.device,
+            )
+            self._mic_stream = stream
+            stream.start()
+            while not self._stop.wait(0.25):
+                if not stream.active:
+                    raise RuntimeError("microphone input stream became inactive")
+        except Exception as exc:
+            self._record_error(exc)
+        finally:
+            if stream is not None:
+                for step in (stream.stop, stream.close):
+                    try:
+                        step()
+                    except Exception:
+                        pass
+            self._mic_stream = None
+
+    def _on_mic_block(self, indata, _frames, _time_info, _status) -> None:
+        """Runs on the PortAudio thread. Copy, enqueue, return — nothing else."""
+        try:
+            import numpy as np
+
+            self._audio_queue.put_nowait(
+                np.array(indata, dtype="float32", copy=True)
+            )
+        except queue.Full:
+            self.dropped_audio_blocks += 1
+        except Exception:
+            pass                      # never raise inside the audio callback
+
+    def _audio_writer(self) -> None:
+        while True:
+            try:
+                block = self._audio_queue.get(timeout=0.25)
+            except queue.Empty:
+                if self._stop.is_set():
+                    return
+                continue
+            self._write_audio(block)
+
+    def _drain_audio(self) -> None:
+        while True:
+            try:
+                block = self._audio_queue.get_nowait()
+            except queue.Empty:
+                return
+            self._write_audio(block)
+
+    def _write_audio(self, block) -> None:
+        try:
+            import numpy as np
+
+            data = np.asarray(block, dtype="float32").reshape(-1)
+            pcm = (np.clip(data, -1.0, 1.0) * 32767.0).astype("<i2").tobytes()
+            with self._wave_lock:
+                if self._wave is None:
+                    return
+                self._wave.writeframesraw(pcm)
+        except Exception as exc:
+            self._record_error(exc)
+
+    def _close_mic(self) -> None:
+        stream, self._mic_stream = self._mic_stream, None
+        if stream is not None:
+            try:
+                stream.stop()
+            except Exception:
+                pass
+
+    # -- mux -----------------------------------------------------------------
+
+    def _mux(self) -> Path | None:
+        """Write the frames and the narration into one mp4."""
+        try:
+            import av
+            import numpy as np
+
+            frames = getattr(self, "_frames", [])
+            if not frames:
+                return None
+            height, width = frames[0].shape[:2]
+            container = av.open(str(self.video_path), mode="w")
+            try:
+                video = container.add_stream("libx264", rate=self.fps)
+                video.width, video.height = width, height
+                video.pix_fmt = "yuv420p"
+                # Small enough to send over a phone tether, still readable text.
+                video.options = {"crf": "28", "preset": "veryfast"}
+
+                audio = None
+                samples = self._read_wav()
+                if samples is not None and samples.size:
+                    audio = container.add_stream("aac", rate=AUDIO_RATE)
+                    audio.layout = "mono"
+
+                for frame in frames:
+                    picture = av.VideoFrame.from_ndarray(frame, format="rgb24")
+                    for packet in video.encode(picture):
+                        container.mux(packet)
+                for packet in video.encode():
+                    container.mux(packet)
+
+                if audio is not None:
+                    frame = av.AudioFrame.from_ndarray(
+                        samples.reshape(1, -1), format="s16", layout="mono"
+                    )
+                    frame.sample_rate = AUDIO_RATE
+                    for packet in audio.encode(frame):
+                        container.mux(packet)
+                    for packet in audio.encode():
+                        container.mux(packet)
+            finally:
+                container.close()
+            return self.video_path
+        except Exception as exc:
+            self._record_error(exc)
+            return None
+
+    def _read_wav(self):
+        try:
+            import numpy as np
+
+            with wave.open(str(self.audio_path), "rb") as handle:
+                raw = handle.readframes(handle.getnframes())
+            return np.frombuffer(raw, dtype="<i2")
+        except Exception:
+            return None
+
+
+def send(paths, destination: str, *, timeout: float = 300.0) -> tuple[bool, str]:
+    """scp the files to `destination`. Returns (ok, message).
+
+    Shells out to the scp that ships with Windows so the user's own keys, agent
+    and ~/.ssh/config apply. PipeVoice never reads, stores or transmits a
+    private key — there is nothing here for it to leak.
+
+    -B is batch mode: no key means an immediate failure instead of a hang on an
+    invisible password prompt that nobody can see or answer from a tray app.
+    """
+    files = [str(p) for p in paths if p and Path(p).exists()]
+    if not files:
+        return False, "nothing to send"
+    destination = (destination or "").strip()
+    if not destination:
+        return False, "no destination configured"
+    scp = shutil.which("scp")
+    if not scp:
+        return False, "scp not found — install the Windows OpenSSH client"
+    try:
+        done = subprocess.run(
+            [scp, "-B", *files, destination],
+            capture_output=True, text=True, timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        return False, f"scp timed out after {timeout:g}s"
+    except Exception as exc:
+        return False, f"{type(exc).__name__}: {exc}"
+    if done.returncode != 0:
+        detail = (done.stderr or done.stdout or "").strip().splitlines()
+        return False, detail[-1] if detail else f"scp exited {done.returncode}"
+    return True, f"sent {len(files)} file(s)"
+
+
+def select_region(root=None) -> tuple[int, int, int, int] | None:
+    """Dim the screen, let the user drag a box, return it. Esc / a click cancels.
+
+    Sized to the whole VIRTUAL desktop, not one monitor, so a box can be drawn
+    on any screen and the coordinates still line up with what mss grabs.
+    """
+    import tkinter as tk
+
+    owns_root = root is None
+    if owns_root:
+        root = tk.Tk()
+        root.withdraw()
+
+    top = tk.Toplevel(root)
+    top.overrideredirect(True)
+    top.configure(bg="#000000")
+    try:
+        top.attributes("-alpha", 0.28)
+        top.attributes("-topmost", True)
+    except Exception:
+        pass
+    width = root.winfo_screenwidth()
+    height = root.winfo_screenheight()
+    top.geometry(f"{width}x{height}+0+0")
+
+    canvas = tk.Canvas(top, cursor="crosshair", bg="#000000", highlightthickness=0)
+    canvas.pack(fill="both", expand=True)
+    canvas.create_text(
+        width // 2, 40,
+        text="Drag over what you want to record  ·  Esc to cancel",
+        fill="#e6e8eb", font=("Segoe UI", 15, "bold"),
+    )
+
+    state = {"x": 0, "y": 0, "box": None, "result": None}
+
+    def press(event):
+        state["x"], state["y"] = event.x, event.y
+        if state["box"] is not None:
+            canvas.delete(state["box"])
+        state["box"] = canvas.create_rectangle(
+            event.x, event.y, event.x, event.y, outline="#e06c75", width=2)
+
+    def drag(event):
+        if state["box"] is not None:
+            canvas.coords(state["box"], state["x"], state["y"], event.x, event.y)
+
+    def release(event):
+        left, top_ = min(state["x"], event.x), min(state["y"], event.y)
+        w, h = abs(event.x - state["x"]), abs(event.y - state["y"])
+        # A stray click is a cancel, not a 3x2 recording.
+        state["result"] = (left, top_, w, h) if w >= 16 and h >= 16 else None
+        top.destroy()
+
+    def cancel(_event=None):
+        state["result"] = None
+        top.destroy()
+
+    canvas.bind("<Button-1>", press)
+    canvas.bind("<B1-Motion>", drag)
+    canvas.bind("<ButtonRelease-1>", release)
+    top.bind("<Escape>", cancel)
+    top.focus_force()
+    top.grab_set()
+    top.wait_window()
+    if owns_root:
+        try:
+            root.destroy()
+        except Exception:
+            pass
+    return state["result"]

--- a/wisprlite/screenrec.py
+++ b/wisprlite/screenrec.py
@@ -120,6 +120,25 @@ class ScreenRecording:
             return None
         return self._mux()
 
+    def rename(self, stem: str) -> None:
+        """Give the finished files a new stem, keeping every extension."""
+        stem = (stem or "").strip()
+        if not stem or stem == self.stem:
+            return
+        target = self.out_dir / f"{stem}.mp4"
+        if target.exists():
+            # Never silently overwrite an earlier recording with the same name.
+            stem = f"{stem} ({self.stem})"
+        for suffix in (".mp4", ".wav", ".txt"):
+            source = self.out_dir / f"{self.stem}{suffix}"
+            if source.exists():
+                try:
+                    source.rename(self.out_dir / f"{stem}{suffix}")
+                except OSError as exc:
+                    self._record_error(exc)
+                    return
+        self.stem = stem
+
     def _record_error(self, exc: Exception) -> None:
         message = f"{type(exc).__name__}: {exc}"
         self.errors.append(message)
@@ -397,6 +416,99 @@ def select_region(root=None) -> tuple[int, int, int, int] | None:
     canvas.bind("<ButtonRelease-1>", release)
     top.bind("<Escape>", cancel)
     top.focus_force()
+    top.grab_set()
+    top.wait_window()
+    if owns_root:
+        try:
+            root.destroy()
+        except Exception:
+            pass
+    return state["result"]
+
+
+# Windows forbids these outright; a remote inbox is no place for them either.
+_ILLEGAL = '<>:"/\\|?*'
+
+
+def safe_name(text: str, *, limit: int = 60) -> str:
+    """Turn what the user typed into something both Windows and scp accept."""
+    cleaned = "".join(
+        " " if ch in _ILLEGAL or ord(ch) < 32 else ch
+        for ch in str(text or "")
+    )
+    cleaned = " ".join(cleaned.split())          # collapse runs of whitespace
+    # A name that is only dots is a directory reference, and a trailing dot or
+    # space is silently dropped by Windows, which makes the file unfindable.
+    cleaned = cleaned.strip(". ")
+    return cleaned[:limit].strip()
+
+
+def stamped_stem(stamp: str, name: str = "") -> str:
+    """`<timestamp> <name>` — the timestamp always leads, so the inbox sorts."""
+    clean = safe_name(name)
+    return f"{stamp} {clean}" if clean else stamp
+
+
+def ask_name(default_stamp: str, root=None) -> str | None:
+    """Ask what to call this recording. Returns "" for no name, None to cancel.
+
+    Shown after recording stops, so naming never delays hitting record — the
+    moment you want to capture something is the wrong moment for a form.
+    """
+    import tkinter as tk
+
+    owns_root = root is None
+    if owns_root:
+        root = tk.Tk()
+        root.withdraw()
+
+    top = tk.Toplevel(root)
+    top.title("Name this recording")
+    top.configure(bg="#13151d")
+    top.resizable(False, False)
+
+    wrap = tk.Frame(top, bg="#13151d", padx=24, pady=20)
+    wrap.pack()
+    tk.Label(wrap, text="Name this recording", bg="#13151d", fg="#e5e7eb",
+             font=("Segoe UI", 13, "bold")).pack(anchor="w")
+    tk.Label(wrap, text=f"Saved as  {default_stamp} <name>", bg="#13151d",
+             fg="#94a3b8", font=("Segoe UI", 9)).pack(anchor="w", pady=(2, 12))
+
+    var = tk.StringVar()
+    field = tk.Entry(wrap, textvariable=var, width=38, bg="#1b1e29", fg="#e5e7eb",
+                     insertbackground="#e5e7eb", relief="flat", font=("Segoe UI", 11))
+    field.pack(ipady=6, fill="x")
+    field.focus_set()
+
+    state = {"result": None}
+
+    def save(_event=None):
+        state["result"] = safe_name(var.get())
+        top.destroy()
+
+    def skip(_event=None):
+        state["result"] = ""          # no name, keep the timestamp
+        top.destroy()
+
+    buttons = tk.Frame(wrap, bg="#13151d")
+    buttons.pack(fill="x", pady=(14, 0))
+    tk.Button(buttons, text="Skip", command=skip, bg="#1b1e29", fg="#e5e7eb",
+              relief="flat", padx=14, pady=6, font=("Segoe UI", 9)).pack(side="left")
+    tk.Button(buttons, text="Save & send", command=save, bg="#e06c75", fg="#1a0c0d",
+              relief="flat", padx=16, pady=6,
+              font=("Segoe UI", 9, "bold")).pack(side="right")
+    field.bind("<Return>", save)
+    top.bind("<Escape>", skip)
+    top.protocol("WM_DELETE_WINDOW", skip)
+
+    top.update_idletasks()
+    width, height = top.winfo_width(), top.winfo_height()
+    top.geometry(f"+{(top.winfo_screenwidth() - width) // 2}"
+                 f"+{(top.winfo_screenheight() - height) // 3}")
+    try:
+        top.attributes("-topmost", True)
+    except Exception:
+        pass
     top.grab_set()
     top.wait_window()
     if owns_root:

--- a/wisprlite/screenrec.py
+++ b/wisprlite/screenrec.py
@@ -131,18 +131,31 @@ class ScreenRecording:
         stem = (stem or "").strip()
         if not stem or stem == self.stem:
             return
-        target = self.out_dir / f"{stem}.mp4"
-        if target.exists():
-            # Never silently overwrite an earlier recording with the same name.
+        suffixes = (".mp4", ".wav", ".txt")
+        # Any of the three colliding means the name is taken. Checking only the
+        # .mp4 would silently overwrite an earlier recording's wav or transcript.
+        if any((self.out_dir / f"{stem}{suffix}").exists() for suffix in suffixes):
             stem = f"{stem} ({self.stem})"
-        for suffix in (".mp4", ".wav", ".txt"):
+        done = []
+        for suffix in suffixes:
             source = self.out_dir / f"{self.stem}{suffix}"
-            if source.exists():
-                try:
-                    source.rename(self.out_dir / f"{stem}{suffix}")
-                except OSError as exc:
-                    self._record_error(exc)
-                    return
+            if not source.exists():
+                continue
+            target = self.out_dir / f"{stem}{suffix}"
+            try:
+                source.rename(target)
+            except OSError as exc:
+                # All three files or none. A half-rename splits one recording
+                # across two names and leaves video_path — derived from stem —
+                # pointing at a file that is not there.
+                self._record_error(exc)
+                for moved_target, moved_source in reversed(done):
+                    try:
+                        moved_target.rename(moved_source)
+                    except OSError:
+                        pass
+                return
+            done.append((target, source))
         self.stem = stem
 
     def _record_error(self, exc: Exception) -> None:
@@ -216,6 +229,22 @@ class ScreenRecording:
                         next_at = time.monotonic()
         except Exception as exc:
             self._record_error(exc)
+            if not self.frames_written:
+                # The container was opened but never took a frame, so stop()
+                # skips the mux and leaves an unplayable stub sitting in the
+                # user's Videos folder looking like a recording.
+                with self._encode_lock:
+                    container, self._container = self._container, None
+                    self._video_stream = self._audio_stream = None
+                try:
+                    if container is not None:
+                        container.close()
+                except Exception:
+                    pass
+                try:
+                    self.video_path.unlink()
+                except OSError:
+                    pass
 
     # -- audio ---------------------------------------------------------------
 

--- a/wisprlite/screenrec.py
+++ b/wisprlite/screenrec.py
@@ -34,6 +34,8 @@ DEFAULT_FPS = 12
 # ~30s of audio in hand before dropping. The mic callback must never block —
 # see feedback_audio_callback_must_not_touch_disk.
 AUDIO_QUEUE_LIMIT = 2_000
+# Shutdown waits longer than this, so quitting never kills a live upload.
+UPLOAD_TIMEOUT = 300.0
 
 
 def default_output_dir() -> Path:
@@ -343,7 +345,7 @@ class ScreenRecording:
             return None
 
 
-def send(paths, destination: str, *, timeout: float = 300.0) -> tuple[bool, str]:
+def send(paths, destination: str, *, timeout: float = UPLOAD_TIMEOUT) -> tuple[bool, str]:
     """scp the files to `destination`. Returns (ok, message).
 
     Shells out to the scp that ships with Windows so the user's own keys, agent
@@ -375,6 +377,17 @@ def send(paths, destination: str, *, timeout: float = 300.0) -> tuple[bool, str]
         detail = (done.stderr or done.stdout or "").strip().splitlines()
         return False, detail[-1] if detail else f"scp exited {done.returncode}"
     return True, f"sent {len(files)} file(s)"
+
+
+def _offset(value: int) -> str:
+    """Tk geometry wants `-1920`, not `+-1920`.
+
+    A monitor positioned left of the primary gives a negative origin, and the
+    naive f"+{x}" produces `+-1920`, which raises TclError — so the selector
+    would not open at all on exactly the setup the virtual-desktop handling
+    was added for.
+    """
+    return f"+{value}" if value >= 0 else str(value)
 
 
 def select_region(root=None) -> tuple[int, int, int, int] | None:
@@ -413,7 +426,7 @@ def select_region(root=None) -> tuple[int, int, int, int] | None:
         width, height = desktop["width"], desktop["height"]
     except Exception:
         pass
-    top.geometry(f"{width}x{height}+{origin_x}+{origin_y}")
+    top.geometry(f"{width}x{height}{_offset(origin_x)}{_offset(origin_y)}")
 
     canvas = tk.Canvas(top, cursor="crosshair", bg="#000000", highlightthickness=0)
     canvas.pack(fill="both", expand=True)

--- a/wisprlite/screenrec.py
+++ b/wisprlite/screenrec.py
@@ -67,6 +67,10 @@ class ScreenRecording:
         self._wave: wave.Wave_write | None = None
         self._wave_lock = threading.Lock()
         self._mic_stream = None
+        self._container = None
+        self._video_stream = None
+        self._audio_stream = None
+        self._encode_lock = threading.Lock()
         self.errors: list[str] = []
         self.dropped_audio_blocks = 0
         self.frames_written = 0
@@ -146,7 +150,40 @@ class ScreenRecording:
 
     # -- video ---------------------------------------------------------------
 
+    def _open_container(self, width: int, height: int) -> None:
+        """Open the mp4 and its video stream, ready to take frames one at a time."""
+        import av
+
+        self._container = av.open(str(self.video_path), mode="w")
+        stream = self._container.add_stream("libx264", rate=self.fps)
+        stream.width, stream.height = width, height
+        stream.pix_fmt = "yuv420p"
+        # Small enough to send over a phone tether, still readable text.
+        stream.options = {"crf": "28", "preset": "veryfast"}
+        self._video_stream = stream
+        # Both streams MUST be declared before the first packet is muxed — the
+        # header is written then, and adding a stream afterwards fails with
+        # "Cannot rebase to zero time". The mic is always recorded, so the
+        # audio track is always declared, even if it ends up empty.
+        audio = self._container.add_stream("aac", rate=AUDIO_RATE)
+        audio.layout = "mono"
+        self._audio_stream = audio
+
+    def _encode_frame(self, frame) -> None:
+        import av
+
+        picture = av.VideoFrame.from_ndarray(frame, format="rgb24")
+        for packet in self._video_stream.encode(picture):
+            self._container.mux(packet)
+
     def _grab_loop(self) -> None:
+        """Grab, encode, mux — one frame at a time.
+
+        Frames are NEVER accumulated. A 1080p frame is 6 MB of raw RGB, so a
+        one-minute recording at 12 fps would be about 4.5 GB held in memory
+        waiting to be encoded, and the recording would die before it produced
+        anything. Encoding as they arrive keeps memory flat.
+        """
         try:
             import mss
             import numpy as np
@@ -155,14 +192,15 @@ class ScreenRecording:
             box = {"left": left, "top": top, "width": width, "height": height}
             interval = 1.0 / self.fps
             with mss.mss() as sct:
-                self._frames: list = []
                 next_at = time.monotonic()
                 while not self._stop.is_set():
                     shot = sct.grab(box)
-                    # BGRA -> RGB, dropping alpha. np.asarray on the raw buffer
-                    # is a view, so copy: the next grab reuses it.
+                    # BGRA -> RGB, dropping alpha.
                     frame = np.array(shot, dtype=np.uint8)[:, :, :3][:, :, ::-1]
-                    self._frames.append(frame.copy())
+                    with self._encode_lock:
+                        if self._container is None:
+                            self._open_container(frame.shape[1], frame.shape[0])
+                        self._encode_frame(np.ascontiguousarray(frame))
                     self.frames_written += 1
                     next_at += interval
                     sleep_for = next_at - time.monotonic()
@@ -263,37 +301,22 @@ class ScreenRecording:
     # -- mux -----------------------------------------------------------------
 
     def _mux(self) -> Path | None:
-        """Write the frames and the narration into one mp4."""
+        """Flush the video, add the narration, close the file."""
         try:
             import av
-            import numpy as np
 
-            frames = getattr(self, "_frames", [])
-            if not frames:
+            with self._encode_lock:
+                container, self._container = self._container, None
+                video, self._video_stream = self._video_stream, None
+                audio, self._audio_stream = self._audio_stream, None
+            if container is None:
                 return None
-            height, width = frames[0].shape[:2]
-            container = av.open(str(self.video_path), mode="w")
             try:
-                video = container.add_stream("libx264", rate=self.fps)
-                video.width, video.height = width, height
-                video.pix_fmt = "yuv420p"
-                # Small enough to send over a phone tether, still readable text.
-                video.options = {"crf": "28", "preset": "veryfast"}
-
-                audio = None
-                samples = self._read_wav()
-                if samples is not None and samples.size:
-                    audio = container.add_stream("aac", rate=AUDIO_RATE)
-                    audio.layout = "mono"
-
-                for frame in frames:
-                    picture = av.VideoFrame.from_ndarray(frame, format="rgb24")
-                    for packet in video.encode(picture):
-                        container.mux(packet)
-                for packet in video.encode():
+                for packet in video.encode():          # flush the encoder
                     container.mux(packet)
 
-                if audio is not None:
+                samples = self._read_wav()
+                if audio is not None and samples is not None and samples.size:
                     frame = av.AudioFrame.from_ndarray(
                         samples.reshape(1, -1), format="s16", layout="mono"
                     )
@@ -375,9 +398,22 @@ def select_region(root=None) -> tuple[int, int, int, int] | None:
         top.attributes("-topmost", True)
     except Exception:
         pass
+    # mss reports the union of every monitor as monitors[0]. Tk only knows the
+    # primary screen and origin 0,0, so a display positioned LEFT of the primary
+    # (negative x) could not be covered or selected at all.
+    origin_x, origin_y = 0, 0
     width = root.winfo_screenwidth()
     height = root.winfo_screenheight()
-    top.geometry(f"{width}x{height}+0+0")
+    try:
+        import mss
+
+        with mss.mss() as sct:
+            desktop = sct.monitors[0]
+        origin_x, origin_y = desktop["left"], desktop["top"]
+        width, height = desktop["width"], desktop["height"]
+    except Exception:
+        pass
+    top.geometry(f"{width}x{height}+{origin_x}+{origin_y}")
 
     canvas = tk.Canvas(top, cursor="crosshair", bg="#000000", highlightthickness=0)
     canvas.pack(fill="both", expand=True)
@@ -401,7 +437,8 @@ def select_region(root=None) -> tuple[int, int, int, int] | None:
             canvas.coords(state["box"], state["x"], state["y"], event.x, event.y)
 
     def release(event):
-        left, top_ = min(state["x"], event.x), min(state["y"], event.y)
+        left = min(state["x"], event.x) + origin_x
+        top_ = min(state["y"], event.y) + origin_y
         w, h = abs(event.x - state["x"]), abs(event.y - state["y"])
         # A stray click is a cancel, not a 3x2 recording.
         state["result"] = (left, top_, w, h) if w >= 16 and h >= 16 else None

--- a/wisprlite/settings.py
+++ b/wisprlite/settings.py
@@ -597,6 +597,11 @@ def main(first_run: bool = False) -> None:
     hotkey_var = tk.StringVar(value=cfg.hotkey)
     clip_hotkey_var = tk.StringVar(value=cfg.clipboard_hotkey)
     meeting_hotkey_var = tk.StringVar(value=cfg.meeting_hotkey)
+    screenrec_hotkey_var = tk.StringVar(value=cfg.screenrec_hotkey)
+    screenrec_dest_var = tk.StringVar(value=cfg.screenrec_destination)
+    screenrec_dir_var = tk.StringVar(value=cfg.screenrec_dir)
+    screenrec_keep_var = tk.BooleanVar(value=cfg.screenrec_keep_local)
+    screenrec_fps_var = tk.StringVar(value=str(cfg.screenrec_fps))
     bookmark_hotkey_var = tk.StringVar(value=cfg.bookmark_hotkey)
     bookmark_acoustic_var = tk.BooleanVar(value=cfg.bookmark_acoustic)
     bookmark_sensitivity_var = tk.DoubleVar(value=cfg.bookmark_sensitivity)
@@ -762,6 +767,17 @@ def main(first_run: bool = False) -> None:
     meeting_cap_btn.config(
         command=_mk_capture(meeting_cap_btn, meeting_hotkey_var)
     )
+
+    r = row(
+        c,
+        "Screen recording hotkey",
+        "Tap once to drag a box over what you want to show, and again to stop. "
+        "Records that area plus your microphone.",
+    )
+    entry(r, screenrec_hotkey_var, width=14)
+    screenrec_cap_btn = ttk.Button(r, text="Capture", width=8)
+    screenrec_cap_btn.pack(side="left", padx=(8, 0))
+    screenrec_cap_btn.config(command=_mk_capture(screenrec_cap_btn, screenrec_hotkey_var))
 
     r = row(c, "Bookmark hotkey", "Tap while recording to mark the current moment.")
     entry(r, bookmark_hotkey_var, width=14)
@@ -966,6 +982,26 @@ def main(first_run: bool = False) -> None:
     _pcap.config(command=_mk_capture(_pcap, picker_var))
 
     # --- Audio ---
+    c = card(
+        "Screen recordings",
+        "Show a bug instead of describing it. Recordings are sent with a text "
+        "transcript of what you said, so a coding agent can read it without "
+        "watching the video.",
+    )
+    entry(row(c, "Send to",
+              "An scp destination, e.g. root@your-vps:/root/project/inbox/. Uses the "
+              "SSH keys you already have — Pipevoice never stores one. Leave blank "
+              "to only save locally."),
+          screenrec_dest_var, width=34)
+    entry(row(c, "Save to",
+              "Blank uses your Videos folder."), screenrec_dir_var, width=34)
+    check(c, "Keep a local copy after sending", screenrec_keep_var,
+          "Off deletes the files once they have arrived. A failed send never deletes anything.")
+    entry(row(c, "Frames per second",
+              "10-15 is realistic at 1080p. Higher costs CPU on the machine you are "
+              "recording, which is the same one running what you are showing."),
+          screenrec_fps_var, width=6)
+
     c = card("Audio")
     combo(row(c, "Microphone"), device_var, [lbl for lbl, _ in devices], width=30)
     combo(row(c, "Accent / language", "Pick yours for better accuracy, including non-native accents."),
@@ -1207,6 +1243,14 @@ def main(first_run: bool = False) -> None:
         cfg.hotkey = hotkey_var.get().strip() or "right ctrl"
         cfg.clipboard_hotkey = clip_hotkey_var.get().strip()
         cfg.meeting_hotkey = meeting_hotkey_var.get().strip()
+        cfg.screenrec_hotkey = screenrec_hotkey_var.get().strip()
+        cfg.screenrec_destination = screenrec_dest_var.get().strip()
+        cfg.screenrec_dir = screenrec_dir_var.get().strip()
+        cfg.screenrec_keep_local = bool(screenrec_keep_var.get())
+        try:
+            cfg.screenrec_fps = max(1, min(60, int(screenrec_fps_var.get().strip() or 12)))
+        except ValueError:
+            cfg.screenrec_fps = 12
         cfg.bookmark_hotkey = bookmark_hotkey_var.get().strip()
         cfg.bookmark_acoustic = bool(bookmark_acoustic_var.get())
         cfg.bookmark_phrases = bookmark_phrases_var.get().strip()


### PR DESCRIPTION
## What

Hotkey → drag a region → record it with your narration → hotkey again → name it →
an `.mp4` plus a `.txt` transcript, `scp`'d to a configured destination.

Filenames lead with the timestamp so an inbox sorts by when it happened:
`2026-08-12 10-33-25 login bug.mp4`. Skip the name and you keep the plain stamp.

Off until a hotkey is set, like meeting capture.

Also: `dropped_blocks` is now written to a meeting's `meta.json`. The counter
existed but never left memory, so a wav ending a second short of the recording
clock could not be told apart from device-open latency.

## Cost

+0.1 MB (`mss`). PyAV was already in the installer via faster-whisper and its
wheels carry `libx264`; transport shells out to Windows' own `scp.exe`, so the
user's keys and `~/.ssh/config` apply and PipeVoice never touches a private key.

## Gates

`review-gate` across three rounds, two BLOCKs — all real:

- every frame held in memory (~4.5 GB/min at 1080p); now streaming-encoded
- pause did not pause: screen+mic recording was exempt from the pause switch
- quitting mid-finalise killed the daemon thread mid-mux/upload
- P2s: `+-1920` geometry on a left-hand monitor, shutdown timeout below the
  upload timeout, double selector on a second hotkey press, failed transcript
  reported as a clean "sent"

296 passed, 7 pre-existing failures (missing faster-whisper/deepgram SDKs).

## Not verified

No screen and no mic on the build box: frame rate, `mss` against real Windows
with DPI scaling, a real `scp`, and audio/video sync drift over minutes.
Shipping to the beta ring for exactly that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)