### PR TITLE
feat: a real recording pill with controls, and the clip handed straight over

### DIFF
--- a/tests/test_overlay.py
+++ b/tests/test_overlay.py
@@ -262,7 +262,10 @@ def test_dragging_the_meeting_pill_moves_it_instead_of_stopping_the_meeting():
         root.update()
 
         clicks = []
-        Overlay._bind_drag_or_click(canvas, root, lambda: clicks.append(1))
+        # The callback takes coordinates now: the recording pill carries
+        # buttons, so a click has to say WHERE it landed.
+        Overlay._bind_drag_or_click(canvas, root,
+                                    lambda x, y: clicks.append((x, y)))
 
         x0, y0 = root.winfo_x(), root.winfo_y()
         canvas.event_generate("<Button-1>", rootx=x0 + 10, rooty=y0 + 10)
@@ -280,7 +283,7 @@ def test_dragging_the_meeting_pill_moves_it_instead_of_stopping_the_meeting():
         canvas.event_generate("<Button-1>", rootx=x1 + 10, rooty=y1 + 10)
         canvas.event_generate("<ButtonRelease-1>", rootx=x1 + 10, rooty=y1 + 10)
         root.update()
-        assert clicks == [1], "a click without a drag must still toggle"
+        assert len(clicks) == 1, "a click without a drag must still toggle"
         assert (root.winfo_x(), root.winfo_y()) == (x1, y1)
 
         # A pixel of jitter during a click is still a click, not a drag.
@@ -288,7 +291,7 @@ def test_dragging_the_meeting_pill_moves_it_instead_of_stopping_the_meeting():
         canvas.event_generate("<B1-Motion>", rootx=x1 + 11, rooty=y1 + 10)
         canvas.event_generate("<ButtonRelease-1>", rootx=x1 + 11, rooty=y1 + 10)
         root.update()
-        assert clicks == [1, 1], "1px of jitter must not swallow the click"
+        assert len(clicks) == 2, "1px of jitter must not swallow the click"
     finally:
         root.destroy()
 

--- a/tests/test_screenrec.py
+++ b/tests/test_screenrec.py
@@ -602,3 +602,66 @@ def test_the_recordings_list_notices_a_transcript_written_after_the_clip():
         assert signature(first) != signature(second), (
             "the poll signature must change when a transcript appears, or the "
             "tab never re-renders and 'no transcript' sticks")
+
+
+def test_pausing_drops_both_streams_so_they_stay_aligned():
+    """Pause must stop audio AND video, or the paused stretch exists in one
+    stream and not the other and everything after it is out of sync."""
+    with tempfile.TemporaryDirectory() as tmp:
+        rec = _recording(tmp)
+        block = np.full((800, 1), 0.25, dtype=np.float32)
+
+        rec._on_mic_block(block, 800, None, None)
+        assert rec._audio_queue.qsize() == 1
+        assert rec.first_audio_at is not None
+
+        rec.pause()
+        assert rec.paused
+        for _ in range(5):
+            rec._on_mic_block(block, 800, None, None)
+        assert rec._audio_queue.qsize() == 1, "audio kept flowing while paused"
+
+        rec.resume()
+        assert not rec.paused
+        rec._on_mic_block(block, 800, None, None)
+        assert rec._audio_queue.qsize() == 2, "audio did not resume"
+
+
+def test_elapsed_excludes_time_spent_paused():
+    """The pill's clock has to show recorded seconds, not wall clock, or it
+    disagrees with the length of the file it produces."""
+    with tempfile.TemporaryDirectory() as tmp:
+        rec = _recording(tmp)
+        assert rec.elapsed() == 0.0            # nothing captured yet
+
+        now = time.monotonic()
+        rec.first_audio_at = now - 10.0
+        assert rec.elapsed() == pytest.approx(10.0, abs=0.2)
+
+        rec.pause()
+        rec._paused_at = now - 4.0             # as if paused 4 seconds ago
+        assert rec.elapsed() == pytest.approx(6.0, abs=0.2), \
+            "a paused recording's clock must stop"
+
+        rec.resume()
+        assert rec.paused_seconds == pytest.approx(4.0, abs=0.2)
+        assert rec.elapsed() == pytest.approx(6.0, abs=0.2), \
+            "resuming must not give back the paused time"
+
+
+def test_the_pill_buttons_are_where_the_clicks_are_caught():
+    """One table drives both drawing and hit-testing, so this proves the
+    geometry a user aims at is the geometry that answers."""
+    from wisprlite.overlay import Overlay, WIN_H
+
+    overlay = Overlay(enabled=False)
+    cy = WIN_H // 2
+    for action, cx in Overlay.SCREENREC_BUTTONS:
+        assert overlay._screenrec_hit(cx, cy) == action
+        assert overlay._screenrec_hit(cx, cy - 4) == action
+    # The pill body is not a button - dragging it must stay possible.
+    assert overlay._screenrec_hit(30, cy) == ""
+    assert overlay._screenrec_hit(120, cy) == ""
+    # And the buttons must not overlap each other.
+    hits = [overlay._screenrec_hit(cx, cy) for _a, cx in Overlay.SCREENREC_BUTTONS]
+    assert len(set(hits)) == len(hits)

--- a/tests/test_ui_smoke.py
+++ b/tests/test_ui_smoke.py
@@ -918,3 +918,29 @@ def test_pausing_pipevoice_also_stops_screen_recording():
 
     app.paused, app._screenrec = False, None
     assert App._screen_recording_paused(app) is False
+
+
+def test_pressing_stop_twice_does_not_start_a_new_recording():
+    """Stop clears _screenrec immediately, then muxes/uploads for seconds while
+    the pill is still up. A second press in that window must do nothing, not
+    fall through to "nothing is recording" and open a region selector."""
+    from unittest import mock
+    from wisprlite.app import App
+
+    app = App.__new__(App)
+    app._screenrec = object()
+    app._fail = mock.Mock()
+    app.toggle_screen_recording = mock.Mock()
+
+    App._screenrec_action(app, "stop")
+    assert app.toggle_screen_recording.call_count == 1
+
+    app._screenrec = None                     # as the finish path leaves it
+    App._screenrec_action(app, "stop")
+    assert app.toggle_screen_recording.call_count == 1, \
+        "a second Stop started a brand-new recording"
+
+    # Pause and resume on a finished recording are equally no-ops.
+    App._screenrec_action(app, "pause")
+    App._screenrec_action(app, "resume")
+    assert not app._fail.called

--- a/wisprlite/__init__.py
+++ b/wisprlite/__init__.py
@@ -1,3 +1,3 @@
 """Pipevoice — push-to-talk voice typing for Windows."""
 
-__version__ = "2.38.1"
+__version__ = "2.39.0"

--- a/wisprlite/app.py
+++ b/wisprlite/app.py
@@ -490,12 +490,17 @@ class App:
     def _screenrec_action(self, action: str) -> None:
         """A button on the recording pill. Runs on the overlay's worker thread."""
         recording = self._screenrec
+        if recording is None:
+            # Stop clears _screenrec immediately and then muxes, transcribes and
+            # uploads on a thread — seconds during which the pill is still up.
+            # Without this guard a second press of Stop in that window falls
+            # through to toggle_screen_recording's "nothing is recording" branch
+            # and opens a region selector to start a NEW one.
+            return
         if action == "stop":
             # Same path as the hotkey, so there is exactly one way to finish a
             # recording and both routes get the naming, transcript and send.
             self.toggle_screen_recording()
-            return
-        if recording is None:
             return
         try:
             if action == "pause":

--- a/wisprlite/app.py
+++ b/wisprlite/app.py
@@ -47,6 +47,8 @@ class App:
             level_provider=lambda: self.recorder.level,
             meeting_provider=self._meeting_overlay_state,
             on_meeting_click=self.toggle_meeting,
+            screenrec_provider=self._screenrec_overlay_state,
+            on_screenrec_action=self._screenrec_action,
             enabled=self.cfg.overlay,
         )
         self.tray = Tray(self)
@@ -475,6 +477,34 @@ class App:
         return bool(self.paused) and self._screenrec is None
 
 
+    def _screenrec_overlay_state(self) -> dict:
+        """What the pill draws. Read from the recorder, never from a copy."""
+        recording = self._screenrec
+        if recording is None:
+            return {"elapsed": 0.0, "paused": False}
+        try:
+            return {"elapsed": recording.elapsed(), "paused": recording.paused}
+        except Exception:
+            return {"elapsed": 0.0, "paused": False}
+
+    def _screenrec_action(self, action: str) -> None:
+        """A button on the recording pill. Runs on the overlay's worker thread."""
+        recording = self._screenrec
+        if action == "stop":
+            # Same path as the hotkey, so there is exactly one way to finish a
+            # recording and both routes get the naming, transcript and send.
+            self.toggle_screen_recording()
+            return
+        if recording is None:
+            return
+        try:
+            if action == "pause":
+                recording.pause()
+            elif action == "resume":
+                recording.resume()
+        except Exception as exc:
+            self._fail(f"screen recording: {exc}")
+
     def toggle_screen_recording(self) -> None:
         """Hotkey once: pick a region and record. Again: stop, transcribe, send."""
         if self._screenrec is not None:
@@ -510,7 +540,7 @@ class App:
             )
             recording.start()
             self._screenrec = recording
-            self.overlay.show("recording", "\u23fa recording — press the hotkey again to stop")
+            self.overlay.show_screenrec()
         except Exception as exc:
             self._screenrec = None
             self._fail(f"screen recording: {exc}")
@@ -590,6 +620,10 @@ class App:
                 self.overlay.show("done", f"\u2713 sent to {destination}{note}")
             else:
                 self.overlay.show("done", f"\u2713 saved to {video.parent}{note}")
+            # Hand the clip straight over: the path on the clipboard is what
+            # gets pasted to an agent, and the tab opens on the new recording so
+            # you can play it back without going looking for it.
+            self._handoff_recording(video, recording.stem)
         except Exception as exc:
             self._fail(f"screen recording: {exc}")
         finally:
@@ -603,6 +637,22 @@ class App:
                     "error": "; ".join(recording.errors[:2]) or "the recording produced no file",
                 }
                 waiter.set()
+
+    def _handoff_recording(self, video, stem: str) -> None:
+        """Clipboard, then the Recordings tab open on this clip.
+
+        Deliberately AFTER the send: the path is only worth pasting once the
+        file it names is finished. Failures here are cosmetic - the recording
+        is already safe on disk - so neither step is allowed to raise.
+        """
+        try:
+            copy_clipboard(str(video))
+        except Exception as exc:
+            log.info("screenrec: could not copy the path: %s", exc)
+        try:
+            self.open_settings(tab="Recordings", select=stem)
+        except Exception as exc:
+            log.info("screenrec: could not open the Recordings tab: %s", exc)
 
     @staticmethod
     def _read_text(path) -> str:
@@ -937,18 +987,26 @@ class App:
             self.stop_mcp_bridge()
         self.tray.update()
 
-    def open_settings(self) -> None:
+    def open_settings(self, tab: str = "", select: str = "") -> None:
         import os
         import subprocess
 
+        # The settings window is a separate process, so "open it on the
+        # Recordings tab with this clip picked" has to travel as environment.
+        env = dict(os.environ)
+        if tab:
+            env["PV_TAB"] = tab
+        if select:
+            env["PV_SELECT"] = select
         try:
             if getattr(sys, "frozen", False):
-                subprocess.Popen([sys.executable, "--settings"])
+                subprocess.Popen([sys.executable, "--settings"], env=env)
             else:
                 from .autostart import _pythonw
 
                 parent = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-                subprocess.Popen([_pythonw(), "-m", "wisprlite", "--settings"], cwd=parent)
+                subprocess.Popen([_pythonw(), "-m", "wisprlite", "--settings"],
+                                 cwd=parent, env=env)
         except Exception as exc:
             self._fail(f"settings: {exc}")
 

--- a/wisprlite/overlay.py
+++ b/wisprlite/overlay.py
@@ -44,6 +44,7 @@ ACCENT = {
     "idle": PALETTE["muted"],
     "picker": PALETTE["picker"],
     "meeting": PALETTE["meeting"],
+    "screenrec": PALETTE["meeting"],
 }
 
 
@@ -111,10 +112,17 @@ class Overlay:
         enabled: bool = True,
         meeting_provider: Optional[Callable[[], dict]] = None,
         on_meeting_click: Optional[Callable[[], None]] = None,
+        screenrec_provider: Optional[Callable[[], dict]] = None,
+        on_screenrec_action: Optional[Callable[[str], None]] = None,
     ) -> None:
         self.level_provider = level_provider or (lambda: 0.0)
         self.meeting_provider = meeting_provider or (lambda: {})
         self.on_meeting_click = on_meeting_click
+        # {"elapsed": float, "paused": bool} — polled each frame so the pill's
+        # clock and its button states come from the recorder, never from a copy
+        # of them that can drift out of step with it.
+        self.screenrec_provider = screenrec_provider or (lambda: {})
+        self.on_screenrec_action = on_screenrec_action
         self.enabled = enabled
         self._q: "queue.Queue[tuple]" = queue.Queue()
         self._thread: Optional[threading.Thread] = None
@@ -149,6 +157,10 @@ class Overlay:
     def show_meeting(self) -> None:
         self._q.put(("meeting", None, ""))
 
+    def show_screenrec(self) -> None:
+        """Show the recording pill. Its clock and buttons poll the recorder."""
+        self._q.put(("screenrec", None, ""))
+
     # ---- tkinter thread ---------------------------------------------------
     def _run(self) -> None:
         try:
@@ -182,7 +194,7 @@ class Overlay:
         canvas = tk.Canvas(root, width=WIN_W, height=WIN_H, bg=bg, highlightthickness=0)
         canvas.pack()
         self._bind_drag_or_click(
-            canvas, root, lambda: self._q.put(("meeting_click", None, "")))
+            canvas, root, lambda x, y: self._q.put(("click", x, y)))
         canvas.bind("<Enter>", lambda _event: self._q.put(("hover", True, "")))
         canvas.bind("<Leave>", lambda _event: self._q.put(("hover", False, "")))
         root.withdraw()
@@ -248,10 +260,16 @@ class Overlay:
                         # state = tip, text = because. Rendered on THIS thread,
                         # which is the only one allowed to touch Tk.
                         self._render_focus_tip(canvas, state, text)
-                    if kind == "meeting_click":
+                    if kind == "click":
                         if st["name"] == "meeting" and self.on_meeting_click:
                             callback = self.on_meeting_click
                             threading.Thread(target=callback, daemon=True).start()
+                        elif st["name"] == "screenrec" and self.on_screenrec_action:
+                            action = self._screenrec_hit(state, text)
+                            if action:
+                                handler = self.on_screenrec_action
+                                threading.Thread(target=handler, args=(action,),
+                                                 daemon=True).start()
                     elif kind == "hover":
                         st["hover"] = bool(state)
                     if kind == "hide":
@@ -262,6 +280,13 @@ class Overlay:
                         st["name"] = state or "listening"
                         st["text"] = text or ""
                         st["hide_at"] = 0.0
+                        resize(WIN_H)
+                        reveal()
+                    elif kind == "screenrec":
+                        st["name"] = "screenrec"
+                        st["text"] = ""
+                        st["hide_at"] = 0.0
+                        st["scene"] = None
                         resize(WIN_H)
                         reveal()
                     elif kind == "meeting":
@@ -326,6 +351,9 @@ class Overlay:
             return
         if st["name"] == "meeting":
             self._draw_meeting(c, st, H, accent)
+            return
+        if st["name"] == "screenrec":
+            self._draw_screenrec(c, st, H, accent)
             return
         self._draw_status(c, st, H, accent)
 
@@ -529,6 +557,91 @@ class Overlay:
                 items[f"{label}_label"],
                 fill=PALETTE["error"] if dead else PALETTE["muted"],
             )
+    # Button geometry for the recording pill, in canvas coordinates. One table,
+    # used to DRAW and to HIT-TEST, so a button can never sit somewhere other
+    # than where the click for it is caught.
+    SCREENREC_BUTTONS = (
+        ("resume", WIN_W - 122),
+        ("pause", WIN_W - 84),
+        ("stop", WIN_W - 46),
+    )
+    SCREENREC_BUTTON_R = 15
+
+    def _screenrec_hit(self, x, y) -> str:
+        """Which button a click at (x, y) landed on, or "" for the pill body."""
+        cy = WIN_H // 2
+        for action, cx in self.SCREENREC_BUTTONS:
+            if (x - cx) ** 2 + (y - cy) ** 2 <= (self.SCREENREC_BUTTON_R + 3) ** 2:
+                return action
+        return ""
+
+    def _draw_screenrec(self, c, st, H: int, accent: str) -> None:
+        """The recording pill: a breathing REC dot, a clock, and real controls.
+
+        It used to be a grey box reading "recording - press the hotkey again to
+        stop", which told you the one thing you had just done and gave you
+        nothing to press.
+        """
+        items = self._base_scene(c, st, "screenrec", H, accent)
+        cy = H // 2
+        info = {}
+        try:
+            info = self.screenrec_provider() or {}
+        except Exception:
+            info = {}
+        paused = bool(info.get("paused"))
+        elapsed = self._elapsed_text(info.get("elapsed", 0.0))
+
+        if "dot" not in items:
+            items["dot"] = c.create_oval(0, 0, 0, 0, outline="")
+            items["clock"] = c.create_text(
+                44, cy, anchor="w", fill=PALETTE["fg"],
+                font=("Segoe UI Semibold", 15),
+            )
+            items["label"] = c.create_text(
+                44, cy + 15, anchor="w", fill=PALETTE["muted"],
+                font=("Segoe UI", 8),
+            )
+            for action, cx in self.SCREENREC_BUTTONS:
+                r = self.SCREENREC_BUTTON_R
+                items[f"{action}_bg"] = c.create_oval(
+                    cx - r, cy - r, cx + r, cy + r,
+                    fill=PALETTE["card"], outline="", width=1,
+                )
+                items[f"{action}_icon"] = c.create_text(
+                    cx, cy, text="", fill=PALETTE["fg"], font=("Segoe UI", 11),
+                )
+
+        # A paused recording must not keep breathing — a pulsing red dot is the
+        # universal "still rolling", and showing it while paused is a lie.
+        breath = 0.0 if paused else (math.sin(st["phase"]) + 1.0) / 2.0
+        dot_colour = PALETTE["muted"] if paused else self._blend(
+            PALETTE["meeting"], PALETTE["meeting_hi"], breath)
+        dot_r = 6.0 + (0.0 if paused else 2.0 * breath)
+        c.coords(items["dot"], 24 - dot_r, cy - dot_r, 24 + dot_r, cy + dot_r)
+        c.itemconfigure(items["dot"], fill=dot_colour)
+        c.itemconfigure(items["clock"], text=elapsed,
+                        fill=PALETTE["muted"] if paused else PALETTE["fg"])
+        c.itemconfigure(items["label"], text="Paused" if paused else "Recording")
+
+        # Grey out the control that cannot do anything right now, rather than
+        # hiding it: buttons that move around are worse than buttons that dim.
+        states = {
+            "resume": ("▶", paused),
+            "pause": ("⏸", not paused),
+            "stop": ("⏹", True),
+        }
+        for action, _cx in self.SCREENREC_BUTTONS:
+            glyph, live = states[action]
+            c.itemconfigure(items[f"{action}_icon"], text=glyph,
+                            fill=PALETTE["fg"] if live else PALETTE["div"])
+            # A disabled button keeps a faint ring. Filled flat with the pill's
+            # own background it disappeared, which reads as "a button is
+            # missing" rather than "that one cannot do anything right now".
+            c.itemconfigure(items[f"{action}_bg"],
+                            fill=PALETTE["card"] if live else PALETTE["bg"],
+                            outline="" if live else PALETTE["div"])
+
     def _draw_status(self, c, st, H: int, accent: str) -> None:
         items = self._base_scene(c, st, "status", H, accent)
         cy = WIN_H // 2
@@ -624,9 +737,11 @@ class Overlay:
             state["x"], state["y"] = event.x_root, event.y_root
             window.geometry(f"+{window.winfo_x() + dx}+{window.winfo_y() + dy}")
 
-        def release(_event) -> None:
+        def release(event) -> None:
             if not state["moved"]:
-                on_click()
+                # Coordinates matter now: the recording pill carries buttons, so
+                # WHERE the click landed decides what it means.
+                on_click(event.x, event.y)
 
         widget.bind("<Button-1>", press)
         widget.bind("<B1-Motion>", drag)

--- a/wisprlite/screenrec.py
+++ b/wisprlite/screenrec.py
@@ -83,6 +83,12 @@ class ScreenRecording:
         # drop that leading second instead of guessing.
         self.first_frame_at: float | None = None
         self.first_audio_at: float | None = None
+        # Pause drops BOTH streams together. Skipped frames and skipped audio
+        # blocks simply never exist, so the paused stretch is cut out of the
+        # finished clip and the two stay aligned without any extra bookkeeping.
+        self._paused = threading.Event()
+        self.paused_seconds = 0.0
+        self._paused_at: float | None = None
 
     # -- paths ---------------------------------------------------------------
 
@@ -216,6 +222,13 @@ class ScreenRecording:
             with mss.mss() as sct:
                 next_at = time.monotonic()
                 while not self._stop.is_set():
+                    if self._paused.is_set():
+                        # Skip the grab entirely rather than encoding a frozen
+                        # frame: a paused stretch should not exist in the clip.
+                        if self._stop.wait(0.1):
+                            return
+                        next_at = time.monotonic()
+                        continue
                     shot = sct.grab(box)
                     # BGRA -> RGB, dropping alpha.
                     frame = np.array(shot, dtype=np.uint8)[:, :, :3][:, :, ::-1]
@@ -291,6 +304,8 @@ class ScreenRecording:
         try:
             import numpy as np
 
+            if self._paused.is_set():
+                return               # dropped here, so the mic is genuinely off
             if self.first_audio_at is None:
                 self.first_audio_at = time.monotonic()
             self._audio_queue.put_nowait(
@@ -373,6 +388,37 @@ class ScreenRecording:
         except Exception as exc:
             self._record_error(exc)
             return None
+
+    # -- pause ---------------------------------------------------------------
+
+    @property
+    def paused(self) -> bool:
+        return self._paused.is_set()
+
+    def pause(self) -> None:
+        if self._paused.is_set():
+            return
+        self._paused_at = time.monotonic()
+        self._paused.set()
+
+    def resume(self) -> None:
+        if not self._paused.is_set():
+            return
+        if self._paused_at is not None:
+            self.paused_seconds += max(0.0, time.monotonic() - self._paused_at)
+            self._paused_at = None
+        self._paused.clear()
+
+    def elapsed(self) -> float:
+        """Seconds of RECORDING, excluding any time spent paused."""
+        if self.first_audio_at is None and self.first_frame_at is None:
+            return 0.0
+        started = min(t for t in (self.first_audio_at, self.first_frame_at)
+                      if t is not None)
+        paused = self.paused_seconds
+        if self._paused_at is not None:
+            paused += max(0.0, time.monotonic() - self._paused_at)
+        return max(0.0, time.monotonic() - started - paused)
 
     def lead_seconds(self) -> float:
         """How long the microphone ran before the first frame was encoded."""

--- a/wisprlite/screenrec_tab.py
+++ b/wisprlite/screenrec_tab.py
@@ -347,16 +347,25 @@ def build(container, root, wheel=None, with_settings=False):
         ("Copy text", _copy_words, "Copy the transcript."),
         ("Delete", _delete_selected, "Remove the video, transcript and audio from this PC."),
     )
+    action_buttons = {}
     for index, (label, command, tip) in enumerate(actions):
         btn = ttk.Button(buttons, text=label, command=command, width=11)
         btn.grid(row=index // 3, column=index % 3, padx=(0, 5), pady=(0, 5), sticky="w")
         tooltip(btn, tip)
+        action_buttons[label] = btn
 
     refresh_btn = ttk.Button(head, text="Refresh", command=lambda: refresh(
         state["selected"]["stem"] if state["selected"] else None))
     refresh_btn.pack(side="right", padx=(0, 12))
 
-    refresh()
+    # Opened straight after a recording: land on that clip with Play accented,
+    # so the obvious next move is the one under the cursor rather than something
+    # to go hunting for. Any other way of opening the tab is unaffected.
+    just_recorded = os.environ.get("PV_SELECT", "").strip()
+    refresh(just_recorded or None)
+    if just_recorded and state["selected"] and state["selected"]["stem"] == just_recorded:
+        action_buttons["Play"].configure(style="Accent.TButton")
+        action_buttons["Play"].focus_set()
 
     # Poll, the way the Meetings tab does. Without this the tab is a snapshot
     # from whenever it was opened: record with it on screen and it still says


### PR DESCRIPTION
## The pill

Was a grey box reading "recording — press the hotkey again to stop": it told
you the one thing you had just done and gave you nothing to press.

Now: a breathing REC dot, a clock of RECORDED seconds, and resume / pause /
stop. A paused pill stops breathing and greys its dot — a pulsing red dot means
"still rolling", and showing one while paused is a lie. Disabled buttons keep a
faint ring rather than vanishing into the pill background, which read as a
missing button rather than an unavailable one.

One geometry table drives both drawing and hit-testing, so a button cannot sit
somewhere other than where its click is caught. Dragging the pill by its body
still works; click callbacks now carry coordinates, since where a click lands
decides what it means.

## Pause is real, not cosmetic

New in `ScreenRecording`. It drops BOTH streams together, so a paused stretch
never exists in either and they stay aligned with no extra bookkeeping. The
clock excludes paused time, or it would disagree with the length of the file it
produces.

## Hand-off after naming

The clip is handed over instead of left to be found:

1. path on the clipboard (what actually gets pasted to an agent)
2. Recordings tab opens on that clip, already selected
3. Play accented and focused

Both steps run after the send and neither may raise — the recording is already
safe on disk, so a clipboard failure must not endanger it. Travels to the
settings subprocess as `PV_TAB` / `PV_SELECT`.

## Gates

332 passed, 7 pre-existing failures (missing faster-whisper/deepgram SDKs).
Sabotage-verified: removing the pause gate turns the "audio kept flowing while
paused" test red. Both pill states rendered and inspected, not assumed.

## Unverified

The ▶ ⏸ ⏹ glyphs were rendered through a Linux font stack. Windows may draw
them differently; if they come out as boxes they become drawn shapes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)