### PR TITLE
fix: show when a tab's settings are open, and let the tab close them

### DIFF
--- a/tests/test_ui_smoke.py
+++ b/tests/test_ui_smoke.py
@@ -1060,3 +1060,65 @@ def test_a_failed_paste_still_leaves_the_words_in_history_and_on_the_clipboard()
     assert "done" not in states, \
         "a failed paste must never flash 'done' first — two answers to 'did that " \
         "work?', in the order that reads as yes"
+
+
+def test_the_settings_link_says_which_state_it_is_in():
+    """It read "Settings" whether the panel was open or shut, so the screen gave
+    no clue which state you were in. It must say what pressing it will DO."""
+    _skip_if_headless()
+    install_platform_stubs()
+    import os
+    import tkinter as tk
+    from wisprlite import settings
+
+    os.environ["PV_TAB"] = "Recordings"
+    seen = {}
+    real_mainloop = tk.Misc.mainloop
+
+    def find(widget, prefix):
+        for child in widget.winfo_children():
+            try:
+                if str(child.cget("text")).startswith(prefix) and child.winfo_ismapped():
+                    return child
+            except Exception:
+                pass
+            found = find(child, prefix)
+            if found is not None:
+                return found
+        return None
+
+    def stub_mainloop(self, _n=0):
+        try:
+            self.update_idletasks(); self.update()
+            # "Settings" alone also matches the TAB header, which is a
+            # different widget entirely. The gear is the link.
+            link = find(self, "Settings  \u2699")
+            seen["shut"] = str(link.cget("text"))
+            link.event_generate("<Button-1>")
+            self.update_idletasks(); self.update()
+            seen["open"] = str(link.cget("text"))
+            # Pressing the tab header must be a way out of the settings.
+            tab = find(self, "Recordings")
+            tab.event_generate("<Button-1>")
+            self.update_idletasks(); self.update()
+            seen["after_tab"] = str(link.cget("text"))
+            intro = find(self, "Press your screen recording hotkey")
+            seen["browser_back"] = bool(intro and intro.winfo_ismapped())
+        finally:
+            try:
+                self.destroy()
+            except Exception:
+                pass
+
+    tk.Misc.mainloop = stub_mainloop
+    try:
+        settings.main()
+    finally:
+        tk.Misc.mainloop = real_mainloop
+
+    assert seen["shut"] != seen["open"], \
+        f"the link reads {seen['shut']!r} in both states — no indication at all"
+    assert "Close" in seen["open"], seen["open"]
+    assert seen["after_tab"] == seen["shut"], \
+        "clicking the tab header must close the settings and reset the link"
+    assert seen["browser_back"], "the tab header must bring the browser back"

--- a/wisprlite/__init__.py
+++ b/wisprlite/__init__.py
@@ -1,3 +1,3 @@
 """Pipevoice — push-to-talk voice typing for Windows."""
 
-__version__ = "2.40.2"
+__version__ = "2.40.3"

--- a/wisprlite/settings.py
+++ b/wisprlite/settings.py
@@ -471,6 +471,18 @@ def main(first_run: bool = False) -> None:
     def _show_tab(name):
         if name not in dict(_tabs):
             name = "Settings"
+        # A tab's settings panel is a detour INSIDE that tab, not a place of its
+        # own, so pressing the tab header is the way back out of it. Do this for
+        # every tab, not just the one being opened: leaving a tab with its
+        # settings still showing means returning to it lands you in a form you
+        # did not ask for.
+        for _n, _f in _tabs:
+            closer = getattr(_f, "pv_close_settings", None)
+            if callable(closer):
+                try:
+                    closer()
+                except Exception:
+                    pass
         for _n, _f in _tabs:
             _f.pack_forget()
         dict(_tabs)[name].pack(fill="both", expand=True)

--- a/wisprlite/winui.py
+++ b/wisprlite/winui.py
@@ -261,15 +261,32 @@ def collapsible_settings(container, link, hides, palette_bg, wheel=None):
     if callable(wheel):
         wheel(canvas)
 
+    # The link said "Settings" whether the panel was open or shut, so it gave no
+    # feedback at all — you could not tell from the screen which state you were
+    # in. It now says what pressing it will DO.
+    shut_text = link.cget("text")
+    open_text = "\u2715  Close settings"
+
+    def close(_event=None):
+        if not holder.winfo_ismapped():
+            return False
+        holder.pack_forget()
+        for widget, kwargs in hides:
+            widget.pack(**kwargs)
+        link.config(text=shut_text, font=("Segoe UI", 9, "underline"))
+        return True
+
     def toggle(_event=None):
-        if holder.winfo_ismapped():
-            holder.pack_forget()
-            for widget, kwargs in hides:
-                widget.pack(**kwargs)
-        else:
-            for widget, _kwargs in hides:
-                widget.pack_forget()
-            holder.pack(fill="both", expand=True, padx=18, pady=(0, 12))
+        if close():
+            return
+        for widget, _kwargs in hides:
+            widget.pack_forget()
+        holder.pack(fill="both", expand=True, padx=18, pady=(0, 12))
+        link.config(text=open_text, font=("Segoe UI", 9, "bold"))
 
     link.bind("<Button-1>", toggle)
+    # Clicking the tab you are already on is "take me back to the list" — the
+    # settings are a detour inside the tab, not a place of their own, so the
+    # tab header has to be a way out of them.
+    container.pv_close_settings = close
     return panel


### PR DESCRIPTION
The link read "Settings" whether the panel was open or shut — nothing on screen
indicated which state you were in.

- It now says what pressing it will **do**: `Settings ⚙` when shut, a bold
  `✕ Close settings` when open.
- Pressing the tab header closes them. The settings are a detour *inside* a tab,
  not a place of their own, so the tab you are already on has to be a way out.
- Every tab's panel closes on any tab change, not just the one being opened —
  otherwise returning to a tab lands you in a form you did not ask for.

338 passed. Sabotage-verified: disabling the tab-header close turns the test
red. Both states rendered and read back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)