### PR TITLE
feat: Recordings tab, settings beside their feature, and an MCP record_screen tool

### DIFF
--- a/tests/test_ui_smoke.py
+++ b/tests/test_ui_smoke.py
@@ -582,6 +582,162 @@ def test_the_screen_recorder_settings_are_actually_on_screen():
         assert wanted in joined, f"{wanted!r} was never mounted"
 
 
+def test_settings_live_in_the_tab_they_belong_to():
+    """Screen-recording settings under Recordings, meeting settings under Meetings.
+
+    Walking for the text alone is not enough - every tab frame exists in the
+    tree whether or not it is the visible one, so "the widget is somewhere"
+    passes even when a card is packed into the wrong tab. This checks ANCESTRY:
+    the card must share a container with its own tab's intro text, and must not
+    share one with the Settings form.
+    """
+    _skip_if_headless()
+    install_platform_stubs()
+    import os
+    import tkinter as tk
+    from wisprlite import settings
+
+    os.environ["PV_TAB"] = "Settings"
+    seen: dict[str, object] = {}
+    real_mainloop = tk.Misc.mainloop
+
+    def walk(widget):
+        for child in widget.winfo_children():
+            try:
+                text = str(child.cget("text"))
+            except Exception:
+                text = ""
+            if text and text not in seen:
+                seen[text] = child
+            walk(child)
+
+    def stub_mainloop(self, _n=0):
+        try:
+            self.update_idletasks()
+            self.update()
+            walk(self)
+        finally:
+            try:
+                self.destroy()
+            except Exception:
+                pass
+
+    tk.Misc.mainloop = stub_mainloop
+    try:
+        settings.main()
+    finally:
+        tk.Misc.mainloop = real_mainloop
+
+    def find(prefix):
+        for text, widget in seen.items():
+            if text.startswith(prefix):
+                return widget
+        raise AssertionError(f"no widget whose text starts with {prefix!r}")
+
+    def ancestors(widget):
+        chain, node = [], widget
+        while node is not None:
+            chain.append(node)
+            node = getattr(node, "master", None)
+        return chain
+
+    settings_form = set(ancestors(find("Min seconds")))          # still in Advanced
+    recordings_tab = set(ancestors(find("Press your screen recording hotkey")))
+    meetings_tab_frames = set(ancestors(find("Press your meeting hotkey")))
+
+    screenrec_card = set(ancestors(find("Screen recordings")))
+    assert screenrec_card & (recordings_tab - settings_form), \
+        "the screen-recording card is not inside the Recordings tab"
+    assert not (screenrec_card & (settings_form - recordings_tab)), \
+        "the screen-recording card is still in the Settings form"
+
+    meeting_card = set(ancestors(find("Meeting hotkey")))
+    assert meeting_card & (meetings_tab_frames - settings_form), \
+        "the meeting settings are not inside the Meetings tab"
+    assert not (meeting_card & (settings_form - meetings_tab_frames)), \
+        "the meeting settings are still in the Settings form"
+
+    assert "Recordings" in seen, "the Recordings tab button was never mounted"
+
+
+def test_the_settings_link_swaps_the_view_and_swaps_it_back():
+    """Opening settings must hide the browser, and closing must bring it back.
+
+    Packed ABOVE the list instead, the settings shoved it off the bottom and
+    then ran off the bottom themselves — neither usable. And a toggle that only
+    goes one way strands the user in a settings panel with no way out.
+    """
+    _skip_if_headless()
+    install_platform_stubs()
+    import os
+    import tkinter as tk
+    from wisprlite import settings
+
+    os.environ["PV_TAB"] = "Recordings"
+    outcome: dict[str, bool] = {}
+    real_mainloop = tk.Misc.mainloop
+
+    def find_visible_link(widget):
+        for child in widget.winfo_children():
+            try:
+                if str(child.cget("text")).startswith("Settings  ") and child.winfo_ismapped():
+                    return child
+            except Exception:
+                pass
+            found = find_visible_link(child)
+            if found is not None:
+                return found
+        return None
+
+    def find_by_text(widget, prefix):
+        for child in widget.winfo_children():
+            try:
+                if str(child.cget("text")).startswith(prefix):
+                    return child
+            except Exception:
+                pass
+            found = find_by_text(child, prefix)
+            if found is not None:
+                return found
+        return None
+
+    def stub_mainloop(self, _n=0):
+        try:
+            self.update_idletasks()
+            self.update()
+            intro = find_by_text(self, "Press your screen recording hotkey")
+            link = find_visible_link(self)
+            outcome["found_link"] = link is not None
+            outcome["browser_before"] = bool(intro and intro.winfo_ismapped())
+            link.event_generate("<Button-1>")
+            self.update_idletasks()
+            self.update()
+            outcome["browser_hidden"] = not intro.winfo_ismapped()
+            hotkey = find_by_text(self, "Screen recording hotkey")
+            outcome["settings_shown"] = bool(hotkey and hotkey.winfo_ismapped())
+            link.event_generate("<Button-1>")
+            self.update_idletasks()
+            self.update()
+            outcome["browser_back"] = intro.winfo_ismapped()
+        finally:
+            try:
+                self.destroy()
+            except Exception:
+                pass
+
+    tk.Misc.mainloop = stub_mainloop
+    try:
+        settings.main()
+    finally:
+        tk.Misc.mainloop = real_mainloop
+
+    assert outcome.get("found_link"), "no visible Settings link on the Recordings tab"
+    assert outcome.get("browser_before"), "the browser should start visible"
+    assert outcome.get("browser_hidden"), "opening settings must hide the browser"
+    assert outcome.get("settings_shown"), "the settings never became visible"
+    assert outcome.get("browser_back"), "closing settings must restore the browser"
+
+
 def _agent_app(**over):
     """An App shaped just enough to run the agent screen-recording path."""
     import types

--- a/tests/test_ui_smoke.py
+++ b/tests/test_ui_smoke.py
@@ -582,6 +582,114 @@ def test_the_screen_recorder_settings_are_actually_on_screen():
         assert wanted in joined, f"{wanted!r} was never mounted"
 
 
+def _agent_app(**over):
+    """An App shaped just enough to run the agent screen-recording path."""
+    import types
+    from unittest import mock
+    from wisprlite.app import App
+
+    app = App.__new__(App)
+    app._screenrec = None
+    app._screenrec_selecting = False
+    app._screenrec_agent = None
+    app._screenrec_agent_result = None
+    app.paused = False
+    app.overlay = mock.Mock()
+    app._notify = mock.Mock()
+    app._fail = mock.Mock()
+    app.cfg = types.SimpleNamespace(
+        screenrec_hotkey="ctrl+alt+r",
+        screenrec_destination="root@vps:/inbox/",
+        screenrec_keep_local=True,
+    )
+    for k, v in over.items():
+        setattr(app, k, v) if not hasattr(app.cfg, k) else setattr(app.cfg, k, v)
+    return app
+
+
+def test_an_agent_call_never_uploads_the_recording():
+    """The agent gets the local path. Sending it to a remote host is a second,
+    larger act, and the agent asking for a clip did not consent to it."""
+    import threading
+    from unittest import mock
+    from wisprlite.app import App
+    from wisprlite import screenrec
+
+    app = _agent_app()
+    recording = mock.Mock()
+    recording.errors = []
+    recording.stop.return_value = pathlib.Path("/out/2026-08-12 10-00-00.mp4")
+    recording.stem = "2026-08-12 10-00-00"
+    recording.audio_path = pathlib.Path("/out/2026-08-12 10-00-00.wav")
+    app._screenrec = recording
+    app._screenrec_agent = threading.Event()
+    app._transcribe_recording = mock.Mock(return_value=None)
+
+    with mock.patch.object(screenrec, "send") as send, \
+         mock.patch.object(screenrec, "ask_name") as ask:
+        App._finish_screen_recording(app)
+
+    assert not send.called, "an agent-driven recording must never be uploaded"
+    assert not ask.called, "an agent-driven recording must not block on a dialog"
+    assert app._screenrec_agent_result["status"] == "ok"
+    assert app._screenrec_agent_result["uploaded"] is False
+    assert app._screenrec_agent_result["video_path"].endswith(".mp4")
+
+
+def test_an_agent_cannot_record_without_a_way_to_stop_or_while_paused():
+    from unittest import mock
+    from wisprlite.app import App
+
+    paused = _agent_app()
+    paused.paused = True
+    assert App.on_agent_record_screen(paused)["status"] == "error"
+
+    no_hotkey = _agent_app(screenrec_hotkey="")
+    result = App.on_agent_record_screen(no_hotkey)
+    assert result["status"] == "error"
+    assert "hotkey" in result["error"], "must say WHY, not just fail"
+
+    busy = _agent_app()
+    busy._screenrec = object()
+    assert App.on_agent_record_screen(busy)["status"] == "error"
+
+
+def test_esc_during_an_agent_recording_writes_nothing():
+    from unittest import mock
+    from wisprlite.app import App
+
+    app = _agent_app()
+    app._begin_screen_recording = mock.Mock()   # leaves _screenrec None, as Esc does
+
+    result = App.on_agent_record_screen(app, prompt="show me the bug")
+
+    assert result["status"] == "cancelled"
+    app._notify.assert_called_once_with("show me the bug")
+    assert app._screenrec_agent is None, "the waiter must not be left dangling"
+
+
+def test_a_failed_agent_recording_releases_the_caller():
+    """Every early return must wake the agent, or it blocks for its full timeout
+    with no idea what happened."""
+    import threading
+    from unittest import mock
+    from wisprlite.app import App
+
+    app = _agent_app()
+    recording = mock.Mock()
+    recording.errors = ["RuntimeError: no frames were captured"]
+    recording.stop.return_value = None
+    app._screenrec = recording
+    waiter = threading.Event()
+    app._screenrec_agent = waiter
+
+    App._finish_screen_recording(app)
+
+    assert waiter.is_set(), "the agent must be woken even when the recording failed"
+    assert app._screenrec_agent_result["status"] == "error"
+    assert "no frames" in app._screenrec_agent_result["error"]
+
+
 def test_quitting_does_not_open_the_naming_dialog():
     """Quit must still finish the recording, but never wait on a modal.
 
@@ -595,6 +703,8 @@ def test_quitting_does_not_open_the_naming_dialog():
     from wisprlite import screenrec
 
     app = App.__new__(App)
+    app._screenrec_agent = None
+    app._screenrec_agent_result = None
     recording = types.SimpleNamespace(
         stem="2026-08-12 10-33-25",
         errors=[],

--- a/wisprlite/__init__.py
+++ b/wisprlite/__init__.py
@@ -1,3 +1,3 @@
 """Pipevoice — push-to-talk voice typing for Windows."""
 
-__version__ = "2.37.0"
+__version__ = "2.38.0"

--- a/wisprlite/about.py
+++ b/wisprlite/about.py
@@ -154,7 +154,15 @@ def build(container, root, wheel=None) -> None:
                 else:
                     status.config(text="Update failed. Check your connection and try again.", fg=WARN)
                     btn.config(state="normal", text="Try again", command=do_update)
-            root.after(0, done)
+            # Close the window while this check is still in flight and the root
+            # is already gone. Tk then raises "main thread is not in main loop"
+            # from THIS thread - at best a traceback the user cannot act on, at
+            # worst it aborts the interpreter.
+            try:
+                if root.winfo_exists():
+                    root.after(0, done)
+            except Exception:
+                pass
         threading.Thread(target=work, daemon=True).start()
 
     def load():
@@ -182,7 +190,15 @@ def build(container, root, wheel=None) -> None:
                 else:
                     status.config(text="You're on the latest version.", fg=GOOD)
                     btn.config(state="normal", text="Check again", command=load, style="TButton")
-            root.after(0, done)
+            # Close the window while this check is still in flight and the root
+            # is already gone. Tk then raises "main thread is not in main loop"
+            # from THIS thread - at best a traceback the user cannot act on, at
+            # worst it aborts the interpreter.
+            try:
+                if root.winfo_exists():
+                    root.after(0, done)
+            except Exception:
+                pass
         threading.Thread(target=work, daemon=True).start()
 
     def render_changelog(rels):

--- a/wisprlite/app.py
+++ b/wisprlite/app.py
@@ -90,6 +90,8 @@ class App:
         self._screenrec = None        # the live ScreenRecording, None when idle
         self._screenrec_selecting = False   # the region selector is open
         self._screenrec_finishing = None    # the thread muxing/sending, if any
+        self._screenrec_agent = None        # Event an MCP caller is waiting on
+        self._screenrec_agent_result = None
         self._armed_voice = None      # a Voice armed by the picker, consumed by the next utterance
         self._voice_mgrs = []         # dedicated voice HotkeyManagers
         self._picker_mgr = None       # the picker HotkeyManager
@@ -538,7 +540,10 @@ class App:
             # Named AFTER the fact: the moment you want to hit record is the
             # wrong moment to be filling in a form. The timestamp always leads
             # so an inbox full of these still sorts.
-            typed = screenrec.ask_name(recording.stem) if ask else ""
+            # An agent is blocked waiting on this, and the user recorded because
+            # the agent asked — do not stop them for a filename.
+            agent_call = self._screenrec_agent is not None
+            typed = screenrec.ask_name(recording.stem) if (ask and not agent_call) else ""
             if typed:
                 recording.rename(screenrec.stamped_stem(recording.stem, typed))
                 video = recording.video_path
@@ -550,6 +555,24 @@ class App:
             # an agent to read, and silently shipping without it looks
             # identical to shipping with it.
             note = "" if transcript is not None else " (no transcript — check the mic)"
+
+            # An agent asked for this one. It already gets the local path back,
+            # so shipping the file to a remote host on the agent's say-so is a
+            # second, larger act that nobody consented to. Hand back the path
+            # and stop; the user can still send it themselves with the hotkey.
+            waiter = self._screenrec_agent
+            if waiter is not None:
+                self._screenrec_agent = None
+                self._screenrec_agent_result = {
+                    "status": "ok",
+                    "video_path": str(video),
+                    "transcript_path": str(transcript) if transcript else "",
+                    "transcript": self._read_text(transcript),
+                    "uploaded": False,
+                }
+                self.overlay.show("done", f"✓ saved to {video.parent}{note}")
+                waiter.set()
+                return
 
             destination = (self.cfg.screenrec_destination or "").strip()
             if destination:
@@ -569,6 +592,61 @@ class App:
                 self.overlay.show("done", f"\u2713 saved to {video.parent}{note}")
         except Exception as exc:
             self._fail(f"screen recording: {exc}")
+        finally:
+            # Every early return above (no frames, send failed, exception) would
+            # otherwise leave an agent blocked until its own timeout with no
+            # idea why. Release it with the reason instead.
+            waiter, self._screenrec_agent = self._screenrec_agent, None
+            if waiter is not None:
+                self._screenrec_agent_result = {
+                    "status": "error",
+                    "error": "; ".join(recording.errors[:2]) or "the recording produced no file",
+                }
+                waiter.set()
+
+    @staticmethod
+    def _read_text(path) -> str:
+        try:
+            return Path(path).read_text(encoding="utf-8") if path else ""
+        except OSError:
+            return ""
+
+    def on_agent_record_screen(self, prompt: str = "", timeout: int = 300) -> dict:
+        """An agent asks the user to SHOW it the problem. Returns clip + words.
+
+        The user drags the region and presses the hotkey to stop, so nothing is
+        captured without a deliberate act — an agent cannot silently start
+        recording a screen and a microphone. Esc during selection returns
+        `cancelled` and writes no file.
+        """
+        if self._screenrec is not None or self._screenrec_selecting:
+            return {"status": "error", "error": "a screen recording is already in progress"}
+        if self.paused:
+            return {"status": "error", "error": "PipeVoice is paused"}
+        hotkey = (self.cfg.screenrec_hotkey or "").strip()
+        if not hotkey:
+            # Without it the user has started something they cannot stop.
+            return {"status": "error",
+                    "error": "no screen recording hotkey is set — Settings > Screen recording"}
+
+        self._screenrec_agent_result = None
+        waiter = threading.Event()
+        self._screenrec_agent = waiter
+        try:
+            self._screenrec_selecting = True
+            if prompt:
+                self._notify(prompt)
+            self._begin_screen_recording()
+            if self._screenrec is None:
+                return {"status": "cancelled", "error": "no region was selected"}
+            if not waiter.wait(timeout=max(5.0, float(timeout))):
+                return {"status": "timeout",
+                        "error": f"still recording after {timeout}s — press {hotkey} to stop"}
+            return self._screenrec_agent_result or {
+                "status": "error", "error": "the recording finished without a result"}
+        finally:
+            if self._screenrec_agent is waiter:
+                self._screenrec_agent = None
 
     def _transcribe_recording(self, recording) -> Path | None:
         """Narration as text, so the agent reads it instead of decoding frames."""
@@ -733,6 +811,8 @@ class App:
         if op == "transcribe":
             return self.on_agent_transcribe(req.get("path", ""), req.get("format", "json"),
                                             req.get("language", ""), req.get("model_size", ""))
+        if op == "record_screen":
+            return self.on_agent_record_screen(req.get("prompt", ""), req.get("timeout", 300))
         return {"status": "error", "error": f"unknown op: {op}"}
 
     def on_agent_transcribe(self, path="", fmt="json", language="", model_size="") -> dict:

--- a/wisprlite/mcp_shim.py
+++ b/wisprlite/mcp_shim.py
@@ -54,6 +54,39 @@ def main() -> None:
         return _send("transcribe", read_timeout=900.0,
                      path=path, format=format, language=language, model_size=model_size)
 
+    @mcp.tool()
+    def record_screen(prompt: str = "", timeout_seconds: int = 300) -> dict:
+        """Ask the user to SHOW you the problem, and get back a video plus what they said.
+
+        Use this when words are the wrong medium: a visual bug, a layout that
+        looks wrong, a UI that behaves oddly, an animation that stutters, or any
+        "it does a weird thing" you would otherwise need three rounds of
+        questions to pin down. Also use it when the user is clearly struggling
+        to describe something in text.
+
+        The user drags a box over the part of the screen that matters, narrates
+        what is wrong, and presses their hotkey to stop. You get:
+          video_path      an .mp4 you can read directly if you handle video
+          transcript      what they said, already transcribed locally
+          transcript_path the same text as a file
+        Read `transcript` first - it is usually enough to locate the problem,
+        and it costs nothing compared with decoding frames.
+
+        `prompt` is shown to the user, so say what you want to see:
+        "show me the checkout page and click the button that does nothing".
+
+        Consent is built in and you cannot bypass it: the user chooses the
+        region by hand, and Esc cancels and writes nothing. The file stays on
+        their machine - this tool never uploads it anywhere, even if they have
+        configured a destination for their own use.
+
+        Returns status 'cancelled' if they pressed Esc, 'timeout' if they are
+        still recording after timeout_seconds. Neither is an error; a person
+        changed their mind or is taking their time.
+        """
+        return _send("record_screen", read_timeout=float(timeout_seconds) + 120.0,
+                     prompt=prompt, timeout=timeout_seconds)
+
     mcp.run()  # stdio transport by default
 
 

--- a/wisprlite/meetings_tab.py
+++ b/wisprlite/meetings_tab.py
@@ -48,7 +48,7 @@ from .summarise import (
 )
 from . import export
 from .polish import PolishFailed, ProviderNotReady, polish_segments
-from .winui import PALETTE, tooltip
+from .winui import PALETTE, collapsible_settings, tooltip
 
 BG = PALETTE["bg"]
 CARD = PALETTE["card"]
@@ -679,8 +679,15 @@ def _wheel_global(widget) -> None:
     widget.bind("<Leave>", lambda _event: widget.unbind_all("<MouseWheel>"))
 
 
-def build(container, root, wheel=None, on_replacements_changed=None, show_tab=None) -> None:
-    """Populate ``container`` with the reusable Meetings browser."""
+def build(container, root, wheel=None, on_replacements_changed=None, show_tab=None,
+          with_settings=False):
+    """Populate ``container`` with the reusable Meetings browser.
+
+    Returns the (empty, hidden) meeting-settings panel when ``with_settings`` is
+    set, so the caller can fill it once its own form helpers exist. Meeting
+    settings belong here rather than in a distant Settings tab: "where do my
+    recordings go" wants to sit next to "here are my recordings".
+    """
     import tkinter as tk
     from tkinter import filedialog, messagebox, ttk
 
@@ -753,6 +760,15 @@ def build(container, root, wheel=None, on_replacements_changed=None, show_tab=No
 
     guide_link.bind("<Button-1>", _open_guide)
 
+    settings_panel = None
+    settings_link = None
+    if with_settings:
+        settings_link = tk.Label(head, text="Settings  ⚙", bg=BG, fg=ACCENT,
+                                 cursor="hand2", font=("Segoe UI", 9, "underline"))
+        settings_link.pack(side="right", padx=(0, 14))
+        tooltip(settings_link, "Meeting hotkey, bookmarks, PipeFocus, where recordings "
+                               "are kept and how many.")
+
     intro = tk.Label(
         container,
         text="Press your meeting hotkey to record a call \u2014 your microphone and the "
@@ -768,6 +784,13 @@ def build(container, root, wheel=None, on_replacements_changed=None, show_tab=No
     # which kills the window before it draws.
     body = tk.Frame(container, bg=BG, padx=18)
     body.pack(fill="both", expand=True, pady=(0, 12))
+
+    if settings_link is not None:
+        settings_panel = collapsible_settings(
+            container, settings_link,
+            [(intro, {"fill": "x", "pady": (0, 10)}),
+             (body, {"fill": "both", "expand": True, "pady": (0, 12)})],
+            BG, wheel)
 
     left = tk.Frame(body, bg=CARD, width=400)
     left.pack(side="left", fill="y")
@@ -2614,6 +2637,7 @@ def build(container, root, wheel=None, on_replacements_changed=None, show_tab=No
     refresh()
     container.bind("<Destroy>", stop_polling, add="+")
     state["poll_after"] = root.after(2000, poll_sessions)
+    return settings_panel
 
 
 def main() -> None:

--- a/wisprlite/screenrec_tab.py
+++ b/wisprlite/screenrec_tab.py
@@ -1,0 +1,359 @@
+"""The Recordings tab: every screen recording, with its narration and settings.
+
+Deliberately simpler than the Meetings tab. A screen recording is one clip and
+one transcript, not a multi-speaker session with bookmarks and summaries, so
+this browses and acts rather than edits.
+
+The settings live here too. Splitting "where do my recordings go" from "here
+are my recordings" across two tabs is the jumping-around this exists to stop.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from . import config
+from .history import _copy_to_clipboard
+from .meetings_tab import _open_folder, format_duration
+from .winui import PALETTE, collapsible_settings, tooltip
+
+BG = PALETTE["bg"]
+CARD = PALETTE["card"]
+FG = PALETTE["fg"]
+MUTED = PALETTE["muted"]
+ACCENT = PALETTE["accent"]
+DIV = PALETTE["div"]
+SCROLL = PALETTE["border"]
+
+VIDEO_SUFFIX = ".mp4"
+
+
+def recordings_dir(cfg=None) -> Path:
+    """Where clips live: the user's folder if set and usable, else the default."""
+    from . import screenrec
+
+    cfg = cfg or config.Config.load()
+    chosen = str(getattr(cfg, "screenrec_dir", "") or "").strip()
+    if chosen:
+        candidate = Path(chosen).expanduser()
+        if candidate.is_dir():
+            return candidate
+    return screenrec.default_output_dir()
+
+
+def _size_label(size: int) -> str:
+    if size >= 1_000_000_000:
+        return f"{size / 1_000_000_000:.1f} GB"
+    if size >= 1_000_000:
+        return f"{size / 1_000_000:.0f} MB"
+    return f"{max(1, size // 1000)} KB"
+
+
+def _duration_seconds(path: Path) -> float | None:
+    """Length of the clip, or None when it cannot be read.
+
+    Read from the container rather than guessed from file size: bitrate varies
+    with how much of the screen is moving, so size is not a proxy for length.
+    """
+    try:
+        import av
+
+        with av.open(str(path)) as container:
+            if container.duration:
+                return float(container.duration) / 1_000_000.0
+    except Exception:
+        pass
+    return None
+
+
+def list_recordings(base_dir=None) -> list[dict]:
+    """Every clip in the folder, newest first, each with its transcript if present."""
+    base = Path(base_dir) if base_dir is not None else recordings_dir()
+    try:
+        videos = [p for p in base.iterdir() if p.suffix.lower() == VIDEO_SUFFIX]
+    except OSError:
+        return []
+    out = []
+    for video in videos:
+        try:
+            stat = video.stat()
+        except OSError:
+            continue
+        transcript = video.with_suffix(".txt")
+        out.append({
+            "path": video,
+            "stem": video.stem,
+            "modified": stat.st_mtime,
+            "size": stat.st_size,
+            "transcript_path": transcript if transcript.exists() else None,
+        })
+    out.sort(key=lambda item: item["modified"], reverse=True)
+    return out
+
+
+def read_transcript(item: dict) -> str:
+    path = item.get("transcript_path")
+    if not path:
+        return ""
+    try:
+        return Path(path).read_text(encoding="utf-8").strip()
+    except OSError:
+        return ""
+
+
+def _play(path: Path) -> None:
+    """Open the clip in whatever the user plays video with."""
+    try:
+        if sys.platform == "win32":
+            os.startfile(str(path))          # noqa: S606 - the user's own file
+        elif sys.platform == "darwin":
+            subprocess.Popen(["open", str(path)])
+        else:
+            subprocess.Popen(["xdg-open", str(path)])
+    except Exception:
+        pass
+
+
+def build(container, root, wheel=None, with_settings=False):
+    """Populate ``container`` with the recordings browser.
+
+    Returns the (empty, hidden) settings panel when ``with_settings`` is set, so
+    the caller can fill it once its own form helpers exist. Returning the frame
+    rather than taking a builder keeps the ordering simple: this tab is built
+    early, the settings widgets are defined later.
+    """
+    import tkinter as tk
+    from tkinter import messagebox, ttk
+
+    state = {"items": [], "selected": None, "rows": []}
+
+    head = tk.Frame(container, bg=BG, padx=18, pady=14)
+    head.pack(fill="x")
+    tk.Label(head, text="Recordings", bg=BG, fg=ACCENT,
+             font=("Segoe UI", 14, "bold")).pack(side="left")
+    count_label = tk.Label(head, text="", bg=BG, fg=MUTED, font=("Segoe UI", 9))
+    count_label.pack(side="left", padx=(10, 0))
+
+    settings_link = tk.Label(head, text="Settings  ⚙", bg=BG, fg=ACCENT,
+                             cursor="hand2", font=("Segoe UI", 9, "underline"))
+    settings_panel = None
+
+    # anchor="w" is load-bearing: a Label centres its wrapped block, so without
+    # it a wraplength wider than the window clips the text at BOTH edges.
+    intro = tk.Label(
+        container,
+        text="Press your screen recording hotkey, drag a box around what you want to "
+             "show, and talk through it. Press the hotkey again to stop — you get an "
+             "mp4 and a transcript of what you said.",
+        bg=BG, fg=MUTED, font=("Segoe UI", 9), justify="left", anchor="w",
+        wraplength=640,
+    )
+    intro.pack(fill="x", padx=18, pady=(0, 10))
+    # Re-wrap to the real window width instead of a guess that is wrong on every
+    # monitor but the one it was written on.
+    container.bind(
+        "<Configure>",
+        lambda e: intro.config(wraplength=max(320, e.width - 48)),
+        add="+",
+    )
+
+    body = tk.Frame(container, bg=BG)
+    body.pack(fill="both", expand=True, padx=18, pady=(0, 14))
+
+    if with_settings:
+        settings_link.pack(side="right")
+        tooltip(settings_link, "Hotkey, where clips are saved, and where they get sent.")
+        settings_panel = collapsible_settings(
+            container, settings_link,
+            [(intro, {"fill": "x", "padx": 18, "pady": (0, 10)}),
+             (body, {"fill": "both", "expand": True, "padx": 18, "pady": (0, 14)})],
+            BG, wheel)
+
+    left = tk.Frame(body, bg=BG, width=250)
+    left.pack(side="left", fill="y")
+    left.pack_propagate(False)
+
+    canvas = tk.Canvas(left, bg=BG, highlightthickness=0)
+    bar = ttk.Scrollbar(left, orient="vertical", command=canvas.yview,
+                        style="Vertical.TScrollbar")
+    canvas.configure(yscrollcommand=bar.set)
+    bar.pack(side="right", fill="y")
+    canvas.pack(side="left", fill="both", expand=True)
+    listing = tk.Frame(canvas, bg=BG)
+    canvas.create_window((0, 0), window=listing, anchor="nw", width=232)
+    listing.bind("<Configure>", lambda e: canvas.configure(scrollregion=canvas.bbox("all")))
+    if callable(wheel):
+        wheel(canvas)
+
+    right = tk.Frame(body, bg=BG)
+    right.pack(side="left", fill="both", expand=True, padx=(16, 0))
+
+    title = tk.Label(right, text="No recording selected", bg=BG, fg=FG,
+                     font=("Segoe UI", 12, "bold"), anchor="w")
+    title.pack(fill="x")
+    detail = tk.Label(right, text="", bg=BG, fg=MUTED, font=("Segoe UI", 9), anchor="w")
+    detail.pack(fill="x", pady=(2, 10))
+
+    buttons = tk.Frame(right, bg=BG)
+    buttons.pack(fill="x", pady=(0, 10))
+
+    tk.Label(right, text="What you said", bg=BG, fg=MUTED,
+             font=("Segoe UI", 9, "bold"), anchor="w").pack(fill="x")
+    text = tk.Text(right, bg=CARD, fg=FG, relief="flat", wrap="word", height=12,
+                   insertbackground=FG, padx=12, pady=10, font=("Segoe UI", 10))
+    text.pack(fill="both", expand=True, pady=(4, 0))
+    text.configure(state="disabled")
+
+    def _set_transcript(body_text: str) -> None:
+        text.configure(state="normal")
+        text.delete("1.0", "end")
+        text.insert("1.0", body_text)
+        text.configure(state="disabled")
+
+    def _select(item) -> None:
+        state["selected"] = item
+        for row, row_item in state["rows"]:
+            on = row_item is item
+            row.configure(bg=CARD if on else BG)
+            for child in row.winfo_children():
+                child.configure(bg=CARD if on else BG)
+        if item is None:
+            title.config(text="No recording selected")
+            detail.config(text="")
+            _set_transcript("")
+            return
+        title.config(text=item["stem"])
+        seconds = _duration_seconds(item["path"])
+        bits = [_size_label(item["size"])]
+        if seconds:
+            bits.insert(0, format_duration(seconds))
+        bits.append(str(item["path"].parent))
+        detail.config(text="  ·  ".join(bits))
+        words = read_transcript(item)
+        _set_transcript(words or "No transcript for this one — check the microphone "
+                                 "was on when you recorded it.")
+
+    def refresh(select_stem: str | None = None) -> None:
+        for row, _ in state["rows"]:
+            row.destroy()
+        state["rows"] = []
+        items = list_recordings()
+        state["items"] = items
+        count_label.config(text=f"{len(items)} recording{'' if len(items) == 1 else 's'}")
+        if not items:
+            empty = tk.Frame(listing, bg=BG)
+            empty.pack(fill="x", pady=6)
+            tk.Label(empty, text="Nothing recorded yet.", bg=BG, fg=MUTED,
+                     font=("Segoe UI", 9), wraplength=260, justify="left").pack(anchor="w")
+            state["rows"] = [(empty, None)]
+            _select(None)
+            return
+        for item in items:
+            row = tk.Frame(listing, bg=BG, cursor="hand2", padx=10, pady=8)
+            row.pack(fill="x", pady=1)
+            tk.Label(row, text=item["stem"], bg=BG, fg=FG, font=("Segoe UI", 10),
+                     anchor="w", wraplength=250, justify="left").pack(fill="x")
+            marks = [_size_label(item["size"])]
+            if item["transcript_path"] is None:
+                marks.append("no transcript")
+            tk.Label(row, text="  ·  ".join(marks), bg=BG, fg=MUTED,
+                     font=("Segoe UI", 8), anchor="w").pack(fill="x")
+            for widget in (row, *row.winfo_children()):
+                widget.bind("<Button-1>", lambda e, it=item: _select(it))
+            state["rows"].append((row, item))
+        wanted = next((i for i in items if i["stem"] == select_stem), None)
+        _select(wanted or items[0])
+
+    def _need_selection():
+        item = state["selected"]
+        if item is None:
+            messagebox.showinfo("Recordings", "Pick a recording first.")
+        return item
+
+    def _play_selected():
+        item = _need_selection()
+        if item:
+            _play(item["path"])
+
+    def _folder_selected():
+        item = _need_selection()
+        if item:
+            _open_folder(item["path"].parent)
+
+    def _copy_path():
+        item = _need_selection()
+        if item:
+            _copy_to_clipboard(root, str(item["path"]))
+
+    def _copy_words():
+        item = _need_selection()
+        if item:
+            _copy_to_clipboard(root, read_transcript(item))
+
+    def _send_selected():
+        item = _need_selection()
+        if not item:
+            return
+        from . import screenrec
+
+        destination = str(getattr(config.Config.load(), "screenrec_destination", "") or "").strip()
+        if not destination:
+            messagebox.showinfo(
+                "Send",
+                "No destination is set. Open Settings above and put an scp target in "
+                "“Send recordings to”, for example root@host:/srv/project/inbox/")
+            return
+        files = [item["path"]]
+        if item["transcript_path"]:
+            files.append(item["transcript_path"])
+        ok, message = screenrec.send(files, destination)
+        if ok:
+            messagebox.showinfo("Send", f"Sent to {destination}")
+        else:
+            # Never claim it arrived, and never remove the local copy on failure.
+            messagebox.showerror("Send failed", message)
+
+    def _delete_selected():
+        item = _need_selection()
+        if not item:
+            return
+        if not messagebox.askyesno(
+                "Delete recording",
+                f"Delete “{item['stem']}”?\n\nThe video, its transcript and its "
+                "audio are removed from this PC. Anything already sent elsewhere stays."):
+            return
+        for path in (item["path"], item["transcript_path"],
+                     item["path"].with_suffix(".wav")):
+            if not path:
+                continue
+            try:
+                Path(path).unlink()
+            except OSError:
+                pass
+        refresh()
+
+    # Two rows of three. One row of six overflowed the pane and silently cut the
+    # last two buttons off the right edge — an action you cannot see is an
+    # action you do not have.
+    actions = (
+        ("Play", _play_selected, "Open the clip in your video player."),
+        ("Send", _send_selected, "scp this recording to your configured destination."),
+        ("Folder", _folder_selected, "Open the containing folder."),
+        ("Copy path", _copy_path, "Copy the file path, to paste to an agent."),
+        ("Copy text", _copy_words, "Copy the transcript."),
+        ("Delete", _delete_selected, "Remove the video, transcript and audio from this PC."),
+    )
+    for index, (label, command, tip) in enumerate(actions):
+        btn = ttk.Button(buttons, text=label, command=command, width=11)
+        btn.grid(row=index // 3, column=index % 3, padx=(0, 5), pady=(0, 5), sticky="w")
+        tooltip(btn, tip)
+
+    refresh_btn = ttk.Button(head, text="Refresh", command=lambda: refresh(
+        state["selected"]["stem"] if state["selected"] else None))
+    refresh_btn.pack(side="right", padx=(0, 12))
+
+    refresh()
+    return settings_panel

--- a/wisprlite/settings.py
+++ b/wisprlite/settings.py
@@ -14,7 +14,8 @@ import json
 import threading
 import webbrowser
 
-from . import about, autostart, cleanup, config, history, meeting, meetings_tab, voices, vocab_mine, winui
+from . import (about, autostart, cleanup, config, history, meeting, meetings_tab,
+               screenrec_tab, voices, vocab_mine, winui)
 
 ENGINES = [("gemini", "Gemini — free, one key does it all"),
            ("groq", "Groq Whisper — fast & cheap, top accuracy"),
@@ -459,10 +460,12 @@ def main(first_run: bool = False) -> None:
     tab_voices = tk.Frame(body_wrap, bg=BG)
     tab_history = tk.Frame(body_wrap, bg=BG)
     tab_meetings = tk.Frame(body_wrap, bg=BG)
+    tab_recordings = tk.Frame(body_wrap, bg=BG)
     tab_guide = tk.Frame(body_wrap, bg=BG)
     tab_about = tk.Frame(body_wrap, bg=BG)
     _tabs = [("Settings", tab_settings), ("Voices", tab_voices), ("History", tab_history),
-             ("Meetings", tab_meetings), ("Guide", tab_guide), ("About", tab_about)]
+             ("Meetings", tab_meetings), ("Recordings", tab_recordings),
+             ("Guide", tab_guide), ("About", tab_about)]
     _tab_w = {}
 
     def _show_tab(name):
@@ -514,11 +517,17 @@ def main(first_run: bool = False) -> None:
     def sync_meeting_replacements(replacements):
         fixes_var.set(", ".join(f"{k}={v}" for k, v in replacements.items()))
 
-    meetings_tab.build(
+    # Both tabs hand back an empty settings panel. They are built here, but the
+    # form helpers (card/row/entry/check) do not exist until further down, so
+    # the panels are FILLED later — see _fill_tab_settings().
+    meeting_settings_panel = meetings_tab.build(
         tab_meetings, root, _wheel,
         on_replacements_changed=sync_meeting_replacements,
         show_tab=_show_tab,
+        with_settings=True,
     )
+    recordings_settings_panel = screenrec_tab.build(
+        tab_recordings, root, _wheel, with_settings=True)
     _build_guide(tab_guide, _wheel)
     about.build(tab_about, root, _wheel)
     _build_voices_tab(tab_voices, _show_tab, _wheel)
@@ -528,13 +537,25 @@ def main(first_run: bool = False) -> None:
     _show_tab(os.getenv("PV_TAB") or ("Guide" if first_run else "Settings"))
     DIV = "#272b37"
 
-    def card(title, subtitle=None):
-        wrap = tk.Frame(frm, bg=BG)
-        wrap.pack(fill="x", pady=(0, 18))
+    def card(title, subtitle=None, parent=None):
+        # `parent` lets a card land in the Meetings or Recordings tab instead of
+        # the Settings form. Same widgets, same StringVars, same Save — only the
+        # frame differs, so nothing about persistence changes.
+        wrap = tk.Frame(parent if parent is not None else frm, bg=BG)
+        wrap.pack(fill="x", pady=(0, 18), padx=18 if parent is not None else 0)
         tk.Label(wrap, text=title, bg=BG, fg=FG, font=("Segoe UI", 13, "bold")).pack(anchor="w", padx=3)
         if subtitle:
-            tk.Label(wrap, text=subtitle, bg=BG, fg=MUTED, font=("Segoe UI", 9),
-                     justify="left").pack(anchor="w", padx=3, pady=(2, 0))
+            # anchor="w" and a wraplength both matter outside the Settings form:
+            # that form caps its own width, a tab panel does not, so an unwrapped
+            # subtitle grows past the window and a Label centres what it cannot
+            # fit — clipping the text at BOTH edges.
+            sub = tk.Label(wrap, text=subtitle, bg=BG, fg=MUTED, font=("Segoe UI", 9),
+                           justify="left", anchor="w", wraplength=640)
+            sub.pack(fill="x", anchor="w", padx=3, pady=(2, 0))
+            if parent is not None:
+                wrap.bind("<Configure>",
+                          lambda e, w=sub: w.config(wraplength=max(320, e.width - 12)),
+                          add="+")
         c = tk.Frame(wrap, bg=CARD)
         c.pack(fill="x", pady=(9, 0))
         c._first = True
@@ -755,6 +776,13 @@ def main(first_run: bool = False) -> None:
 
     clip_cap_btn.config(command=clip_capture)
 
+    # --- Meetings: rendered into the Meetings tab, not this form ---
+    c = card(
+        "Meetings",
+        "Recording a call captures your microphone and the computer's audio "
+        "separately, so nobody gets mixed up.",
+        parent=meeting_settings_panel,
+    )
     r = row(
         c,
         "Meeting hotkey",
@@ -767,17 +795,6 @@ def main(first_run: bool = False) -> None:
     meeting_cap_btn.config(
         command=_mk_capture(meeting_cap_btn, meeting_hotkey_var)
     )
-
-    r = row(
-        c,
-        "Screen recording hotkey",
-        "Tap once to drag a box over what you want to show, and again to stop. "
-        "Records that area plus your microphone.",
-    )
-    entry(r, screenrec_hotkey_var, width=14)
-    screenrec_cap_btn = ttk.Button(r, text="Capture", width=8)
-    screenrec_cap_btn.pack(side="left", padx=(8, 0))
-    screenrec_cap_btn.config(command=_mk_capture(screenrec_cap_btn, screenrec_hotkey_var))
 
     r = row(c, "Bookmark hotkey", "Tap while recording to mark the current moment.")
     entry(r, bookmark_hotkey_var, width=14)
@@ -981,13 +998,21 @@ def main(first_run: bool = False) -> None:
     _pcap.pack(side="left", padx=(8, 0))
     _pcap.config(command=_mk_capture(_pcap, picker_var))
 
-    # --- Audio ---
+    # --- Screen recordings: rendered into the Recordings tab, not this form ---
     c = card(
         "Screen recordings",
         "Show a bug instead of describing it. Recordings are sent with a text "
         "transcript of what you said, so a coding agent can read it without "
         "watching the video.",
+        parent=recordings_settings_panel,
     )
+    r = row(c, "Screen recording hotkey",
+            "Tap once to drag a box over what you want to show, and again to stop. "
+            "Records that area plus your microphone.")
+    entry(r, screenrec_hotkey_var, width=14)
+    screenrec_cap_btn = ttk.Button(r, text="Capture", width=8)
+    screenrec_cap_btn.pack(side="left", padx=(8, 0))
+    screenrec_cap_btn.config(command=_mk_capture(screenrec_cap_btn, screenrec_hotkey_var))
     entry(row(c, "Send to",
               "An scp destination, e.g. root@your-vps:/root/project/inbox/. Uses the "
               "SSH keys you already have — Pipevoice never stores one. Leave blank "
@@ -1191,6 +1216,13 @@ def main(first_run: bool = False) -> None:
     c = card("Advanced", "Most people never need these.")
     entry(row(c, "Min seconds", "Ignore taps shorter than this."), min_seconds_var, width=7)
     entry(row(c, "Deepgram wait", "Seconds to wait for final words."), dg_timeout_var, width=7)
+    combo(row(c, "Paste speed", "Slower is more reliable in some apps."),
+          paste_speed_var, [l for _, l in PASTE_SPEEDS], width=10)
+
+    # --- Meeting storage: rendered into the Meetings tab, beside the recordings
+    # it governs. These sat under "Advanced" three tabs away from the list they
+    # apply to, which is exactly the jumping-around this move removes.
+    c = card("Where meetings are kept", parent=meeting_settings_panel)
     entry(
         row(c, "Meeting max minutes", "Safety limit for an unattended recording."),
         meeting_max_minutes_var,
@@ -1217,9 +1249,6 @@ def main(first_run: bool = False) -> None:
 
     ttk.Button(_mr, text="Browse", width=8,
                command=_browse_meetings).pack(side="left", padx=(8, 0))
-
-    combo(row(c, "Paste speed", "Slower is more reliable in some apps."),
-          paste_speed_var, [l for _, l in PASTE_SPEEDS], width=10)
 
     # --- Save / Cancel (live in the fixed footer) ---
     def value_for(var, table):

--- a/wisprlite/winui.py
+++ b/wisprlite/winui.py
@@ -229,3 +229,47 @@ def fit_scroll_body(canvas, window_id, max_width: int = 1080) -> None:
         canvas.coords(window_id, max(0, (event.width - width) // 2), 0)
 
     canvas.bind("<Configure>", _fit, add="+")
+
+
+def collapsible_settings(container, link, hides, palette_bg, wheel=None):
+    """A settings panel a tab can swap in over its own content.
+
+    Returns the frame to fill. Clicking ``link`` hides every widget in ``hides``
+    and shows the panel instead; clicking again reverses it.
+
+    It SWAPS rather than pushes because a settings block is taller than the
+    window: packed above a browser it shoved the list off the bottom and then
+    ran off the bottom itself, so neither was usable. It scrolls for the same
+    reason — the Meetings settings alone are taller than the window.
+    """
+    import tkinter as tk
+    from tkinter import ttk
+
+    holder = tk.Frame(container, bg=palette_bg)
+    canvas = tk.Canvas(holder, bg=palette_bg, highlightthickness=0)
+    bar = ttk.Scrollbar(holder, orient="vertical", command=canvas.yview,
+                        style="Vertical.TScrollbar")
+    canvas.configure(yscrollcommand=bar.set)
+    bar.pack(side="right", fill="y")
+    canvas.pack(side="left", fill="both", expand=True)
+    panel = tk.Frame(canvas, bg=palette_bg)
+    window_id = canvas.create_window((0, 0), window=panel, anchor="nw")
+    panel.bind("<Configure>",
+               lambda e: canvas.configure(scrollregion=canvas.bbox("all")))
+    canvas.bind("<Configure>",
+                lambda e: canvas.itemconfigure(window_id, width=e.width), add="+")
+    if callable(wheel):
+        wheel(canvas)
+
+    def toggle(_event=None):
+        if holder.winfo_ismapped():
+            holder.pack_forget()
+            for widget, kwargs in hides:
+                widget.pack(**kwargs)
+        else:
+            for widget, _kwargs in hides:
+                widget.pack_forget()
+            holder.pack(fill="both", expand=True, padx=18, pady=(0, 12))
+
+    link.bind("<Button-1>", toggle)
+    return panel


### PR DESCRIPTION
## What

**Recordings tab.** Every clip newest-first with size and whether a transcript
exists, the narration in a panel beside it, and Play / Send / Folder / Copy path
/ Copy text / Delete.

**Settings moved to the feature they configure.** Screen-recording settings live
on the Recordings tab; meeting settings moved out of Hotkeys and Advanced onto
the Meetings tab. Meeting storage in particular sat under "Advanced", three tabs
from the list it governs. Settings swap for the browser and scroll rather than
pushing it off the bottom.

**MCP `record_screen`.** An agent can ask the user to show it the problem and
gets back an mp4 plus the narration, transcribed locally.

## Consent, on the MCP tool

Structural, not a checkbox. The user drags the region by hand, Esc writes
nothing, recording is off until a hotkey is set, and pause blocks an
agent-requested recording exactly like a hotkey one. **An agent call never
uploads** - it gets a local path; shipping the file to a remote host is a second
and larger act it did not ask for. It also skips the naming dialog, since the
agent is blocked waiting.

## Found by rendering it, not by reasoning about it

- settings packed above the list shoved the list off the bottom, then ran off
  the bottom themselves
- the intro label clipped at BOTH edges (a Label centres a block it cannot fit)
- two of six action buttons silently cut off the right edge

## Fixed outside this feature

`about.py` called `root.after` from its release-check thread with no liveness
check. Closing the window mid-check raised "main thread is not in main loop"
from a worker thread, which aborted the interpreter once three windows were
opened in one process. Suite warnings 11 -> 1.

## Gates

326 passed, 7 pre-existing failures (missing faster-whisper/deepgram SDKs).
Sabotage-verified: reverting the card placement, the toggle-back, the no-upload
guard and the pipeline offset each turn a test red.

## Known gap, unchanged by this PR

The MCP shim needs a source checkout: the shipped exe is a `--noconsole`
PyInstaller build and is not a working stdio MCP target. `/for-ai-agents` says so
rather than implying otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)