### PR TITLE
fix: the Recordings tab notices new clips, and the narration lines up with the picture

### DIFF
--- a/tests/test_screenrec.py
+++ b/tests/test_screenrec.py
@@ -376,6 +376,43 @@ def test_renaming_moves_every_file_of_the_recording():
             assert (rec.out_dir / f"2026-08-12 10-33-25 login bug{suffix}").exists()
 
 
+def test_audio_recorded_before_the_first_frame_is_trimmed():
+    """Measured on James's first real clip: 12.46s of audio against 11.42s of
+    video, both muxed from zero, so the narration ran a second ahead of the
+    picture for the whole recording. The mic opens faster than mss plus x264.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        rec = _recording(tmp)
+        samples = np.arange(screenrec.AUDIO_RATE * 5, dtype="<i2")
+
+        rec.first_audio_at, rec.first_frame_at = 100.0, 101.5
+        assert rec.lead_seconds() == pytest.approx(1.5)
+        trimmed = rec._trim_lead(samples)
+        assert trimmed.size == samples.size - int(1.5 * screenrec.AUDIO_RATE)
+        assert trimmed[0] == samples[int(1.5 * screenrec.AUDIO_RATE)], \
+            "the wrong end was trimmed"
+
+        # Video first (or simultaneous) means nothing to correct.
+        rec.first_audio_at, rec.first_frame_at = 101.0, 100.0
+        assert rec.lead_seconds() == 0.0
+        assert rec._trim_lead(samples) is samples
+
+        # A clip with no frames at all must not be touched.
+        rec.first_frame_at = None
+        assert rec._trim_lead(samples) is samples
+
+
+def test_trimming_never_eats_the_whole_narration():
+    """A bad clock reading must not silently delete what somebody said."""
+    with tempfile.TemporaryDirectory() as tmp:
+        rec = _recording(tmp)
+        samples = np.arange(screenrec.AUDIO_RATE * 3, dtype="<i2")
+        rec.first_audio_at, rec.first_frame_at = 0.0, 600.0   # absurd
+        trimmed = rec._trim_lead(samples)
+        assert trimmed.size >= screenrec.AUDIO_RATE, \
+            "at least a second of audio must survive any lead correction"
+
+
 def test_a_failed_rename_puts_every_file_back():
     """All three files or none.
 
@@ -524,3 +561,40 @@ def test_shutdown_waits_longer_than_an_upload_can_take():
     source = pathlib.Path(app_module.__file__).read_text()
     assert "screenrec.UPLOAD_TIMEOUT + 60.0" in source
     assert screenrec.UPLOAD_TIMEOUT >= 300.0
+
+
+def test_the_recordings_list_notices_a_transcript_written_after_the_clip():
+    """The signature must change when the .txt lands, not only when the mp4 does.
+
+    James recorded a clip while the Recordings tab was open. The tab was a
+    snapshot from when it opened, so it still read "0 recordings" — the proof
+    he sent was a video OF that tab saying "Nothing recorded yet." The
+    transcript is written seconds after the mux, so a listing that keys only on
+    the video would show "no transcript" for ever.
+    """
+    from wisprlite import screenrec_tab
+
+    with tempfile.TemporaryDirectory() as tmp:
+        base = pathlib.Path(tmp)
+        assert screenrec_tab.list_recordings(base) == []
+
+        clip = base / "2026-08-12 16-24-42.mp4"
+        clip.write_bytes(b"video")
+        first = screenrec_tab.list_recordings(base)
+        assert len(first) == 1
+        assert first[0]["transcript_path"] is None
+
+        (base / "2026-08-12 16-24-42.txt").write_text("okay doing a little test",
+                                                     encoding="utf-8")
+        second = screenrec_tab.list_recordings(base)
+        assert second[0]["transcript_path"] is not None, \
+            "a transcript written after the clip must be picked up"
+        assert screenrec_tab.read_transcript(second[0]) == "okay doing a little test"
+
+        def signature(items):
+            return tuple((i["stem"], i["size"], i["transcript_path"] is not None)
+                         for i in items)
+
+        assert signature(first) != signature(second), (
+            "the poll signature must change when a transcript appears, or the "
+            "tab never re-renders and 'no transcript' sticks")

--- a/wisprlite/__init__.py
+++ b/wisprlite/__init__.py
@@ -1,3 +1,3 @@
 """Pipevoice — push-to-talk voice typing for Windows."""
 
-__version__ = "2.38.0"
+__version__ = "2.38.1"

--- a/wisprlite/screenrec.py
+++ b/wisprlite/screenrec.py
@@ -76,6 +76,13 @@ class ScreenRecording:
         self.errors: list[str] = []
         self.dropped_audio_blocks = 0
         self.frames_written = 0
+        # The mic opens faster than mss + the x264 container, so audio starts
+        # first. Measured on a real 12s clip: 12.46s of audio against 11.42s of
+        # video, both starting at 0 — the narration ran a second ahead of the
+        # picture for the whole recording. Recording both instants lets the mux
+        # drop that leading second instead of guessing.
+        self.first_frame_at: float | None = None
+        self.first_audio_at: float | None = None
 
     # -- paths ---------------------------------------------------------------
 
@@ -215,6 +222,8 @@ class ScreenRecording:
                     with self._encode_lock:
                         if self._container is None:
                             self._open_container(frame.shape[1], frame.shape[0])
+                        if self.first_frame_at is None:
+                            self.first_frame_at = time.monotonic()
                         self._encode_frame(np.ascontiguousarray(frame))
                     self.frames_written += 1
                     next_at += interval
@@ -282,6 +291,8 @@ class ScreenRecording:
         try:
             import numpy as np
 
+            if self.first_audio_at is None:
+                self.first_audio_at = time.monotonic()
             self._audio_queue.put_nowait(
                 np.array(indata, dtype="float32", copy=True)
             )
@@ -346,7 +357,7 @@ class ScreenRecording:
                 for packet in video.encode():          # flush the encoder
                     container.mux(packet)
 
-                samples = self._read_wav()
+                samples = self._trim_lead(self._read_wav())
                 if audio is not None and samples is not None and samples.size:
                     frame = av.AudioFrame.from_ndarray(
                         samples.reshape(1, -1), format="s16", layout="mono"
@@ -362,6 +373,32 @@ class ScreenRecording:
         except Exception as exc:
             self._record_error(exc)
             return None
+
+    def lead_seconds(self) -> float:
+        """How long the microphone ran before the first frame was encoded."""
+        if self.first_frame_at is None or self.first_audio_at is None:
+            return 0.0
+        return max(0.0, self.first_frame_at - self.first_audio_at)
+
+    def _trim_lead(self, samples):
+        """Drop the audio captured before there was any picture.
+
+        Both streams are muxed starting at zero, so without this the whole
+        narration plays ahead of what it is describing — you hear "click this
+        button" a second before the cursor moves. Trimming the head is right
+        rather than padding the video: the missing picture never existed.
+
+        Only the startup gap is corrected. A capped, sane bound keeps a bad
+        clock reading from eating the start of what someone said.
+        """
+        lead = self.lead_seconds()
+        if samples is None or not lead:
+            return samples
+        drop = min(int(lead * AUDIO_RATE), max(0, samples.size - AUDIO_RATE))
+        if drop <= 0:
+            return samples
+        log.info("screenrec: trimmed %.2fs of audio that preceded the first frame", lead)
+        return samples[drop:]
 
     def _read_wav(self):
         try:

--- a/wisprlite/screenrec_tab.py
+++ b/wisprlite/screenrec_tab.py
@@ -128,7 +128,8 @@ def build(container, root, wheel=None, with_settings=False):
     import tkinter as tk
     from tkinter import messagebox, ttk
 
-    state = {"items": [], "selected": None, "rows": []}
+    state = {"items": [], "selected": None, "rows": [], "signature": (),
+             "poll_after": None, "destroyed": False}
 
     head = tk.Frame(container, bg=BG, padx=18, pady=14)
     head.pack(fill="x")
@@ -356,4 +357,40 @@ def build(container, root, wheel=None, with_settings=False):
     refresh_btn.pack(side="right", padx=(0, 12))
 
     refresh()
+
+    # Poll, the way the Meetings tab does. Without this the tab is a snapshot
+    # from whenever it was opened: record with it on screen and it still says
+    # "0 recordings", and a clip listed in the gap between the mux finishing and
+    # the transcript being written is stuck reading "no transcript" for ever.
+    # James hit exactly that, and the recording he sent to prove it was a video
+    # of this tab saying "Nothing recorded yet."
+    def _signature():
+        return tuple((item["stem"], item["size"], item["transcript_path"] is not None)
+                     for item in list_recordings())
+
+    def poll():
+        if state.get("destroyed"):
+            return
+        try:
+            if _signature() != state.get("signature"):
+                state["signature"] = _signature()
+                refresh(state["selected"]["stem"] if state["selected"] else None)
+        except Exception:
+            pass                     # a polling loop must not kill the window
+        state["poll_after"] = root.after(2000, poll)
+
+    def stop_polling(event=None):
+        if event is not None and event.widget is not container:
+            return
+        state["destroyed"] = True
+        after_id = state.get("poll_after")
+        if after_id:
+            try:
+                root.after_cancel(after_id)
+            except Exception:
+                pass
+
+    state["signature"] = _signature()
+    container.bind("<Destroy>", stop_polling, add="+")
+    state["poll_after"] = root.after(2000, poll)
     return settings_panel


### PR DESCRIPTION
Both bugs came out of James's first real recording, and that recording is the
evidence: he filmed the Recordings tab, and the frame at 6s shows it reading
**"0 recordings / Nothing recorded yet"** while he was recording into it.

## The tab never polled

It was a snapshot from whenever it was opened. A clip made while it was on
screen never appeared, and — worse — a clip listed in the gap between the mux
finishing and the transcript being written read "no transcript" for ever, since
the transcript is written seconds after the video.

Polls every 2s now, keyed on stem + size + whether the `.txt` exists, so a
transcript that lands later re-renders the row. Same shape as the Meetings tab,
including cancelling the `after` on destroy.

## The narration ran ahead of the picture

Measured on that clip:

| | |
|---|---|
| Video | 11.42s, 137 frames, 12.0 fps (target was 12) |
| Audio | 12.46s |
| Both start at | 0.000 |

The mic opens faster than `mss` plus the x264 container, so the audio had a
~1s head start for the whole recording. Not progressive drift — a fixed offset.

Both first-sample instants are recorded now, and the mux drops the audio
captured before there was any picture. Trimming the head rather than padding the
video is right: the missing picture never existed. Bounded so a bad clock
reading cannot eat what somebody said.

## Gates

329 passed, 7 pre-existing failures (missing faster-whisper/deepgram SDKs).
Sabotage-verified: reversing the trim direction turns the test red, as does
removing the trim from the mux path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)