### PR TITLE
fix: surface silent polish failures + close the socket a short tap leaks

### DIFF
--- a/tests/test_ui_smoke.py
+++ b/tests/test_ui_smoke.py
@@ -1161,3 +1161,141 @@ def test_the_local_fallback_loads_the_model_once_not_every_utterance():
     assert len(builds) == 1, \
         f"the model was loaded {len(builds)} times for 5 utterances"
     assert not app._fail.called
+
+
+def _np_zeros(n):
+    import numpy as np
+    return np.zeros(n, dtype="float32")
+
+
+def test_a_press_too_short_to_transcribe_closes_the_engine_socket():
+    """A tap under min_seconds opened a Deepgram websocket on key-down and then
+    walked away from it. Ten seconds later the server killed it with a 1011 and
+    two ERROR lines - 59 of them in one of James's logs, 5% of all dictations,
+    every one a live connection held open for nothing.
+    """
+    import types
+    from unittest import mock
+    from wisprlite.app import App
+
+    app = App.__new__(App)
+    app.cfg = types.SimpleNamespace(min_seconds=0.35)
+    app._session = mock.Mock()
+    app.overlay = mock.Mock()
+    app._set_icon = mock.Mock()
+    app._release = mock.Mock()
+    app._active = {}
+    app._fg_ctx = {}
+
+    session = app._session
+    App._finish(app, _np_zeros(16000), 0.1)
+
+    session.cancel.assert_called_once_with()
+
+
+def test_a_short_press_with_no_session_does_not_explode():
+    """The early return also runs when start_session failed, so _session is None."""
+    import types
+    from unittest import mock
+    from wisprlite.app import App
+
+    app = App.__new__(App)
+    app.cfg = types.SimpleNamespace(min_seconds=0.35)
+    app._session = None
+    app.overlay = mock.Mock()
+    app._set_icon = mock.Mock()
+    app._release = mock.Mock()
+    app._active = {}
+    app._fg_ctx = {}
+
+    App._finish(app, _np_zeros(16000), 0.1)   # must not raise
+
+    app.overlay.hide.assert_called_once_with()
+
+
+def test_a_silent_polish_failure_is_shown_instead_of_hidden():
+    """Flow mode ON, provider reachable, nothing came back - a dead model id, a
+    revoked key, a quota wall. cleanup.clean() returns None and the raw text was
+    delivered with only a log line, so the words just got worse with no way to
+    know why. One log carried 235 of these across three months.
+    """
+    import types
+    from unittest import mock
+    from wisprlite.app import App
+    from wisprlite import cleanup
+
+    app = App.__new__(App)
+    app.cfg = types.SimpleNamespace(
+        cleanup_provider="gemini", cleanup_model="gemini-2.5-flash",
+        language="", speech_notes="",
+    )
+    app._eff = lambda key: {"ai_cleanup": True}.get(key, "")
+    app.overlay = mock.Mock()
+
+    with mock.patch.object(cleanup, "provider_ready", return_value=True), \
+         mock.patch.object(cleanup, "clean", return_value=None), \
+         mock.patch.object(cleanup, "last_error", return_value="model no longer available"):
+        out = App._polish(app, "raw words")
+
+    assert out == "raw words", "the raw text must still be delivered"
+    assert app._polish_error == "model no longer available", \
+        "the failure must be recorded, not swallowed"
+
+
+def test_a_successful_polish_leaves_no_warning_behind():
+    """The flag is per-utterance. One bad polish must not mark every later one."""
+    import types
+    from unittest import mock
+    from wisprlite.app import App
+    from wisprlite import cleanup
+
+    app = App.__new__(App)
+    app.cfg = types.SimpleNamespace(
+        cleanup_provider="gemini", cleanup_model="m", language="", speech_notes="",
+    )
+    app._eff = lambda key: {"ai_cleanup": True}.get(key, "")
+    app.overlay = mock.Mock()
+    app._polish_error = "stale failure from last time"
+
+    with mock.patch.object(cleanup, "provider_ready", return_value=True), \
+         mock.patch.object(cleanup, "clean", return_value="Raw words."):
+        out = App._polish(app, "raw words")
+
+    assert out == "Raw words."
+    assert app._polish_error is None, "a good polish must clear the previous warning"
+
+
+def test_the_polish_warning_never_overwrites_a_delivery_failure():
+    """Two things went wrong at once: the polish failed AND the paste failed.
+    The overlay has one line, and 'couldn't type there' is the news that costs
+    the user words. It must be the message left on screen."""
+    import types
+    from unittest import mock
+    from wisprlite.app import App
+    from wisprlite import history
+
+    app = App.__new__(App)
+    app.cfg = types.SimpleNamespace(
+        history_enabled=True, replacements={}, paste_speed="normal",
+    )
+    app.overlay = mock.Mock()
+    app._fail = mock.Mock()
+
+    with mock.patch.object(history, "record"), \
+         mock.patch("wisprlite.app.type_text", side_effect=RuntimeError("no window")), \
+         mock.patch("wisprlite.app.copy_clipboard", return_value=True):
+        ok = App._deliver(app, "hello", False, "type", False)
+
+    assert ok is False, \
+        "a failed paste must report failure so the polish warning stays off the screen"
+
+
+def test_the_reason_is_pulled_out_of_the_provider_json_blob():
+    """Providers return a three-line JSON envelope; the overlay has one line."""
+    from wisprlite.cleanup import _short_reason
+
+    exc = Exception(
+        "Error code: 404 - [{'error': {'code': 404, 'message': 'This model "
+        "models/gemini-2.5-flash is no longer available.', 'status': 'NOT_FOUND'}}]"
+    )
+    assert _short_reason(exc) == "This model models/gemini-2.5-flash is no longer available"

--- a/tests/test_ui_smoke.py
+++ b/tests/test_ui_smoke.py
@@ -1299,3 +1299,36 @@ def test_the_reason_is_pulled_out_of_the_provider_json_blob():
         "models/gemini-2.5-flash is no longer available.', 'status': 'NOT_FOUND'}}]"
     )
     assert _short_reason(exc) == "This model models/gemini-2.5-flash is no longer available"
+
+
+def test_an_apostrophe_in_the_reason_does_not_cut_it_to_one_word():
+    """`[^']+` stopped at the first apostrophe inside the value, so a message
+    like "It's no longer available" reached the overlay as "It"."""
+    from wisprlite.cleanup import _short_reason
+
+    exc = Exception(
+        "Error code: 404 - [{'error': {'code': 404, 'message': \"It's no longer "
+        "available, use a newer model\", 'status': 'NOT_FOUND'}}]"
+    )
+    assert _short_reason(exc) == "It's no longer available, use a newer model"
+
+
+def test_one_thread_s_failure_does_not_overwrite_another_s():
+    """A meeting summary polishing in the background shares cleanup.py with a
+    live dictation. A module-global reason let the later call win."""
+    import threading
+    from wisprlite.cleanup import _set_last_error, last_error
+
+    _set_last_error("the dictation's reason")
+    done = threading.Event()
+
+    def other():
+        _set_last_error("the meeting summary's reason")
+        done.set()
+
+    t = threading.Thread(target=other)
+    t.start()
+    done.wait(2)
+    t.join()
+
+    assert last_error() == "the dictation's reason"

--- a/wisprlite/__init__.py
+++ b/wisprlite/__init__.py
@@ -1,3 +1,3 @@
 """Pipevoice — push-to-talk voice typing for Windows."""
 
-__version__ = "2.40.5"
+__version__ = "2.40.6"

--- a/wisprlite/app.py
+++ b/wisprlite/app.py
@@ -159,6 +159,7 @@ class App:
         self._engines = {}            # per-engine cache (name -> engine), for per-app profiles
         self._session = None
         self._clipboard_only = False
+        self._polish_error: str | None = None
         self._active = {}             # per-utterance profile overrides (never mutates cfg)
         self._fg_ctx = {}             # foreground window captured at hotkey-press time
         self._started_at = 0.0
@@ -362,6 +363,16 @@ class App:
     def _finish(self, audio, duration) -> None:
         try:
             if duration < self.cfg.min_seconds or audio.size == 0:
+                # Close the socket we opened on key-down. Without this a tap too
+                # short to transcribe left a live Deepgram connection with no
+                # audio on it, and ten seconds later the server killed it with a
+                # 1011 - two ERROR lines per accidental tap, and a connection
+                # held open for nothing. 59 of them in one log.
+                if self._session is not None:
+                    try:
+                        self._session.cancel()
+                    except Exception:
+                        log.exception("cancel failed on short press")
                 self.overlay.hide()
                 self._set_icon("idle")
                 return
@@ -432,7 +443,9 @@ class App:
             out = self._eff("output_mode")
             to_clipboard = (self._clipboard_only or out == "clipboard"
                             or foreground.is_no_text_target(self._fg_ctx))
-            self._deliver(text, to_clipboard, out, press_enter)
+            if self._deliver(text, to_clipboard, out, press_enter) and self._polish_error:
+                self.overlay.set_state(
+                    "error", f"Raw text — polish failed: {self._polish_error}"[:110])
             self._beep(990, 60)
             self._set_icon("idle")
         finally:
@@ -441,8 +454,12 @@ class App:
             self._fg_ctx = {}
             self._release()
 
-    def _deliver(self, text: str, to_clipboard: bool, out: str, press_enter: bool) -> None:
-        """Save the words, then hand them over. In that order, deliberately."""
+    def _deliver(self, text: str, to_clipboard: bool, out: str, press_enter: bool) -> bool:
+        """Save the words, then hand them over. In that order, deliberately.
+
+        Returns True when delivery landed cleanly, so a caller can add a softer
+        warning on top without stomping a real failure message.
+        """
         # Record BEFORE delivering. Typing is the fragile half - a window
         # that refuses synthetic input, a keyboard backend that raises - and
         # this used to run AFTER it, inside a try that has only a finally.
@@ -461,6 +478,7 @@ class App:
             if text:
                 copy_clipboard(text)
             self.overlay.set_state("done", "Copied to clipboard" if text else "↵")
+            return True
         else:
             try:
                 type_text(text, out, press_enter=press_enter,
@@ -470,6 +488,7 @@ class App:
                 # flipped to an error - two contradictory answers to "did that
                 # work?", in the order that reads as yes.
                 self.overlay.set_state("done", text or "↵")
+                return True
             except Exception as exc:
                 # Never swallow the words. Put them somewhere usable and say
                 # so, rather than showing the polished text on the overlay
@@ -480,6 +499,7 @@ class App:
                         "error", "Couldn't type there — copied instead, press Ctrl+V")
                 else:
                     self._fail(f"couldn't type that: {exc}")
+                return False
 
     def _fallback(self, audio, err) -> str:
         """If a cloud engine failed (e.g. offline), try local Whisper once."""
@@ -997,6 +1017,7 @@ class App:
     # ---- agent MCP -------------------------------------------------------
     def _polish(self, text: str) -> str:
         """Optional LLM cleanup ('Flow mode'); returns the input unchanged if off/unavailable."""
+        self._polish_error = None
         if not (text and self._eff("ai_cleanup")):
             return text
         from . import cleanup
@@ -1007,6 +1028,13 @@ class App:
                                  self.cfg.language, self.cfg.speech_notes,
                                  style=self._eff("cleanup_style"),
                                  custom_instruction=self._eff("cleanup_instruction"))
+        if polished is None:
+            # Flow mode was ON and the provider was reachable, yet nothing came
+            # back - a dead model id, a revoked key, a quota wall. This used to
+            # return the raw text with only a log line, so the words simply got
+            # worse and nobody could see why. One log carried 235 of these.
+            self._polish_error = cleanup.last_error() or "AI cleanup unavailable"
+            log.warning("polish failed, delivering raw text: %s", self._polish_error)
         return polished or text
 
     def _agent_dispatch(self, req: dict) -> dict:

--- a/wisprlite/cleanup.py
+++ b/wisprlite/cleanup.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 from typing import Optional
 
 log = logging.getLogger("wisprlite")
@@ -181,6 +182,7 @@ def chat_completion(
     if key_env:
         api_key = os.getenv(key_env, "").strip()
         if not api_key:
+            _set_last_error(f"no API key for {provider}")
             log.warning("AI request: no API key for provider %s", provider)
             if raise_errors:
                 raise RuntimeError(f"no API key for provider {provider}")
@@ -200,12 +202,40 @@ def chat_completion(
             messages=messages,
         )
         out = (resp.choices[0].message.content or "").strip()
+        _set_last_error("")
         return out if allow_empty else (out or None)
     except Exception as exc:
+        _set_last_error(_short_reason(exc))
         log.warning("AI request failed (%s): %s", provider, exc)
         if raise_errors:
             raise RuntimeError(f"{provider} request failed: {exc}") from exc
         return None
+
+
+_last_error = ""
+
+
+def _set_last_error(msg: str) -> None:
+    global _last_error
+    _last_error = msg
+
+
+def last_error() -> str:
+    """Why the most recent AI request came back empty, in a line a human can read.
+
+    The provider errors are JSON blobs three lines long; the caller wants to put
+    the reason on a 110-pixel overlay, so this keeps the sentence and drops the
+    envelope.
+    """
+    return _last_error
+
+
+def _short_reason(exc: Exception) -> str:
+    text = str(exc)
+    match = re.search(r"'message':\s*'([^']+)'", text)
+    if match:
+        return match.group(1).strip().rstrip(".")
+    return text.strip().splitlines()[0][:120] if text.strip() else exc.__class__.__name__
 
 
 def clean(text: str, provider: str = "openai", model: str = "",

--- a/wisprlite/cleanup.py
+++ b/wisprlite/cleanup.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import logging
 import os
 import re
+import threading
 from typing import Optional
 
 log = logging.getLogger("wisprlite")
@@ -212,12 +213,13 @@ def chat_completion(
         return None
 
 
-_last_error = ""
+# Thread-local, not a module global: a meeting summary polishing in the
+# background must not overwrite the reason a dictation's polish just failed.
+_errors = threading.local()
 
 
 def _set_last_error(msg: str) -> None:
-    global _last_error
-    _last_error = msg
+    _errors.last = msg
 
 
 def last_error() -> str:
@@ -227,14 +229,19 @@ def last_error() -> str:
     the reason on a 110-pixel overlay, so this keeps the sentence and drops the
     envelope.
     """
-    return _last_error
+    return getattr(_errors, "last", "")
 
 
 def _short_reason(exc: Exception) -> str:
     text = str(exc)
-    match = re.search(r"'message':\s*'([^']+)'", text)
+    # Stop at the NEXT key, not at the next apostrophe - "It's no longer
+    # available" would otherwise come back as the single word "It". Python's own
+    # repr switches the quoting to double quotes when the value contains one,
+    # so both styles have to be accepted.
+    match = re.search(r"""['"]message['"]:\s*(['"])(.*?)\1,\s*['"](?:status|code)['"]""",
+                      text, re.DOTALL)
     if match:
-        return match.group(1).strip().rstrip(".")
+        return match.group(2).strip().rstrip(".")
     return text.strip().splitlines()[0][:120] if text.strip() else exc.__class__.__name__
 
 


### PR DESCRIPTION
Both bugs found by reading a real 2,453-line `pipevoice.log` (20 Jun → 4 Sep).

### 1. AI cleanup failed 235 times and said nothing
- 170× `gemini-2.5-flash is no longer available`
- 65× `PERMISSION_DENIED` / "project has been denied access"

`cleanup.clean()` returns `None` on failure and `_polish` did `return polished or text`, so the **raw** transcript went out with only a log line. Output silently got worse with no way to see why.

Now: `_polish` records the reason and the overlay shows `Raw text — polish failed: <reason>`, extracted from the provider's JSON envelope so it fits one line. A delivery failure still wins the overlay — "couldn't type there" is the news that costs you words.

### 2. A tap under `min_seconds` abandoned a live Deepgram websocket
The session opens on key-down; the early return in `_finish` hid the overlay and walked away. Ten seconds later the server killed the socket with a `1011` and two ERROR lines. **59 of them in that log — 5% of all dictations**, each a connection held open for nothing. `_finish` now cancels the session it opened.

Not a stall: only 3 of the 59 produced an actual transcription failure, so this was leaked connections and log noise, not lost words.

### Verification
- 8 new tests. Each of the two fixes was **reverted and confirmed to turn its test red**.
- Suite: 320 passed, same 15 pre-existing failures `main` already has (baselined in a clean worktree).
- `/jury` (minimax-m3) raised a P2 and a P3; both were real and are fixed in the second commit — apostrophe truncation in the reason parser, and a module-global reason that a background meeting summary could overwrite mid-dictation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WStiFEE9AHoF4esPCaKiYD