### PR TITLE
fix: the local fallback must not reload Whisper every utterance

### DIFF
--- a/tests/test_ui_smoke.py
+++ b/tests/test_ui_smoke.py
@@ -1122,3 +1122,42 @@ def test_the_settings_link_says_which_state_it_is_in():
     assert seen["after_tab"] == seen["shut"], \
         "clicking the tab header must close the settings and reset the link"
     assert seen["browser_back"], "the tab header must bring the browser back"
+
+
+def test_the_local_fallback_loads_the_model_once_not_every_utterance():
+    """Reported as "cloud issues, reverting to local, taking a lot longer".
+
+    _fallback built a fresh LocalEngine per failure, and constructing one loads
+    the entire Whisper model. A bad key meant paying that load on every single
+    utterance. It must go through the engine cache like every other path.
+    """
+    import types
+    from unittest import mock
+    from wisprlite.app import App
+
+    builds = []
+    app = App.__new__(App)
+    app.cfg = types.SimpleNamespace(
+        engine="gemini", local_model_size="base.en", local_device="auto",
+        local_compute_type="int8", language="en-US",
+    )
+    app._active = {}
+    app._engines = {}
+    app.overlay = mock.Mock()
+    app._fail = mock.Mock()
+
+    class FakeLocal:
+        def __init__(self):
+            builds.append(1)
+        def start_session(self, on_partial=None):
+            return types.SimpleNamespace(finish=lambda audio: "words")
+
+    app._build_engine = lambda name=None: (FakeLocal() if name == "local"
+                                           else pytest.fail("wrong engine: " + str(name)))
+
+    for _ in range(5):
+        assert App._fallback(app, object(), RuntimeError("cloud down")) == "words"
+
+    assert len(builds) == 1, \
+        f"the model was loaded {len(builds)} times for 5 utterances"
+    assert not app._fail.called

--- a/wisprlite/__init__.py
+++ b/wisprlite/__init__.py
@@ -1,3 +1,3 @@
 """Pipevoice — push-to-talk voice typing for Windows."""
 
-__version__ = "2.40.3"
+__version__ = "2.40.4"

--- a/wisprlite/app.py
+++ b/wisprlite/app.py
@@ -490,10 +490,12 @@ class App:
             return ""
         try:
             self.overlay.set_state("transcribing", "Cloud failed — using local…")
-            from .engines.local_engine import LocalEngine
-
-            local = LocalEngine(model_size=self.cfg.local_model_size, language=(self.cfg.language or "").split("-")[0] or None,
-                                device=self.cfg.local_device, compute_type=self.cfg.local_compute_type)
+            # Through the CACHE, not a fresh LocalEngine. Building one loads the
+            # whole Whisper model, and this path built a new one for every failed
+            # utterance — so a spell of cloud trouble meant paying a full model
+            # load on every single thing you said. That is the "it got much
+            # slower" people report when their key or quota goes bad.
+            local = self._get_engine("local")
             return local.start_session(on_partial=self.overlay.set_text).finish(audio)
         except Exception as exc:
             self._fail(f"{err} (local fallback: {exc})")


### PR DESCRIPTION
User report: *"a lot of cloud issues and reverting to local with no results. It
taking a lot longer to get results."*

`_fallback` constructed a fresh `LocalEngine` on every cloud failure, and
`LocalEngine.__init__` builds a `WhisperModel` — the entire model load. It never
touched `self._engines`, the cache that exists for exactly this.

So once a key or quota went bad, every single utterance paid a full model load.
That is the "much slower".

Sabotage-proved: 5 utterances caused **5 model loads** before, **1** after.

## Not fixed here

The "no results" half is not explained by this and needs their log — a model
that fails to load is caught and reported, so an empty result points elsewhere.

Related, for the reply to the reporter: faster-whisper caches models in
`%USERPROFILE%\.cache\huggingface\hub` (PipeVoice does not override it). A
part-finished download there causes slow retries and empty results, and
deleting it is safe.

339 passed, 7 pre-existing failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)