### PR TITLE
feat: a Clear button for the local model cache

### DIFF
--- a/tests/test_modelcache.py
+++ b/tests/test_modelcache.py
@@ -1,0 +1,94 @@
+"""The Clear-cache button: what it removes, and what it must never remove."""
+
+import os
+import pathlib
+import sys
+import tempfile
+
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent))
+
+from wisprlite import modelcache
+
+
+def _make_cache(tmp):
+    root = pathlib.Path(tmp) / "hub"
+    (root / "models--Systran--faster-whisper-base.en" / "blobs").mkdir(parents=True)
+    (root / "models--Systran--faster-whisper-base.en" / "blobs" / "model.bin").write_bytes(b"x" * 3000)
+    (root / "models--guillaumekln--faster-whisper-tiny").mkdir(parents=True)
+    (root / "models--guillaumekln--faster-whisper-tiny" / "m.bin").write_bytes(b"y" * 1000)
+    # Somebody else's model. This is a SHARED cache.
+    (root / "models--meta-llama--Llama-3-8B").mkdir(parents=True)
+    (root / "models--meta-llama--Llama-3-8B" / "weights.bin").write_bytes(b"z" * 5000)
+    return root
+
+
+def test_it_only_ever_touches_faster_whisper_models(monkeypatch):
+    """The HuggingFace cache is shared with anything else the user runs. Taking
+    the whole folder would delete someone's unrelated 8B model."""
+    with tempfile.TemporaryDirectory() as tmp:
+        root = _make_cache(tmp)
+        monkeypatch.setenv("HUGGINGFACE_HUB_CACHE", str(root))
+
+        names = [p.name for p in modelcache.model_dirs()]
+        assert len(names) == 2, names
+        assert all("faster-whisper" in n for n in names)
+
+        ok, message = modelcache.clear()
+
+        assert ok, message
+        assert not (root / "models--Systran--faster-whisper-base.en").exists()
+        assert not (root / "models--guillaumekln--faster-whisper-tiny").exists()
+        assert (root / "models--meta-llama--Llama-3-8B" / "weights.bin").read_bytes() == b"z" * 5000, \
+            "it deleted somebody else's model"
+
+
+def test_the_size_it_reports_covers_only_our_models(monkeypatch):
+    with tempfile.TemporaryDirectory() as tmp:
+        root = _make_cache(tmp)
+        monkeypatch.setenv("HUGGINGFACE_HUB_CACHE", str(root))
+        assert modelcache.size_bytes() == 4000, "the 5000-byte Llama was counted"
+
+
+def test_an_empty_cache_is_not_an_error(monkeypatch):
+    with tempfile.TemporaryDirectory() as tmp:
+        monkeypatch.setenv("HUGGINGFACE_HUB_CACHE", str(pathlib.Path(tmp) / "nope"))
+        assert modelcache.model_dirs() == []
+        assert modelcache.size_bytes() == 0
+        ok, message = modelcache.clear()
+        assert ok and "Nothing cached" in message
+
+
+def test_a_locked_model_is_reported_not_glossed_over(monkeypatch):
+    """"Cleared" while the broken download is still there is the worst possible
+    answer: the user retries, it is still slow, and they stop trusting it."""
+    with tempfile.TemporaryDirectory() as tmp:
+        root = _make_cache(tmp)
+        monkeypatch.setenv("HUGGINGFACE_HUB_CACHE", str(root))
+        real_rmtree = modelcache.shutil.rmtree
+
+        def refuse_one(path, *a, **kw):
+            if "base.en" in str(path):
+                raise OSError(32, "The process cannot access the file")
+            return real_rmtree(path, *a, **kw)
+
+        monkeypatch.setattr(modelcache.shutil, "rmtree", refuse_one)
+        ok, message = modelcache.clear()
+
+        assert not ok, "a partial failure must not report success"
+        assert "Close PipeVoice" in message
+        assert (root / "models--Systran--faster-whisper-base.en").exists()
+
+
+def test_it_finds_the_cache_the_way_the_library_does(monkeypatch):
+    monkeypatch.delenv("HF_HUB_CACHE", raising=False)
+    monkeypatch.setenv("HUGGINGFACE_HUB_CACHE", "/explicit/hub")
+    assert modelcache.cache_dir() == pathlib.Path("/explicit/hub")
+
+    monkeypatch.delenv("HUGGINGFACE_HUB_CACHE")
+    monkeypatch.setenv("HF_HOME", "/somewhere/hf")
+    assert modelcache.cache_dir() == pathlib.Path("/somewhere/hf/hub")
+
+    monkeypatch.delenv("HF_HOME")
+    assert modelcache.cache_dir().parts[-3:] == (".cache", "huggingface", "hub")

--- a/wisprlite/__init__.py
+++ b/wisprlite/__init__.py
@@ -1,3 +1,3 @@
 """Pipevoice — push-to-talk voice typing for Windows."""
 
-__version__ = "2.40.4"
+__version__ = "2.40.5"

--- a/wisprlite/modelcache.py
+++ b/wisprlite/modelcache.py
@@ -1,0 +1,104 @@
+"""The local Whisper model cache: where it is, how big, and clearing it.
+
+faster-whisper downloads its models through huggingface_hub, so they land in
+the shared HF cache rather than anywhere PipeVoice owns. A part-finished
+download there causes slow retries and empty transcripts, and the only fix is
+to remove it and let it fetch again.
+
+Deliberately surgical: the HF cache is SHARED with anything else the user runs
+that uses HuggingFace models. Only faster-whisper's own directories are
+touched, never the whole cache.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+from pathlib import Path
+
+log = logging.getLogger("wisprlite")
+
+# What faster-whisper's repos are called on the hub: Systran/faster-whisper-*
+# today, guillaumekln/faster-whisper-* historically. Both contain this.
+MARKER = "faster-whisper"
+
+
+def cache_dir() -> Path:
+    """The HuggingFace hub cache, honouring the same env vars the library does."""
+    for var in ("HUGGINGFACE_HUB_CACHE", "HF_HUB_CACHE"):
+        value = os.getenv(var, "").strip()
+        if value:
+            return Path(value)
+    home = os.getenv("HF_HOME", "").strip()
+    if home:
+        return Path(home) / "hub"
+    return Path.home() / ".cache" / "huggingface" / "hub"
+
+
+def model_dirs() -> list[Path]:
+    """Every cached faster-whisper model. Nothing else is ever returned."""
+    root = cache_dir()
+    try:
+        entries = list(root.iterdir())
+    except OSError:
+        return []
+    return sorted(p for p in entries if p.is_dir() and MARKER in p.name)
+
+
+def _dir_size(path: Path) -> int:
+    total = 0
+    for base, _dirs, files in os.walk(path):
+        for name in files:
+            try:
+                # A symlinked blob counts once, where it actually lives; the HF
+                # cache uses symlinks heavily and following them double-counts.
+                total += os.lstat(os.path.join(base, name)).st_size
+            except OSError:
+                pass
+    return total
+
+
+def size_bytes() -> int:
+    return sum(_dir_size(p) for p in model_dirs())
+
+
+def human_size(size: int) -> str:
+    if size >= 1_000_000_000:
+        return f"{size / 1_000_000_000:.1f} GB"
+    if size >= 1_000_000:
+        return f"{size / 1_000_000:.0f} MB"
+    if size > 0:
+        return f"{max(1, size // 1000)} KB"
+    return "empty"
+
+
+def clear() -> tuple[bool, str]:
+    """Delete the cached models. Returns (everything went, message).
+
+    A model that is currently loaded is held open on Windows, so this reports
+    what is still locked rather than pretending it succeeded — "cleared" while
+    the broken download is still there is the worst possible answer.
+    """
+    dirs = model_dirs()
+    if not dirs:
+        return True, "Nothing cached — the model will download next time you use it."
+    freed, failed = 0, []
+    for path in dirs:
+        size = _dir_size(path)
+        try:
+            shutil.rmtree(path)
+            freed += size
+        except OSError as exc:
+            log.info("modelcache: could not remove %s: %s", path, exc)
+            failed.append(path.name)
+    if failed:
+        return False, (
+            f"Removed {human_size(freed)}, but {len(failed)} could not be deleted "
+            "because PipeVoice is still using them. Close PipeVoice from the tray "
+            "and try again."
+        )
+    return True, (
+        f"Cleared {human_size(freed)}. The model downloads again next time you "
+        "use local transcription."
+    )

--- a/wisprlite/settings.py
+++ b/wisprlite/settings.py
@@ -1231,6 +1231,53 @@ def main(first_run: bool = False) -> None:
     combo(row(c, "Paste speed", "Slower is more reliable in some apps."),
           paste_speed_var, [l for _, l in PASTE_SPEEDS], width=10)
 
+    # A part-finished model download makes local transcription slow and empty,
+    # and the only cure was deleting a folder by hand from a support reply.
+    from . import modelcache
+
+    _cache_row = row(c, "Local model cache",
+                     "Whisper's downloaded models. Clear this if local transcription "
+                     "is slow or returns nothing —\nit downloads again next time you "
+                     "use it.")
+    _cache_size = tk.StringVar(value="…")
+    ttk.Label(_cache_row, textvariable=_cache_size, width=9).pack(side="left", padx=(0, 8))
+    _clear_btn = ttk.Button(_cache_row, text="Clear", width=8)
+    _clear_btn.pack(side="left")
+
+    def _refresh_cache_size():
+        # Walking the cache touches the disk, so keep it off the UI thread —
+        # a big cache on a slow drive would otherwise freeze the window.
+        def work():
+            try:
+                text = modelcache.human_size(modelcache.size_bytes())
+            except Exception:
+                text = "unknown"
+            root.after(0, lambda: _cache_size.set(text))
+        threading.Thread(target=work, daemon=True).start()
+
+    def _clear_cache():
+        from tkinter import messagebox
+
+        if not messagebox.askyesno(
+                "Clear model cache",
+                "Delete the downloaded Whisper models?\n\nThey download again "
+                "(about 150 MB for the default) the next time you use local "
+                "transcription. Nothing you have dictated or recorded is touched."):
+            return
+        _clear_btn.config(state="disabled", text="…")
+        def work():
+            ok, message = modelcache.clear()
+            def done():
+                _clear_btn.config(state="normal", text="Clear")
+                _refresh_cache_size()
+                (messagebox.showinfo if ok else messagebox.showwarning)(
+                    "Model cache", message)
+            root.after(0, done)
+        threading.Thread(target=work, daemon=True).start()
+
+    _clear_btn.config(command=_clear_cache)
+    _refresh_cache_size()
+
     # --- Meeting storage: rendered into the Meetings tab, beside the recordings
     # it governs. These sat under "Advanced" three tabs away from the list they
     # apply to, which is exactly the jumping-around this move removes.


### PR DESCRIPTION
The answer to *"is there a cache I can clear?"* was a support reply telling
someone to delete a folder by hand. Now it is a button in **Settings →
Advanced**, with the current size beside it.

## Surgical on purpose

The HuggingFace cache is **shared** with anything else the user runs, so only
directories containing `faster-whisper` are touched. A test puts a Llama model
in the same cache and fails if it is removed — sabotaging the filter turns it
red.

## Failure is reported, not glossed

A currently-loaded model is held open on Windows. A partial failure names how
many are locked and says to close PipeVoice, rather than reporting success while
the broken download is still there. "Cleared" when it wasn't is worse than no
button: the user retries, it is still slow, and they stop believing it.

Size is walked on a worker thread — a large cache on a slow drive would freeze
the window on open.

344 passed, 7 pre-existing failures. Rendered and inspected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)