### PR TITLE
fix: a failed paste must not destroy the transcript

### DIFF
--- a/tests/test_ui_smoke.py
+++ b/tests/test_ui_smoke.py
@@ -1018,3 +1018,42 @@ def test_a_failed_send_does_not_strand_the_pill_on_a_progress_bar():
     with mock.patch.object(App, "_ask_name_in_pill", return_value=""):
         App._finish_screen_recording(app2)
     assert app2._screenrec_ui.snapshot()["phase"] == "recording"
+
+
+def test_a_failed_paste_still_leaves_the_words_in_history_and_on_the_clipboard():
+    """James, 2026-08-12: it "records the dictation, polishes it, then does not
+    paste into the box" - and the transcript was missing from history too.
+
+    history.record ran AFTER type_text inside a try that has only a finally, so
+    a raising keyboard backend skipped it entirely. Words you have already said
+    must not be destroyed by a failure to deliver them.
+    """
+    import types
+    from unittest import mock
+    from wisprlite.app import App
+    from wisprlite import history
+
+    recorded = []
+    app = App.__new__(App)
+    app.cfg = types.SimpleNamespace(
+        history_enabled=True, replacements={}, voice_commands=False,
+        paste_speed="normal", min_seconds=0.0, engine="gemini", language="",
+    )
+    app._clipboard_only = False
+    app._active = {}
+    app._fg_ctx = {}
+    app.overlay = mock.Mock()
+    app._fail = mock.Mock()
+    app._beep = mock.Mock()
+    app._set_icon = mock.Mock()
+
+    with mock.patch.object(history, "record", side_effect=lambda t, k: recorded.append((t, k))), \
+         mock.patch("wisprlite.app.type_text", side_effect=RuntimeError("no window")), \
+         mock.patch("wisprlite.app.copy_clipboard", return_value=True) as clip:
+        App._deliver(app, "hello there", False, "type", False)
+
+    assert recorded == [("hello there", "typed")], \
+        f"the transcript was lost when typing failed: {recorded}"
+    clip.assert_called_once_with("hello there")
+    states = [c.args[0] for c in app.overlay.set_state.call_args_list]
+    assert "error" in states, "a failed paste must say so, not look like success"

--- a/tests/test_ui_smoke.py
+++ b/tests/test_ui_smoke.py
@@ -1057,3 +1057,6 @@ def test_a_failed_paste_still_leaves_the_words_in_history_and_on_the_clipboard()
     clip.assert_called_once_with("hello there")
     states = [c.args[0] for c in app.overlay.set_state.call_args_list]
     assert "error" in states, "a failed paste must say so, not look like success"
+    assert "done" not in states, \
+        "a failed paste must never flash 'done' first — two answers to 'did that " \
+        "work?', in the order that reads as yes"

--- a/wisprlite/__init__.py
+++ b/wisprlite/__init__.py
@@ -1,3 +1,3 @@
 """Pipevoice — push-to-talk voice typing for Windows."""
 
-__version__ = "2.40.0"
+__version__ = "2.40.1"

--- a/wisprlite/app.py
+++ b/wisprlite/app.py
@@ -432,20 +432,7 @@ class App:
             out = self._eff("output_mode")
             to_clipboard = (self._clipboard_only or out == "clipboard"
                             or foreground.is_no_text_target(self._fg_ctx))
-            if to_clipboard:
-                if text:
-                    copy_clipboard(text)
-                self.overlay.set_state("done", "Copied to clipboard" if text else "↵")
-            else:
-                self.overlay.set_state("done", text or "↵")
-                type_text(text, out, press_enter=press_enter, paste_speed=self.cfg.paste_speed)
-            if self.cfg.history_enabled and text:
-                try:
-                    from . import history
-
-                    history.record(text, "clipboard" if self._clipboard_only else "typed")
-                except Exception:
-                    pass
+            self._deliver(text, to_clipboard, out, press_enter)
             self._beep(990, 60)
             self._set_icon("idle")
         finally:
@@ -453,6 +440,42 @@ class App:
             self._active = {}
             self._fg_ctx = {}
             self._release()
+
+    def _deliver(self, text: str, to_clipboard: bool, out: str, press_enter: bool) -> None:
+        """Save the words, then hand them over. In that order, deliberately."""
+        # Record BEFORE delivering. Typing is the fragile half - a window
+        # that refuses synthetic input, a keyboard backend that raises - and
+        # this used to run AFTER it, inside a try that has only a finally.
+        # So a failed paste took the transcript down with it: nothing in the
+        # box AND nothing in the history, which is how you lose words you
+        # have already said.
+        if self.cfg.history_enabled and text:
+            try:
+                from . import history
+
+                history.record(text, "clipboard" if to_clipboard else "typed")
+            except Exception:
+                log.exception("history record failed")
+
+        if to_clipboard:
+            if text:
+                copy_clipboard(text)
+            self.overlay.set_state("done", "Copied to clipboard" if text else "↵")
+        else:
+            self.overlay.set_state("done", text or "↵")
+            try:
+                type_text(text, out, press_enter=press_enter,
+                          paste_speed=self.cfg.paste_speed)
+            except Exception as exc:
+                # Never swallow the words. Put them somewhere usable and say
+                # so, rather than showing the polished text on the overlay
+                # and delivering nothing.
+                log.exception("typing failed (mode=%s)", out)
+                if text and copy_clipboard(text):
+                    self.overlay.set_state(
+                        "error", "Couldn't type there — copied instead, press Ctrl+V")
+                else:
+                    self._fail(f"couldn't type that: {exc}")
 
     def _fallback(self, audio, err) -> str:
         """If a cloud engine failed (e.g. offline), try local Whisper once."""

--- a/wisprlite/app.py
+++ b/wisprlite/app.py
@@ -462,10 +462,14 @@ class App:
                 copy_clipboard(text)
             self.overlay.set_state("done", "Copied to clipboard" if text else "↵")
         else:
-            self.overlay.set_state("done", text or "↵")
             try:
                 type_text(text, out, press_enter=press_enter,
                           paste_speed=self.cfg.paste_speed)
+                # "done" only once it IS done. Set before the attempt, a failure
+                # showed the polished text as a success for a frame and then
+                # flipped to an error - two contradictory answers to "did that
+                # work?", in the order that reads as yes.
+                self.overlay.set_state("done", text or "↵")
             except Exception as exc:
                 # Never swallow the words. Put them somewhere usable and say
                 # so, rather than showing the polished text on the overlay


### PR DESCRIPTION
Reported as two symptoms — "records the dictation, polishes it, then does not
paste into the box", and the words missing from the history too. One cause.

`history.record` ran AFTER `type_text`, inside a `try` that has only a `finally`
and no `except` (`app.py:363`). A keyboard backend that raises — a window
refusing synthetic input — threw straight past the history write and out of
`_on_stop`. Nothing in the box AND nothing in the history: words already spoken,
gone.

## Changes

- **Record first.** The transcript is the durable artifact; delivering it is the
  fragile part, and the durable thing must not be hostage to the fragile one.
- **Catch a typing failure**, fall back to the clipboard, and say so — "Couldn't
  type there — copied instead, press Ctrl+V". Showing polished text on the
  overlay while delivering nothing is the worst of both.
- The delivery block is a real method (`_deliver`) rather than a limb of
  `_on_stop`, so the regression drives real code instead of a test-only seam.

## Not fixed, deliberately

Typing into an **elevated** window silently succeeds and goes nowhere — no
exception, so the fallback cannot fire and history *would* record it. Different
failure, needs UIPI detection.

## Gates

337 passed, 7 pre-existing failures (missing faster-whisper/deepgram SDKs).
Sabotage-verified: removing the exception guard turns the regression red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)