### PR TITLE
feat: one pill for the whole recording, from REC dot to finished clip

### DIFF
--- a/tests/test_screenrec.py
+++ b/tests/test_screenrec.py
@@ -650,18 +650,70 @@ def test_elapsed_excludes_time_spent_paused():
 
 
 def test_the_pill_buttons_are_where_the_clicks_are_caught():
-    """One table drives both drawing and hit-testing, so this proves the
-    geometry a user aims at is the geometry that answers."""
+    """One table drives both drawing and hit-testing, in every phase, so this
+    proves the geometry a user aims at is the geometry that answers."""
     from wisprlite.overlay import Overlay, WIN_H
 
     overlay = Overlay(enabled=False)
     cy = WIN_H // 2
+
     for action, cx in Overlay.SCREENREC_BUTTONS:
-        assert overlay._screenrec_hit(cx, cy) == action
-        assert overlay._screenrec_hit(cx, cy - 4) == action
+        assert overlay._screenrec_hit(cx, cy, "recording") == action
+        assert overlay._screenrec_hit(cx, cy - 4, "recording") == action
     # The pill body is not a button - dragging it must stay possible.
-    assert overlay._screenrec_hit(30, cy) == ""
-    assert overlay._screenrec_hit(120, cy) == ""
-    # And the buttons must not overlap each other.
-    hits = [overlay._screenrec_hit(cx, cy) for _a, cx in Overlay.SCREENREC_BUTTONS]
-    assert len(set(hits)) == len(hits)
+    assert overlay._screenrec_hit(30, cy, "recording") == ""
+    assert overlay._screenrec_hit(120, cy, "recording") == ""
+    hits = [overlay._screenrec_hit(cx, cy, "recording")
+            for _a, cx in Overlay.SCREENREC_BUTTONS]
+    assert len(set(hits)) == len(hits), "two buttons answer the same click"
+
+    # Naming reuses the last two slots, on the row the entry sits on (y=56).
+    save_cx, skip_cx = Overlay.SCREENREC_BUTTONS[1][1], Overlay.SCREENREC_BUTTONS[2][1]
+    assert overlay._screenrec_hit(save_cx, 56, "naming") == "save"
+    assert overlay._screenrec_hit(skip_cx, 56, "naming") == "skip"
+    assert overlay._screenrec_hit(Overlay.SCREENREC_BUTTONS[0][1], 56, "naming") == "", \
+        "the resume slot must be dead while naming"
+
+    # Nothing is clickable while it is finishing.
+    for _a, cx in Overlay.SCREENREC_BUTTONS:
+        assert overlay._screenrec_hit(cx, cy, "working") == ""
+
+    # The finished row: named buttons, and their boxes must not overlap.
+    boxes = [overlay._done_button_box(i) for i in range(len(Overlay.SCREENREC_DONE))]
+    for index, (action, _label) in enumerate(Overlay.SCREENREC_DONE):
+        x1, y1, x2, y2 = boxes[index]
+        assert overlay._screenrec_hit((x1 + x2) // 2, (y1 + y2) // 2, "done") == action
+        assert x1 >= 0 and x2 <= 380, "a button is off the edge of the pill"
+    for left, right in zip(boxes, boxes[1:]):
+        assert left[2] < right[0], "two finished-clip buttons overlap"
+    assert overlay._screenrec_hit(190, 20, "done") == "", "the title row is not a button"
+
+
+def test_the_pill_naming_hands_back_what_was_typed_and_never_blocks_for_ever():
+    """Naming moved into the pill, so the finish thread waits on an Event rather
+    than a modal. It must survive nobody ever answering."""
+    from uistub import install_platform_stubs
+
+    install_platform_stubs()          # app.py pulls in sounddevice via audio.py
+    from wisprlite.app import ScreenrecUI
+
+    ui = ScreenrecUI()
+    assert ui.snapshot()["phase"] == "recording"
+
+    event = ui.expect_name("2026-08-12 17-32-18")
+    state = ui.snapshot()
+    assert state["phase"] == "naming"
+    assert state["name"] == "2026-08-12 17-32-18"
+    assert not event.is_set()
+
+    ui.answer_name("  login bug  ")
+    assert event.is_set()
+    assert ui.take_name() == "login bug", "the typed name must survive, trimmed"
+    assert ui.take_name() == "", "the name is consumed once"
+    assert ui.snapshot()["phase"] == "working", "answering must move the pill on"
+
+    # Skip is an empty answer, not a missing one.
+    ui.expect_name("stamp")
+    ui.answer_name("")
+    assert ui.take_name() == ""
+    assert ui.snapshot()["phase"] == "working"

--- a/tests/test_ui_smoke.py
+++ b/tests/test_ui_smoke.py
@@ -970,7 +970,6 @@ def test_the_finished_pill_never_announces_the_scp_destination():
     recording.audio_path = pathlib.Path("/out/2026-08-12 17-32-18.wav")
     app._screenrec = recording
     app._transcribe_recording = mock.Mock(return_value=None)
-    app._handoff_recording = mock.Mock()
 
     with mock.patch.object(App, "_ask_name_in_pill", return_value=""), \
          mock.patch.object(screenrec, "send", return_value=(True, "ok")):
@@ -983,3 +982,39 @@ def test_the_finished_pill_never_announces_the_scp_destination():
         f"the pill is naming a destination again: {blob}"
     assert "sent" in state["title"].lower(), \
         "it must still say the clip went somewhere, just not where"
+
+
+def test_a_failed_send_does_not_strand_the_pill_on_a_progress_bar():
+    """The pill is phase-driven, so any path that does not reach "done" must
+    put it away. Left as-is the user watches a sweeping bar for ever."""
+    from unittest import mock
+    from wisprlite.app import App
+    from wisprlite import screenrec
+
+    app = _agent_app()
+    app._screenrec_agent = None
+    recording = mock.Mock()
+    recording.errors = []
+    recording.stem = "2026-08-12 17-32-18"
+    recording.stop.return_value = pathlib.Path("/out/clip.mp4")
+    recording.audio_path = pathlib.Path("/out/clip.wav")
+    app._screenrec = recording
+    app._transcribe_recording = mock.Mock(return_value=None)
+
+    with mock.patch.object(App, "_ask_name_in_pill", return_value=""), \
+         mock.patch.object(screenrec, "send", return_value=(False, "connection refused")):
+        App._finish_screen_recording(app)
+
+    assert app._screenrec_ui.snapshot()["phase"] == "recording", \
+        "a failed send left the pill mid-flight"
+    assert app.overlay.hide.called, "the pill must be put away, not left up"
+    assert app._fail.called, "and the failure must still be reported"
+
+    # An exception anywhere in the flow must land the same way.
+    app2 = _agent_app()
+    app2._screenrec_agent = None
+    app2._screenrec = recording
+    app2._transcribe_recording = mock.Mock(side_effect=RuntimeError("boom"))
+    with mock.patch.object(App, "_ask_name_in_pill", return_value=""):
+        App._finish_screen_recording(app2)
+    assert app2._screenrec_ui.snapshot()["phase"] == "recording"

--- a/tests/test_ui_smoke.py
+++ b/tests/test_ui_smoke.py
@@ -742,13 +742,15 @@ def _agent_app(**over):
     """An App shaped just enough to run the agent screen-recording path."""
     import types
     from unittest import mock
-    from wisprlite.app import App
+    from wisprlite.app import App, ScreenrecUI
 
     app = App.__new__(App)
     app._screenrec = None
     app._screenrec_selecting = False
     app._screenrec_agent = None
     app._screenrec_agent_result = None
+    app._screenrec_ui = ScreenrecUI()
+    app._finished_recording = None
     app.paused = False
     app.overlay = mock.Mock()
     app._notify = mock.Mock()
@@ -782,11 +784,11 @@ def test_an_agent_call_never_uploads_the_recording():
     app._transcribe_recording = mock.Mock(return_value=None)
 
     with mock.patch.object(screenrec, "send") as send, \
-         mock.patch.object(screenrec, "ask_name") as ask:
+         mock.patch.object(App, "_ask_name_in_pill") as ask:
         App._finish_screen_recording(app)
 
     assert not send.called, "an agent-driven recording must never be uploaded"
-    assert not ask.called, "an agent-driven recording must not block on a dialog"
+    assert not ask.called, "an agent-driven recording must not stop for a name"
     assert app._screenrec_agent_result["status"] == "ok"
     assert app._screenrec_agent_result["uploaded"] is False
     assert app._screenrec_agent_result["video_path"].endswith(".mp4")
@@ -855,12 +857,14 @@ def test_quitting_does_not_open_the_naming_dialog():
     """
     import types
     from unittest import mock
-    from wisprlite.app import App
+    from wisprlite.app import App, ScreenrecUI
     from wisprlite import screenrec
 
     app = App.__new__(App)
     app._screenrec_agent = None
     app._screenrec_agent_result = None
+    app._screenrec_ui = ScreenrecUI()
+    app._finished_recording = None
     recording = types.SimpleNamespace(
         stem="2026-08-12 10-33-25",
         errors=[],
@@ -873,12 +877,12 @@ def test_quitting_does_not_open_the_naming_dialog():
     app._fail = mock.Mock()
     app._transcribe_recording = mock.Mock(return_value=None)
 
-    with mock.patch.object(screenrec, "ask_name") as ask:
+    with mock.patch.object(App, "_ask_name_in_pill") as ask:
         App._finish_screen_recording(app, ask=False)
-        assert not ask.called, "shutdown must not open a modal that waits for input"
+        assert not ask.called, "shutdown must not wait for a name it cannot be given"
 
     app._screenrec = recording
-    with mock.patch.object(screenrec, "ask_name", return_value="") as ask:
+    with mock.patch.object(App, "_ask_name_in_pill", return_value="") as ask:
         App._finish_screen_recording(app)
         assert ask.called, "the normal stop path still asks for a name"
 
@@ -944,3 +948,38 @@ def test_pressing_stop_twice_does_not_start_a_new_recording():
     App._screenrec_action(app, "pause")
     App._screenrec_action(app, "resume")
     assert not app._fail.called
+
+
+def test_the_finished_pill_never_announces_the_scp_destination():
+    """It used to sit open reading "sent to root@host:/srv/inbox/" - a string
+    the user configured, that never changes, and that they had to dismiss.
+
+    Drives the REAL finish path with a destination configured: asserting on a
+    hand-built state object cannot catch the caller putting a host back in.
+    """
+    from unittest import mock
+    from wisprlite.app import App
+    from wisprlite import screenrec
+
+    app = _agent_app()
+    app._screenrec_agent = None
+    recording = mock.Mock()
+    recording.errors = []
+    recording.stem = "2026-08-12 17-32-18"
+    recording.stop.return_value = pathlib.Path("/out/2026-08-12 17-32-18.mp4")
+    recording.audio_path = pathlib.Path("/out/2026-08-12 17-32-18.wav")
+    app._screenrec = recording
+    app._transcribe_recording = mock.Mock(return_value=None)
+    app._handoff_recording = mock.Mock()
+
+    with mock.patch.object(App, "_ask_name_in_pill", return_value=""), \
+         mock.patch.object(screenrec, "send", return_value=(True, "ok")):
+        App._finish_screen_recording(app)
+
+    state = app._screenrec_ui.snapshot()
+    assert state["phase"] == "done"
+    blob = " ".join(str(v) for v in state.values())
+    assert "root@vps" not in blob and ":/inbox/" not in blob, \
+        f"the pill is naming a destination again: {blob}"
+    assert "sent" in state["title"].lower(), \
+        "it must still say the clip went somewhere, just not where"

--- a/wisprlite/__init__.py
+++ b/wisprlite/__init__.py
@@ -1,3 +1,3 @@
 """Pipevoice — push-to-talk voice typing for Windows."""
 
-__version__ = "2.39.0"
+__version__ = "2.40.0"

--- a/wisprlite/app.py
+++ b/wisprlite/app.py
@@ -61,7 +61,17 @@ class ScreenrecUI:
     def answer_name(self, typed: str) -> None:
         with self._lock:
             self._name = (typed or "").strip()
-            self._state.update(phase="working", status="Finishing up\u2026")
+            # Phase only. The status line belongs to whoever is doing the work,
+            # and setting one here flashed a string nobody owned for a frame.
+            self._state.update(phase="working")
+        self._name_event.set()
+
+    def abandon_name(self) -> None:
+        """Nobody answered. Drop the field so a very late Save cannot strand a
+        name that the finished recording will never see."""
+        with self._lock:
+            self._name = ""
+            self._state.update(phase="working")
         self._name_event.set()
 
     def take_name(self) -> str:
@@ -546,7 +556,7 @@ class App:
             return ""
         answered = self._screenrec_ui.expect_name(default)
         if not answered.wait(timeout=180.0):
-            self._screenrec_ui.update(phase="working", status="Finishing up\u2026")
+            self._screenrec_ui.abandon_name()
             return ""
         return self._screenrec_ui.take_name()
 
@@ -721,6 +731,14 @@ class App:
             # was one more box to dismiss. Whether a clip was delivered belongs
             # in the Recordings tab, next to the clip.
             self._finished_recording = video
+            # The path lands on the clipboard without being asked: it is what
+            # gets pasted to an agent, and it costs nothing. OPENING the tab is
+            # a button now, not something that steals focus from whatever you
+            # were doing.
+            try:
+                copy_clipboard(str(video))
+            except Exception as exc:
+                log.info("screenrec: could not copy the path: %s", exc)
             self._screenrec_ui.update(
                 phase="done",
                 title="Recording saved" + (" and sent" if destination else ""),
@@ -729,9 +747,15 @@ class App:
         except Exception as exc:
             self._fail(f"screen recording: {exc}")
         finally:
-            # Every early return above (no frames, send failed, exception) would
-            # otherwise leave an agent blocked until its own timeout with no
-            # idea why. Release it with the reason instead.
+            # The pill is driven by a phase, so every early return above (no
+            # frames, send failed, exception) would otherwise leave it showing a
+            # sweeping progress bar or a name field for ever. Anything that did
+            # not reach "done" ends as a dismissable error instead.
+            if self._screenrec_ui.snapshot().get("phase") != "done":
+                self._screenrec_ui.clear()
+                self.overlay.hide()
+            # Every early return would equally leave an agent blocked until its
+            # own timeout with no idea why. Release it with the reason instead.
             waiter, self._screenrec_agent = self._screenrec_agent, None
             if waiter is not None:
                 self._screenrec_agent_result = {

--- a/wisprlite/app.py
+++ b/wisprlite/app.py
@@ -26,6 +26,50 @@ except Exception:
     winsound = None
 
 
+class ScreenrecUI:
+    """The pill's phase, shared between the finish thread and the Tk thread.
+
+    Kept out of App because both threads touch it every frame: one lock and one
+    dict beats sprinkling attributes that are read mid-write.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._state = {"phase": "recording"}
+        self._name_event = threading.Event()
+        self._name = ""
+
+    def snapshot(self) -> dict:
+        with self._lock:
+            return dict(self._state)
+
+    def update(self, **fields) -> None:
+        with self._lock:
+            self._state.update(fields)
+
+    def clear(self) -> None:
+        with self._lock:
+            self._state = {"phase": "recording"}
+
+    def expect_name(self, default: str) -> threading.Event:
+        with self._lock:
+            self._name = ""
+            self._name_event.clear()
+            self._state.update(phase="naming", name=default)
+        return self._name_event
+
+    def answer_name(self, typed: str) -> None:
+        with self._lock:
+            self._name = (typed or "").strip()
+            self._state.update(phase="working", status="Finishing up\u2026")
+        self._name_event.set()
+
+    def take_name(self) -> str:
+        with self._lock:
+            name, self._name = self._name, ""
+            return name
+
+
 class App:
     def __init__(self) -> None:
         self.cfg = config.Config.load()
@@ -94,6 +138,8 @@ class App:
         self._screenrec_finishing = None    # the thread muxing/sending, if any
         self._screenrec_agent = None        # Event an MCP caller is waiting on
         self._screenrec_agent_result = None
+        self._screenrec_ui = ScreenrecUI()   # the pill's phase
+        self._finished_recording = None      # what its Play/Copy act on
         self._armed_voice = None      # a Voice armed by the picker, consumed by the next utterance
         self._voice_mgrs = []         # dedicated voice HotkeyManagers
         self._picker_mgr = None       # the picker HotkeyManager
@@ -478,17 +524,40 @@ class App:
 
 
     def _screenrec_overlay_state(self) -> dict:
-        """What the pill draws. Read from the recorder, never from a copy."""
+        """What the pill draws. Live numbers from the recorder, phase from here."""
+        info = dict(self._screenrec_ui.snapshot())
         recording = self._screenrec
-        if recording is None:
-            return {"elapsed": 0.0, "paused": False}
-        try:
-            return {"elapsed": recording.elapsed(), "paused": recording.paused}
-        except Exception:
-            return {"elapsed": 0.0, "paused": False}
+        if recording is not None:
+            try:
+                info["elapsed"] = recording.elapsed()
+                info["paused"] = recording.paused
+            except Exception:
+                pass
+        return info
 
-    def _screenrec_action(self, action: str) -> None:
-        """A button on the recording pill. Runs on the overlay's worker thread."""
+    def _ask_name_in_pill(self, default: str) -> str:
+        """Show the name field IN the pill and wait for Save or Skip.
+
+        A separate dialog for one short field meant three windows for one
+        action. Bounded: if the pill is switched off, or nobody ever answers,
+        the recording keeps its timestamp rather than waiting for ever.
+        """
+        if not self.cfg.overlay:
+            return ""
+        answered = self._screenrec_ui.expect_name(default)
+        if not answered.wait(timeout=180.0):
+            self._screenrec_ui.update(phase="working", status="Finishing up\u2026")
+            return ""
+        return self._screenrec_ui.take_name()
+
+    def _screenrec_action(self, action: str, value: str = "") -> None:
+        """A control on the pill. Runs on the overlay's worker thread."""
+        if action in ("save", "skip"):
+            self._screenrec_ui.answer_name(value if action == "save" else "")
+            return
+        if action in ("play", "copy", "open"):
+            self._screenrec_done_action(action)
+            return
         recording = self._screenrec
         if recording is None:
             # Stop clears _screenrec immediately and then muxes, transcribes and
@@ -509,6 +578,27 @@ class App:
                 recording.resume()
         except Exception as exc:
             self._fail(f"screen recording: {exc}")
+
+    def _screenrec_done_action(self, action: str) -> None:
+        """Play / Copy path / Open, from the finished-clip pill."""
+        video = self._finished_recording
+        if video is None:
+            return
+        try:
+            if action == "play":
+                from .screenrec_tab import _play
+
+                _play(Path(video))
+            elif action == "copy":
+                copy_clipboard(str(video))
+            elif action == "open":
+                self.open_settings(tab="Recordings", select=Path(video).stem)
+        except Exception as exc:
+            log.info("screenrec: %s failed: %s", action, exc)
+        if action in ("play", "open"):
+            # The pill has done its job once you have gone somewhere else.
+            self._screenrec_ui.clear()
+            self.overlay.hide()
 
     def toggle_screen_recording(self) -> None:
         """Hotkey once: pick a region and record. Again: stop, transcribe, send."""
@@ -545,6 +635,8 @@ class App:
             )
             recording.start()
             self._screenrec = recording
+            self._screenrec_ui.clear()
+            self._finished_recording = None
             self.overlay.show_screenrec()
         except Exception as exc:
             self._screenrec = None
@@ -566,7 +658,7 @@ class App:
         if recording is None:
             return
         try:
-            self.overlay.show("thinking", "\u23f9 finishing the recording\u2026")
+            self._screenrec_ui.update(phase="working", status="Wrapping up the video\u2026")
             video = recording.stop()
             if video is None:
                 self._fail("screen recording: " + "; ".join(recording.errors[:2]))
@@ -578,11 +670,12 @@ class App:
             # An agent is blocked waiting on this, and the user recorded because
             # the agent asked — do not stop them for a filename.
             agent_call = self._screenrec_agent is not None
-            typed = screenrec.ask_name(recording.stem) if (ask and not agent_call) else ""
+            typed = self._ask_name_in_pill(recording.stem) if (ask and not agent_call) else ""
             if typed:
                 recording.rename(screenrec.stamped_stem(recording.stem, typed))
                 video = recording.video_path
             files = [video]
+            self._screenrec_ui.update(phase="working", status="Writing down what you said\u2026")
             transcript = self._transcribe_recording(recording)
             if transcript is not None:
                 files.append(transcript)
@@ -611,6 +704,7 @@ class App:
 
             destination = (self.cfg.screenrec_destination or "").strip()
             if destination:
+                self._screenrec_ui.update(phase="working", status="Sending it over\u2026")
                 ok, message = screenrec.send(files, destination)
                 if not ok:
                     # Never delete on failure, and never claim it arrived.
@@ -622,13 +716,16 @@ class App:
                             Path(path).unlink()
                         except OSError:
                             pass
-                self.overlay.show("done", f"\u2713 sent to {destination}{note}")
-            else:
-                self.overlay.show("done", f"\u2713 saved to {video.parent}{note}")
-            # Hand the clip straight over: the path on the clipboard is what
-            # gets pasted to an agent, and the tab opens on the new recording so
-            # you can play it back without going looking for it.
-            self._handoff_recording(video, recording.stem)
+            # Deliberately NOT announcing the scp destination. It is a string
+            # the user configured, it never changes, and leaving it on screen
+            # was one more box to dismiss. Whether a clip was delivered belongs
+            # in the Recordings tab, next to the clip.
+            self._finished_recording = video
+            self._screenrec_ui.update(
+                phase="done",
+                title="Recording saved" + (" and sent" if destination else ""),
+                subtitle=(recording.stem + note).strip(),
+            )
         except Exception as exc:
             self._fail(f"screen recording: {exc}")
         finally:

--- a/wisprlite/overlay.py
+++ b/wisprlite/overlay.py
@@ -249,6 +249,13 @@ class Overlay:
             except Exception:
                 pass
 
+        def fire(action: str, value: str = "") -> None:
+            """Hand a pill action to the app, off the Tk thread."""
+            handler = self.on_screenrec_action
+            if not handler:
+                return
+            threading.Thread(target=handler, args=(action, value), daemon=True).start()
+
         def drain() -> bool:
             try:
                 while True:
@@ -265,11 +272,10 @@ class Overlay:
                             callback = self.on_meeting_click
                             threading.Thread(target=callback, daemon=True).start()
                         elif st["name"] == "screenrec" and self.on_screenrec_action:
-                            action = self._screenrec_hit(state, text)
+                            action = self._screenrec_hit(
+                                state, text, st.get("screenrec_phase", "recording"))
                             if action:
-                                handler = self.on_screenrec_action
-                                threading.Thread(target=handler, args=(action,),
-                                                 daemon=True).start()
+                                fire(action)
                     elif kind == "hover":
                         st["hover"] = bool(state)
                     if kind == "hide":
@@ -282,11 +288,24 @@ class Overlay:
                         st["hide_at"] = 0.0
                         resize(WIN_H)
                         reveal()
+                    elif kind == "screenrec_submit":
+                        # Save/Skip from the in-pill name field. The typed text
+                        # travels with the action, so the app never has to reach
+                        # into a widget owned by another thread.
+                        typed = ""
+                        entry = (st.get("items") or {}).get("entry")
+                        if entry is not None and state == "save":
+                            try:
+                                typed = entry.get()
+                            except Exception:
+                                typed = ""
+                        fire(state or "skip", typed)
                     elif kind == "screenrec":
                         st["name"] = "screenrec"
                         st["text"] = ""
                         st["hide_at"] = 0.0
                         st["scene"] = None
+                        st["screenrec_phase"] = "recording"
                         resize(WIN_H)
                         reveal()
                     elif kind == "meeting":
@@ -326,6 +345,16 @@ class Overlay:
                 return
             if st["hide_at"] and time.time() >= st["hide_at"]:
                 conceal()
+            if st["name"] == "screenrec":
+                # The finished-clip phase needs a second row for its buttons, and
+                # the phase is driven by the app rather than by a queue event, so
+                # the height has to follow it here.
+                try:
+                    phase = str((self.screenrec_provider() or {}).get("phase")
+                                or "recording")
+                except Exception:
+                    phase = "recording"
+                resize(self.SCREENREC_H.get(phase, WIN_H))
             if st["visible"]:
                 self._draw(canvas, st)
             root.after(FRAME_MS, tick)
@@ -560,87 +589,209 @@ class Overlay:
     # Button geometry for the recording pill, in canvas coordinates. One table,
     # used to DRAW and to HIT-TEST, so a button can never sit somewhere other
     # than where the click for it is caught.
+    # Button geometry, in canvas coordinates. One table drives DRAWING and
+    # HIT-TESTING, so a button can never sit somewhere other than where the
+    # click for it is caught.
     SCREENREC_BUTTONS = (
         ("resume", WIN_W - 122),
         ("pause", WIN_W - 84),
         ("stop", WIN_W - 46),
     )
     SCREENREC_BUTTON_R = 15
+    # The finished-recording row: three named actions, because glyphs alone do
+    # not say "open PipeVoice".
+    SCREENREC_DONE = (("play", "Play"), ("copy", "Copy path"), ("open", "Open"))
+    DONE_BTN_W, DONE_BTN_H, DONE_BTN_Y = 108, 30, 62
+    SCREENREC_H = {"recording": WIN_H, "naming": 88, "working": WIN_H, "done": 100}
 
-    def _screenrec_hit(self, x, y) -> str:
-        """Which button a click at (x, y) landed on, or "" for the pill body."""
-        cy = WIN_H // 2
-        for action, cx in self.SCREENREC_BUTTONS:
+    def _done_button_box(self, index: int):
+        gap = 8
+        total = len(self.SCREENREC_DONE) * self.DONE_BTN_W + (len(self.SCREENREC_DONE) - 1) * gap
+        x1 = (WIN_W - total) // 2 + index * (self.DONE_BTN_W + gap)
+        return x1, self.DONE_BTN_Y, x1 + self.DONE_BTN_W, self.DONE_BTN_Y + self.DONE_BTN_H
+
+    def _screenrec_hit(self, x, y, phase: str = "recording") -> str:
+        """Which control a click at (x, y) landed on, or "" for the pill body."""
+        if phase == "done":
+            for index, (action, _label) in enumerate(self.SCREENREC_DONE):
+                x1, y1, x2, y2 = self._done_button_box(index)
+                if x1 <= x <= x2 and y1 <= y <= y2:
+                    return action
+            return ""
+        if phase == "working":
+            return ""                 # nothing to press while it is finishing
+        cy = 56 if phase == "naming" else WIN_H // 2
+        live = ("save", "skip") if phase == "naming" else \
+               tuple(a for a, _cx in self.SCREENREC_BUTTONS)
+        slots = self.SCREENREC_BUTTONS[-len(live):] if phase == "naming" \
+            else self.SCREENREC_BUTTONS
+        for action, (_name, cx) in zip(live, slots):
             if (x - cx) ** 2 + (y - cy) ** 2 <= (self.SCREENREC_BUTTON_R + 3) ** 2:
                 return action
         return ""
 
     def _draw_screenrec(self, c, st, H: int, accent: str) -> None:
-        """The recording pill: a breathing REC dot, a clock, and real controls.
+        """One pill for the whole recording, from REC dot to finished clip.
 
         It used to be a grey box reading "recording - press the hotkey again to
-        stop", which told you the one thing you had just done and gave you
-        nothing to press.
+        stop", then a SEPARATE dialog to name the file, then the same box stuck
+        open announcing an scp destination nobody needed to read. Four windows
+        for one action. Now it is four phases of one pill.
         """
-        items = self._base_scene(c, st, "screenrec", H, accent)
-        cy = H // 2
         info = {}
         try:
             info = self.screenrec_provider() or {}
         except Exception:
             info = {}
-        paused = bool(info.get("paused"))
-        elapsed = self._elapsed_text(info.get("elapsed", 0.0))
+        phase = str(info.get("phase") or "recording")
+        st["screenrec_phase"] = phase
+        items = self._base_scene(c, st, f"screenrec:{phase}", H, accent)
+        cy = WIN_H // 2
 
+        if phase == "recording":
+            self._draw_screenrec_recording(c, st, items, info, cy)
+        elif phase == "naming":
+            self._draw_screenrec_naming(c, st, items, info, cy)
+        elif phase == "working":
+            self._draw_screenrec_working(c, st, items, info, cy)
+        else:
+            self._draw_screenrec_done(c, st, items, info, cy)
+
+    def _rec_dot(self, c, items, cy, *, breathing: bool, phase: float):
         if "dot" not in items:
             items["dot"] = c.create_oval(0, 0, 0, 0, outline="")
-            items["clock"] = c.create_text(
-                44, cy, anchor="w", fill=PALETTE["fg"],
-                font=("Segoe UI Semibold", 15),
-            )
-            items["label"] = c.create_text(
-                44, cy + 15, anchor="w", fill=PALETTE["muted"],
-                font=("Segoe UI", 8),
-            )
-            for action, cx in self.SCREENREC_BUTTONS:
-                r = self.SCREENREC_BUTTON_R
+        breath = (math.sin(phase) + 1.0) / 2.0 if breathing else 0.0
+        colour = self._blend(PALETTE["meeting"], PALETTE["meeting_hi"], breath) \
+            if breathing else PALETTE["muted"]
+        r = 6.0 + (2.0 * breath if breathing else 0.0)
+        c.coords(items["dot"], 24 - r, cy - r, 24 + r, cy + r)
+        c.itemconfigure(items["dot"], fill=colour)
+
+    def _circle_buttons(self, c, items, cy, spec):
+        """Draw the circular controls. `spec` maps slot -> (glyph, enabled)."""
+        for action, cx in self.SCREENREC_BUTTONS:
+            if action not in spec:
+                continue
+            glyph, live = spec[action]
+            r = self.SCREENREC_BUTTON_R
+            if f"{action}_bg" not in items:
                 items[f"{action}_bg"] = c.create_oval(
-                    cx - r, cy - r, cx + r, cy + r,
-                    fill=PALETTE["card"], outline="", width=1,
-                )
+                    cx - r, cy - r, cx + r, cy + r, fill=PALETTE["card"],
+                    outline="", width=1)
                 items[f"{action}_icon"] = c.create_text(
-                    cx, cy, text="", fill=PALETTE["fg"], font=("Segoe UI", 11),
-                )
-
-        # A paused recording must not keep breathing — a pulsing red dot is the
-        # universal "still rolling", and showing it while paused is a lie.
-        breath = 0.0 if paused else (math.sin(st["phase"]) + 1.0) / 2.0
-        dot_colour = PALETTE["muted"] if paused else self._blend(
-            PALETTE["meeting"], PALETTE["meeting_hi"], breath)
-        dot_r = 6.0 + (0.0 if paused else 2.0 * breath)
-        c.coords(items["dot"], 24 - dot_r, cy - dot_r, 24 + dot_r, cy + dot_r)
-        c.itemconfigure(items["dot"], fill=dot_colour)
-        c.itemconfigure(items["clock"], text=elapsed,
-                        fill=PALETTE["muted"] if paused else PALETTE["fg"])
-        c.itemconfigure(items["label"], text="Paused" if paused else "Recording")
-
-        # Grey out the control that cannot do anything right now, rather than
-        # hiding it: buttons that move around are worse than buttons that dim.
-        states = {
-            "resume": ("▶", paused),
-            "pause": ("⏸", not paused),
-            "stop": ("⏹", True),
-        }
-        for action, _cx in self.SCREENREC_BUTTONS:
-            glyph, live = states[action]
+                    cx, cy, text="", fill=PALETTE["fg"], font=("Segoe UI", 11))
             c.itemconfigure(items[f"{action}_icon"], text=glyph,
                             fill=PALETTE["fg"] if live else PALETTE["div"])
             # A disabled button keeps a faint ring. Filled flat with the pill's
-            # own background it disappeared, which reads as "a button is
-            # missing" rather than "that one cannot do anything right now".
+            # own background it disappeared, reading as "a button is missing".
             c.itemconfigure(items[f"{action}_bg"],
                             fill=PALETTE["card"] if live else PALETTE["bg"],
                             outline="" if live else PALETTE["div"])
+
+    def _draw_screenrec_recording(self, c, st, items, info, cy) -> None:
+        paused = bool(info.get("paused"))
+        if "clock" not in items:
+            items["clock"] = c.create_text(44, cy, anchor="w", fill=PALETTE["fg"],
+                                           font=("Segoe UI Semibold", 15))
+            items["label"] = c.create_text(44, cy + 15, anchor="w",
+                                           fill=PALETTE["muted"], font=("Segoe UI", 8))
+        # A paused recording must not keep breathing: a pulsing red dot is the
+        # universal "still rolling", and showing one while paused is a lie.
+        self._rec_dot(c, items, cy, breathing=not paused, phase=st["phase"])
+        c.itemconfigure(items["clock"], text=self._elapsed_text(info.get("elapsed", 0.0)),
+                        fill=PALETTE["muted"] if paused else PALETTE["fg"])
+        c.itemconfigure(items["label"], text="Paused" if paused else "Recording")
+        self._circle_buttons(c, items, cy, {
+            "resume": ("\u25b6", paused),
+            "pause": ("\u23f8", not paused),
+            "stop": ("\u23f9", True),
+        })
+
+    def _draw_screenrec_naming(self, c, st, items, info, cy) -> None:
+        """Name it here, in the pill. A second window for one short field was
+        one window too many."""
+        if "entry" not in items:
+            # A bare text box appearing the moment you stop recording does not
+            # say what it wants. One line of caption fixes that.
+            items["caption"] = c.create_text(
+                24, 22, anchor="w", fill=PALETTE["muted"], font=("Segoe UI", 9),
+                text="Name this recording \u2014 Enter to save, Esc to skip")
+            entry = self._name_entry(c)
+            items["entry"] = entry
+            items["entry_window"] = c.create_window(
+                22, 56, anchor="w", window=entry,
+                width=WIN_W - 22 - 96, height=30)
+            entry.delete(0, "end")
+            entry.insert(0, str(info.get("name") or ""))
+            entry.focus_set()
+            entry.icursor("end")
+        self._circle_buttons(c, items, 56, {
+            "pause": ("\u2713", True),      # save
+            "stop": ("\u2715", True),       # skip
+        })
+
+    def _draw_screenrec_working(self, c, st, items, info, cy) -> None:
+        """A moving bar and a line about what it is doing, because "it takes a
+        few seconds" with nothing moving reads as a hang."""
+        if "work_text" not in items:
+            items["work_text"] = c.create_text(
+                24, cy - 9, anchor="w", fill=PALETTE["fg"], font=("Segoe UI", 11))
+            items["work_track"] = self._round_rect(
+                c, 24, cy + 9, WIN_W - 24, cy + 15, 3,
+                fill=PALETTE["meter_track"], outline="")
+            items["work_bar"] = self._round_rect(
+                c, 24, cy + 9, 120, cy + 15, 3, fill=PALETTE["meeting"], outline="")
+        c.itemconfigure(items["work_text"],
+                        text=str(info.get("status") or "Finishing up\u2026"))
+        # Indeterminate: nothing here knows how long x264 or an upload will take,
+        # and a fake percentage that stalls at 90% is worse than an honest sweep.
+        span = WIN_W - 48
+        width = span * 0.32
+        travel = (span - width)
+        pos = (math.sin(st["phase"] * 0.6) + 1.0) / 2.0
+        x1 = 24 + travel * pos
+        c.coords(items["work_bar"], *self._round_rect_points(x1, cy + 9, x1 + width, cy + 15, 3))
+
+    def _draw_screenrec_done(self, c, st, items, info, cy) -> None:
+        if "done_title" not in items:
+            items["done_title"] = c.create_text(
+                24, 26, anchor="w", fill=PALETTE["fg"], font=("Segoe UI Semibold", 12))
+            items["done_sub"] = c.create_text(
+                24, 44, anchor="w", fill=PALETTE["muted"], font=("Segoe UI", 8))
+            for index, (action, label) in enumerate(self.SCREENREC_DONE):
+                x1, y1, x2, y2 = self._done_button_box(index)
+                items[f"done_{action}_bg"] = self._round_rect(
+                    c, x1, y1, x2, y2, 8, fill=PALETTE["card"], outline="")
+                items[f"done_{action}_text"] = c.create_text(
+                    (x1 + x2) // 2, (y1 + y2) // 2, text=label,
+                    fill=PALETTE["fg"], font=("Segoe UI", 9))
+        c.itemconfigure(items["done_title"], text=str(info.get("title") or "Saved"))
+        c.itemconfigure(items["done_sub"], text=str(info.get("subtitle") or ""))
+        # Play leads: after watching a recording finish, playing it back is what
+        # you do next nine times out of ten.
+        c.itemconfigure(items["done_play_bg"], fill=PALETTE["meeting"])
+        c.itemconfigure(items["done_play_text"], fill="#1a0c0d")
+
+    @staticmethod
+    def _round_rect_points(x1, y1, x2, y2, r):
+        return [
+            x1 + r, y1, x2 - r, y1, x2, y1, x2, y1 + r,
+            x2, y2 - r, x2, y2, x2 - r, y2, x1 + r, y2,
+            x1, y2, x1, y2 - r, x1, y1 + r, x1, y1,
+        ]
+
+    def _name_entry(self, c):
+        import tkinter as tk
+
+        entry = tk.Entry(
+            c, bg=PALETTE["card"], fg=PALETTE["fg"], relief="flat",
+            insertbackground=PALETTE["fg"], font=("Segoe UI", 11),
+            highlightthickness=1, highlightbackground=PALETTE["div"],
+            highlightcolor=PALETTE["meeting"],
+        )
+        entry.bind("<Return>", lambda _e: self._q.put(("screenrec_submit", "save", "")))
+        entry.bind("<Escape>", lambda _e: self._q.put(("screenrec_submit", "skip", "")))
+        return entry
 
     def _draw_status(self, c, st, H: int, accent: str) -> None:
         items = self._base_scene(c, st, "status", H, accent)


### PR DESCRIPTION
Four windows for one action became four phases of one pill.

**Naming moved inside the pill** — caption, field, tick and cross, Enter to save
and Esc to skip. A separate dialog for one short field was a second window
nobody asked for. The finish thread waits on an Event rather than a modal,
bounded at 3 minutes so an unanswered prompt keeps the timestamp.

**While it works** the pill says what it is doing over a sweeping bar. The sweep
is deliberately indeterminate: nothing knows how long x264 or an upload takes,
and a fake percentage that stalls at 90% is worse than an honest sweep.

**When done**: the clip's name, and Play / Copy path / Open, Play leading. The
path also lands on the clipboard unasked, since that is what gets pasted to an
agent.

**It no longer announces the scp destination.** A string the user configured,
that never changes, that they had to dismiss. Whether a clip was delivered
belongs in the Recordings tab next to the clip.

## Jury findings

P1 fixed: a failed send or any exception left the pill on a progress bar for
ever, because nothing reset the phase on the way out.

Refuted, with evidence: `"and sent"` does not lie on a failed send (the failure
branch returns before the title is set), and `_agent_app()` does set `app.cfg`.

## Gates

336 passed, 7 pre-existing failures (missing faster-whisper/deepgram SDKs).
Sabotage-verified: removing the phase reset turns the strand test red; putting
the destination back in the title turns the announcement test red. All four
phases rendered and inspected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)