### PR TITLE
fix: read the recordings folder once per poll, not twice

### DIFF
--- a/tests/test_screenrec.py
+++ b/tests/test_screenrec.py
@@ -564,7 +564,11 @@ def test_shutdown_waits_longer_than_an_upload_can_take():
 
 
 def test_the_recordings_list_notices_a_transcript_written_after_the_clip():
-    """The signature must change when the .txt lands, not only when the mp4 does.
+    """The listing and its poll signature must change when the .txt lands.
+
+    Scope: this covers list_recordings() and the signature the poll compares,
+    not the Tk callback itself — the tab-level swap behaviour is covered in
+    tests/test_ui_smoke.py.
 
     James recorded a clip while the Recordings tab was open. The tab was a
     snapshot from when it opened, so it still read "0 recordings" — the proof

--- a/wisprlite/screenrec_tab.py
+++ b/wisprlite/screenrec_tab.py
@@ -372,8 +372,13 @@ def build(container, root, wheel=None, with_settings=False):
         if state.get("destroyed"):
             return
         try:
-            if _signature() != state.get("signature"):
-                state["signature"] = _signature()
+            # Read the folder ONCE. Scanning twice stores a signature from a
+            # later read than the one that triggered the render, so a file that
+            # lands between the two reads is recorded as already-seen and never
+            # gets drawn.
+            current = _signature()
+            if current != state.get("signature"):
+                state["signature"] = current
                 refresh(state["selected"]["stem"] if state["selected"] else None)
         except Exception:
             pass                     # a polling loop must not kill the window


### PR DESCRIPTION
From the jury panel on #50.

`poll()` called `_signature()` twice — once to compare, once to store. The
stored value therefore came from a LATER read than the one that triggered the
render, so a file landing between the two reads was recorded as already-seen
and never got drawn. Same class of miss the polling was added to fix, one tick
wide.

Also narrowed a test docstring that implied it covered the Tk callback. It
covers `list_recordings()` and the signature, and now says so.

Refuted from the same panel: `refresh()` with a stem deleted since the last
poll is already safe — it falls back to `items[0]` and returns early on an empty
list.

329 passed, 7 pre-existing failures (missing faster-whisper/deepgram SDKs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)