### PR TITLE
fix: pin mcp<2 — 2.x removed the module the shim imports

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,8 @@ jobs:
           # extra). requirements.txt pins `mcp>=1.2`, so CI drifted onto 1.28.1
           # and the build broke with no code change — first seen 2026-07-27,
           # last green build was v2.30.3 on 2026-06-25.
-          pip install -r requirements.txt pyinstaller "mcp[cli]"
+          # requirements.txt pins mcp<2; the [cli] extra must not override it.
+          pip install -r requirements.txt pyinstaller "mcp[cli]<2"
 
       - name: Generate icon
         run: python assets/make_icon.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,9 +22,11 @@ Pillow>=10.0          # renders the tray icon
 pyperclip>=1.8        # "Paste" output mode
 
 # tkinter (the overlay HUD) ships with the standard Windows Python installer.
-# Upper bound is load-bearing: `mcp>=1.2` unpinned has broken this build
-# TWICE from upstream drift alone — once at build time (2026-07-27, typer
-# in mcp.cli) and once at RUNTIME (v2.40.1, pydantic_settings missing from
-# the bundle). The CI smoke test is the real gate; this just stops a major
-# version arriving unannounced.
-mcp>=1.2,<3  # MCP SDK — only imported by the --mcp stdio shim
+# Upper bound is load-bearing, and <2 is a fact rather than caution: mcp 2.x
+# REMOVED mcp.server.fastmcp, the only thing the shim imports. Proven by CI,
+# which built against 2.x and failed with "No module named
+# 'mcp.server.fastmcp'". Unpinned, this has broken the build twice from
+# upstream drift alone - once at build time (typer in mcp.cli, 2026-07-27) and
+# once at RUNTIME (v2.40.1, pydantic_settings missing from the bundle). The CI
+# smoke test is the real gate; the pin just stops a rewrite arriving unnoticed.
+mcp>=1.2,<2  # MCP SDK — only imported by the --mcp stdio shim


### PR DESCRIPTION
The smoke test added in #55 failed on its first run, which is the point of it.

It built against mcp 2.x and reported `No module named 'mcp.server.fastmcp'`.
That subpackage does not exist in 2.x — my `<3` bound was wrong.

Package metadata confirms both halves:

- **mcp 1.29.0** requires `pydantic-settings`, `jsonschema`, `sse-starlette`,
  `starlette`, `uvicorn` — exactly the collects added in #55
- **mcp 2.0.0** lists none of them, because FastMCP left

CI installs `"mcp[cli]"` as a separate argument, so that needed the bound too or
it would have overridden `requirements.txt`.

Also confirmed by that CI log: the readable failure message reaches stderr on a
real Windows build rather than showing a traceback popup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)