### PR TITLE
fix: bundle what FastMCP actually imports, and prove it in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,10 +46,44 @@ jobs:
           --collect-all ctranslate2
           --collect-all pystray
           --collect-all PIL
+          --collect-all mss
           --collect-all mcp
           --collect-all pydantic
           --collect-all anyio
+          --collect-all pydantic_settings
+          --collect-all jsonschema
+          --collect-all sse_starlette
+          --collect-all starlette
+          --collect-all uvicorn
+          --collect-all httpx
           launch.py
+
+      # The build being green says nothing about the app running. v2.40.1
+      # shipped a --mcp that died on `import pydantic_settings` the moment an
+      # agent spawned it: PyInstaller cannot see FastMCP's module-level imports,
+      # so it left them out and nothing noticed. Drive the BUILT exe and make it
+      # answer, or the same class of miss ships again.
+      - name: Smoke-test the built exe's MCP server
+        shell: pwsh
+        run: |
+          $exe = "dist/Pipevoice/Pipevoice.exe"
+          $req = '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"ci","version":"1"}}}'
+          $req | Set-Content mcp_in.txt -Encoding ascii
+          $p = Start-Process $exe -ArgumentList '--mcp' -RedirectStandardInput mcp_in.txt `
+                 -RedirectStandardOutput mcp_out.txt -RedirectStandardError mcp_err.txt `
+                 -PassThru -WindowStyle Hidden
+          Start-Sleep 25
+          if (!$p.HasExited) { $p.Kill() }
+          $out = Get-Content mcp_out.txt -Raw -ErrorAction SilentlyContinue
+          $err = Get-Content mcp_err.txt -Raw -ErrorAction SilentlyContinue
+          if ($err) { Write-Host "stderr:`n$err" }
+          if ($out -match 'jsonrpc') {
+            Write-Host "MCP server answered."
+          } else {
+            Write-Host "MCP server produced no JSON-RPC reply."
+            Write-Host "stdout:`n$out"
+            exit 1
+          }
 
       - name: Install Inno Setup
         run: choco install innosetup --no-progress -y

--- a/build_exe.bat
+++ b/build_exe.bat
@@ -18,6 +18,16 @@ pyinstaller --noconfirm --clean --noconsole --onedir --noupx --name Pipevoice ^
     --collect-all mcp ^
     --collect-all pydantic ^
     --collect-all anyio ^
+    REM FastMCP imports these at module load and PyInstaller cannot see
+    REM them statically. Missing pydantic_settings shipped a --mcp that
+    REM died on import in v2.40.1 - the build was green, the feature was
+    REM dead. The CI smoke test now runs the built exe to catch this.
+    --collect-all pydantic_settings ^
+    --collect-all jsonschema ^
+    --collect-all sse_starlette ^
+    --collect-all starlette ^
+    --collect-all uvicorn ^
+    --collect-all httpx ^
     launch.py
 echo.
 echo Done. See dist\Pipevoice\Pipevoice.exe

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,4 +22,9 @@ Pillow>=10.0          # renders the tray icon
 pyperclip>=1.8        # "Paste" output mode
 
 # tkinter (the overlay HUD) ships with the standard Windows Python installer.
-mcp>=1.2  # MCP SDK — only imported by the --mcp stdio shim
+# Upper bound is load-bearing: `mcp>=1.2` unpinned has broken this build
+# TWICE from upstream drift alone — once at build time (2026-07-27, typer
+# in mcp.cli) and once at RUNTIME (v2.40.1, pydantic_settings missing from
+# the bundle). The CI smoke test is the real gate; this just stops a major
+# version arriving unannounced.
+mcp>=1.2,<3  # MCP SDK — only imported by the --mcp stdio shim

--- a/wisprlite/__init__.py
+++ b/wisprlite/__init__.py
@@ -1,3 +1,3 @@
 """Pipevoice — push-to-talk voice typing for Windows."""
 
-__version__ = "2.40.1"
+__version__ = "2.40.2"

--- a/wisprlite/mcp_shim.py
+++ b/wisprlite/mcp_shim.py
@@ -28,7 +28,22 @@ def _send(op: str, read_timeout: float = 130.0, **kw) -> dict:
 
 
 def main() -> None:
-    from mcp.server.fastmcp import FastMCP
+    try:
+        from mcp.server.fastmcp import FastMCP
+    except ImportError as exc:
+        # A packaged build that missed one of FastMCP's module-level imports
+        # showed the user a raw Python traceback in a popup. Say what is wrong
+        # and where it goes, on stderr, where the MCP client will log it.
+        import sys
+
+        print(
+            f"PipeVoice MCP server cannot start: {exc}.\n"
+            "This build is missing a bundled dependency. Please report it at "
+            "https://github.com/SignalEngine/PipeVoice/issues — meanwhile the "
+            "hotkey, recordings and dictation all work as normal.",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
 
     mcp = FastMCP("pipevoice")
 


### PR DESCRIPTION
The packaged `--mcp` died on `import pydantic_settings`. PyInstaller cannot see
FastMCP's module-level imports, so it left them out: **the build was green, the
release shipped, and the feature was dead on arrival with nothing to notice.**

## This corrects an earlier claim of mine

I said the `--noconsole` build was not a working stdio MCP target. The traceback
disproves that — the exe launches and reaches Python fine. It was a packaging
gap, not a subsystem one, and I should not have stated it without checking.

## Changes

- Collect `pydantic_settings`, `jsonschema`, `sse_starlette`, `starlette`,
  `uvicorn`, `httpx`. CI was also missing `--collect-all mss`, which
  `build_exe.bat` has had.
- **CI now drives the built exe**: pipes an `initialize` request into
  `Pipevoice.exe --mcp` and fails the build unless a JSON-RPC reply comes back.
  A green build saying nothing about whether the app runs is exactly how this
  shipped.
- Pin `mcp>=1.2,<3`. Unpinned it has broken this build **twice** from upstream
  drift alone — once at build time (typer in `mcp.cli`, 2026-07-27) and once at
  runtime (this one).
- The shim fails with a readable stderr line instead of a raw traceback popup.
  Verified against the real ImportError path.

## Gates

337 passed, 7 pre-existing failures. One run core-dumped under Xvfb and four
consecutive runs after it were clean — flagged as an unreproduced intermittent,
not claimed as fixed.

**The CI smoke test is the actual gate for this change.** If the collect list is
still short, this build goes red rather than shipping another dead feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)