### PR TITLE
feat(audio): 48kHz recording, loudness normalisation, and a mic picker that recommends

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ assets/wisprlite.png
 
 # review-gate output artifact — never commit
 .review-verdict.md
+node_modules

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -237,3 +237,31 @@ CI (`build.yml`) runs on `windows-latest`: `pip install -r requirements.txt pyin
 - **Tests.** Live in `tests/` (`test_voices`, `test_profiles_style`, `test_cleanup_styles`, `test_*`). **No pytest/framework, no CI test step** — run each file directly (`python3 tests/test_x.py`), manually. Tests that need `faster_whisper`/`deepgram` (absent on the dev box) stub the engine module instead — see `test_transcribe_window.py`.
 - **Always run codex-review.** Standing instruction: run the `codex-review` skill on any substantive code change before declaring it done, and screenshot-verify UI changes.
 - **Release ritual.** Bump `wisprlite/__init__.py` `__version__` → merge to `main` → push an **annotated** tag `vX.Y.Z`. CI builds and publishes the GitHub Release with `Pipevoice-Setup.exe`. Then set the changelog with `gh release edit <tag> --notes-file …` (the CI tag-message auto-notes is flaky). Installed apps auto-update from the latest Release.
+
+## Two sample rates, deliberately
+
+Dictation and recording have different jobs, so they run at different rates.
+Six modules define a rate constant; only two of them are about listening.
+
+| Path | Rate | Why |
+|---|---|---|
+| `audio.py`, `engines/{deepgram,openai,gemini}_engine.py` | 16 kHz | Dictation audio is never played back. It goes straight to a speech engine, and 16 kHz is the rate those APIs want. |
+| `screenrec.py` (`AUDIO_RATE`), `meeting.py` (`SAMPLE_RATE`) | 48 kHz | The `.mp4` and the session `.wav`s are files a human listens to. 16 kHz hard-cuts everything above 8 kHz — the sibilance and "air" that make a voice sound present — so recordings sounded like a phone call.
+
+**Do not "unify" these.** Raising the dictation rate wastes bandwidth on every
+utterance for a listener that does not exist; lowering the recording rate brings
+the muffle back.
+
+Transcription of recordings needs no resampling: `transcribe_file` and
+`transcribe_file_deepgram` both take a **file path** and resample internally.
+The one exception is PipeFocus, which streams live PCM — `focus_stream()` takes
+a `sample_rate` argument and `app.py` passes `meeting.SAMPLE_RATE`. If those two
+ever disagree, Deepgram decodes the audio at the wrong speed and every PipeFocus
+transcript becomes garbage.
+
+`loudness.py` applies peak normalisation at finalise (never in an audio
+callback): quiet takes are boosted towards -1 dBFS, gain capped at 8x so a
+near-silent take is not amplified into hiss, and audio already above -3 dBFS is
+left alone. `mics.py` collapses PortAudio's per-host-API duplicate endpoints to
+one entry per physical microphone and ranks them, which is what the settings
+picker and "Test my mic" both read.

--- a/GATES.md
+++ b/GATES.md
@@ -1,0 +1,57 @@
+# Gates — audio quality + mic picker
+
+Bound to the code tree (`wisprlite/`, `tests/`), not to a commit id. Committed
+last, after every gate below is green.
+
+1. `grep -n "16_000\|16000" wisprlite/screenrec.py wisprlite/meeting.py` returns
+   nothing.
+   CHECK: `grep -n "16_000\|16000" wisprlite/screenrec.py wisprlite/meeting.py`
+   EXPECT: no output, exit 1 (grep found nothing).
+
+2. A recorded `.mp4` reports 48000 Hz from ffprobe and decodes to non-silence.
+   Not runnable on this VPS (no mic, no ffprobe fixture pipeline) — covered
+   instead by a unit test on `_mux`/`_open_container` asserting `AUDIO_RATE ==
+   48_000` is what gets passed to `av.add_stream`/`AudioFrame.sample_rate`.
+   Positive control: assert the same assertion fails against a fixture pinned
+   to 16_000.
+   CHECK: `python3 -m pytest -q tests/test_screenrec.py -k rate`
+   EXPECT: pass; reverting `AUDIO_RATE` to `16_000` turns it red.
+
+3. `focus_stream` receives the same rate the meeting writes.
+   CHECK: `python3 -m pytest -q tests/test_focus.py -k sample_rate`
+   EXPECT: pass; reverting the `sample_rate` param (hardcoding 16_000 again)
+   turns it red.
+
+4. Normalisation: a quiet sine is boosted towards -1 dBFS (capped at +18 dB
+   gain so a near-silent take isn't blown into hiss), an already-hot sine is
+   untouched, and digital silence is untouched (no div-by-zero, no runaway
+   gain).
+   CHECK: `python3 -m pytest -q tests/test_loudness.py`
+   EXPECT: pass; reverting `normalize_peak` to a no-op turns it red.
+
+5. `group_inputs` collapses a fixture with the same mic under four host APIs
+   to ONE entry and picks the WASAPI endpoint.
+   CHECK: `python3 -m pytest -q tests/test_mics.py -k group`
+   EXPECT: pass; removing the host-API preference order turns it red.
+
+6. `recommend` never returns a Stereo Mix endpoint when a real mic is present,
+   and returns `None` on an empty list rather than raising.
+   CHECK: `python3 -m pytest -q tests/test_mics.py -k recommend`
+   EXPECT: pass.
+
+7. `verdict()` returns each of the five strings for a hand-built measurement
+   dict.
+   CHECK: `python3 -m pytest -q tests/test_mics.py -k verdict`
+   EXPECT: pass.
+
+8. Full suite does not add a 16th failure beyond the baseline.
+   CHECK: `python3 -m pytest -q --ignore=tests/test_transcribe_deepgram_e2e.py`
+   EXPECT: same 15 pre-existing failures (test_env_precedence.py x8,
+   test_transcribe_window.py x7), 0 new failures, new tests from this plan
+   passing.
+
+## Not verifiable on this VPS
+
+No audio device, no Windows. How the recording actually *sounds*, and how the
+real Windows device list groups on James's machine, are handed to him
+explicitly rather than claimed here.

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/root/intentos/node_modules

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/root/intentos/node_modules

--- a/tests/test_focus.py
+++ b/tests/test_focus.py
@@ -184,6 +184,35 @@ def test_the_focus_stream_is_not_billed_per_channel():
     )
 
 
+def test_focus_stream_takes_the_meetings_own_sample_rate():
+    # meeting.py now records at 48kHz. If focus_stream keeps a second hardcoded
+    # 16_000 literal, every PipeFocus transcript decodes as noise: the server
+    # is told the wrong rate for the PCM it is actually being fed.
+    import inspect
+
+    from wisprlite.engines import deepgram_engine
+
+    sig = inspect.signature(deepgram_engine.focus_stream)
+    assert sig.parameters["sample_rate"].default == 16_000, (
+        "keep the old default so no other caller changes"
+    )
+    source = inspect.getsource(deepgram_engine.focus_stream)
+    assert "sample_rate=sample_rate" in source, (
+        "focus_stream must forward its own sample_rate, not a literal, into LiveOptions"
+    )
+
+
+def test_pipefocus_connects_at_the_meetings_sample_rate():
+    import inspect
+
+    from wisprlite import app
+
+    source = inspect.getsource(app.App._start_pipefocus)
+    assert "sample_rate=meeting.SAMPLE_RATE" in source, (
+        "PipeFocus must stream at the rate meeting.py actually records, not a stale literal"
+    )
+
+
 class _FakeConn:
     """A live connection that can be told to die, like the real one does."""
 

--- a/tests/test_loudness.py
+++ b/tests/test_loudness.py
@@ -1,0 +1,70 @@
+"""Peak normalisation: monotonic gain only, capped, never on silence."""
+
+import pathlib
+import sys
+import wave
+
+import numpy as np
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent))
+
+from wisprlite import loudness
+
+
+def _sine_at(dbfs: float, seconds: float = 0.5, rate: int = 16_000) -> np.ndarray:
+    amplitude = loudness.FULL_SCALE * (10.0 ** (dbfs / 20.0))
+    t = np.linspace(0, seconds, int(rate * seconds), endpoint=False)
+    return (np.sin(2 * np.pi * 220 * t) * amplitude).astype("<i2")
+
+
+def test_a_quiet_sine_is_boosted_towards_the_target():
+    quiet = _sine_at(-10.0)  # well inside the 8x/+18dB cap
+    boosted = loudness.normalize_peak(quiet)
+    assert abs(loudness.peak_dbfs(boosted) - loudness.TARGET_DBFS) <= 0.5
+
+
+def test_an_already_hot_sine_is_left_untouched():
+    hot = _sine_at(-2.0)
+    result = loudness.normalize_peak(hot)
+    assert np.array_equal(result, hot)
+
+
+def test_digital_silence_is_left_untouched_no_crash():
+    silence = np.zeros(8000, dtype="<i2")
+    result = loudness.normalize_peak(silence)
+    assert np.array_equal(result, silence)
+
+
+def test_empty_buffer_is_left_untouched_no_crash():
+    empty = np.array([], dtype="<i2")
+    result = loudness.normalize_peak(empty)
+    assert result.size == 0
+
+
+def test_a_near_silent_take_is_capped_not_blown_into_a_wall_of_hiss():
+    near_silent = _sine_at(-40.0)  # needs +39dB; cap holds it at +18dB
+    boosted = loudness.normalize_peak(near_silent)
+    gain = loudness.peak_dbfs(boosted) - loudness.peak_dbfs(near_silent)
+    assert gain <= 18.1, "gain must never exceed the 8x/+18dB cap"
+    assert loudness.peak_dbfs(boosted) < loudness.TARGET_DBFS - 1, (
+        "a near-silent take must not reach the same target as a merely quiet one"
+    )
+
+
+def test_normalize_wav_file_rewrites_a_quiet_wav_in_place(tmp_path):
+    path = tmp_path / "mic.wav"
+    quiet = _sine_at(-10.0)
+    with wave.open(str(path), "wb") as handle:
+        handle.setparams((1, 2, 16_000, 0, "NONE", "not compressed"))
+        handle.writeframes(quiet.tobytes())
+
+    loudness.normalize_wav_file(path)
+
+    with wave.open(str(path), "rb") as handle:
+        raw = handle.readframes(handle.getnframes())
+    result = np.frombuffer(raw, dtype="<i2")
+    assert abs(loudness.peak_dbfs(result) - loudness.TARGET_DBFS) <= 0.5
+
+
+def test_normalize_wav_file_never_raises_on_a_missing_file(tmp_path):
+    loudness.normalize_wav_file(tmp_path / "nope.wav")

--- a/tests/test_meeting.py
+++ b/tests/test_meeting.py
@@ -17,7 +17,7 @@ sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent))
 
 from wisprlite import config
 from wisprlite import meeting
-from wisprlite.meeting import MeetingRecorder
+from wisprlite.meeting import SAMPLE_RATE, MeetingRecorder
 
 
 class FixedDateTime(RealDateTime):
@@ -135,7 +135,7 @@ def test_meta_round_trip_and_elapsed():
 
         meta = json.loads((session / "meta.json").read_text(encoding="utf-8"))
         assert json.loads(json.dumps(meta)) == meta
-        assert meta["sample_rate"] == 16_000
+        assert meta["sample_rate"] == SAMPLE_RATE
         assert meta["channels"] == 1
         assert meta["mic"]["first_block_monotonic"] is not None
         assert meta["desktop"]["first_block_monotonic"] is not None
@@ -146,10 +146,14 @@ def test_meta_round_trip_and_elapsed():
 
         for filename in ("mic.wav", "desktop.wav"):
             with wave.open(str(session / filename), "rb") as audio:
-                assert audio.getframerate() == 16_000
+                assert audio.getframerate() == SAMPLE_RATE
                 assert audio.getnchannels() == 1
                 assert audio.getsampwidth() == 2
                 assert audio.getnframes() > 0
+
+
+def test_meeting_records_at_48khz_not_the_16khz_speech_rate():
+    assert SAMPLE_RATE == 48_000
 
 
 def test_mid_recording_checkpoint_patches_wave_header():

--- a/tests/test_meeting.py
+++ b/tests/test_meeting.py
@@ -982,3 +982,33 @@ def test_a_writer_that_finished_hands_over_its_tail():
         recorder._close_waves()
         with wave.open(str(path), "rb") as audio:
             assert audio.getnframes() == 800
+
+
+def test_a_quiet_meeting_wav_is_normalised_when_the_recording_stops():
+    """The normalisation maths being right proves nothing about whether stop()
+    CALLS it. Sabotaging the call site left the whole suite green."""
+    import numpy as np
+    from wisprlite import loudness
+
+    with tempfile.TemporaryDirectory() as tmp:
+        session = pathlib.Path(tmp) / "meeting-quiet"
+        session.mkdir()
+        recorder = MeetingRecorder(pathlib.Path(tmp))
+        recorder.session_dir = session
+        recorder._started_at = "2026-09-04T12:00:00+00:00"
+        recorder._active = True
+        for stream in ("mic", "desktop"):
+            recorder._waves[stream] = recorder._open_wave(session / f"{stream}.wav")
+            # -26 dBFS: quiet enough to correct, inside the 8x cap.
+            quiet = np.full((4_000, 1), 10 ** (-26 / 20), dtype=np.float32)
+            recorder._write_block(stream, quiet)
+
+        recorder.stop()
+
+        for stream in ("mic", "desktop"):
+            with wave.open(str(session / f"{stream}.wav"), "rb") as audio:
+                samples = np.frombuffer(audio.readframes(audio.getnframes()), dtype="<i2")
+            assert loudness.peak_dbfs(samples) > -10, (
+                f"{stream}.wav left at {loudness.peak_dbfs(samples):.1f} dBFS — "
+                "stop() is not normalising"
+            )

--- a/tests/test_mics.py
+++ b/tests/test_mics.py
@@ -150,3 +150,24 @@ def test_measure_on_silence_does_not_raise():
 def test_measure_on_empty_array_does_not_raise():
     m = mics.measure(np.array([], dtype=np.float32), 16_000)
     assert m["clipping_pct"] == 0.0
+
+
+def test_silence_reports_no_signal_to_noise_not_infinite():
+    """rms and noise floor are both -inf for digital silence: 0/0, undefined.
+    Reporting inf made a dead mic look like it had immaculate SNR."""
+    m = mics.measure(np.zeros(16_000, dtype=np.float32), 16_000)
+    assert m["snr_db"] == 0.0
+    assert mics.verdict(m) == "Nothing heard — is this the right mic?"
+
+
+def test_a_stereo_endpoint_does_not_outrank_a_mono_one():
+    """Channel count says nothing about microphone quality — webcams and
+    headsets report both — so it must not decide the recommendation."""
+    grouped = [
+        {"index": 3, "name": "Yeti Mono", "hostapi": "Windows WASAPI", "channels": 1,
+         "default_samplerate": 48000.0, "is_default": False, "is_virtual": False},
+        {"index": 7, "name": "Webcam Stereo", "hostapi": "Windows WASAPI", "channels": 2,
+         "default_samplerate": 48000.0, "is_default": False, "is_virtual": False},
+    ]
+    assert mics.recommend(grouped)["index"] == 3, \
+        "the stereo endpoint won purely on channel count"

--- a/tests/test_mics.py
+++ b/tests/test_mics.py
@@ -1,0 +1,152 @@
+"""Mic grouping, ranking, and the pure "test my mic" maths — no sound card needed."""
+
+import math
+import pathlib
+import sys
+
+import numpy as np
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent))
+
+from wisprlite import mics
+
+
+def _endpoint(index, name, hostapi, channels=1, rate=48000.0, is_default=False):
+    return {
+        "index": index, "name": name, "hostapi": hostapi,
+        "channels": channels, "default_samplerate": rate, "is_default": is_default,
+    }
+
+
+# One physical mic (a USB headset) enumerated once per host API, the way
+# PortAudio does on Windows — worst (MME) sorted first, as the plan warns.
+_FOUR_HOST_APIS = [
+    _endpoint(0, "Blue Yeti", "MME"),
+    _endpoint(1, "Blue Yeti", "Windows DirectSound"),
+    _endpoint(2, "Blue Yeti", "Windows WDM-KS"),
+    _endpoint(3, "Blue Yeti", "Windows WASAPI", is_default=True),
+]
+
+
+def test_group_inputs_collapses_the_same_mic_across_host_apis_to_one_entry():
+    grouped = mics.group_inputs(_FOUR_HOST_APIS)
+    assert len(grouped) == 1
+    assert grouped[0]["hostapi"] == "Windows WASAPI"
+    assert grouped[0]["index"] == 3
+
+
+def test_group_inputs_without_the_preference_order_would_pick_mme_first():
+    # Sabotage check: if the host-API preference is removed and grouping just
+    # takes the first endpoint seen, MME — the worst of the four — wins.
+    naive_choice = _FOUR_HOST_APIS[0]
+    assert naive_choice["hostapi"] == "MME"
+    grouped = mics.group_inputs(_FOUR_HOST_APIS)
+    assert grouped[0]["hostapi"] != "MME"
+
+
+def test_group_inputs_keeps_distinct_physical_mics_separate():
+    raw = _FOUR_HOST_APIS + [_endpoint(4, "USB Microphone", "Windows WASAPI")]
+    grouped = mics.group_inputs(raw)
+    assert len(grouped) == 2
+
+
+def test_group_inputs_truncates_mme_names_to_the_same_key_as_the_full_name():
+    # MME truncates device names to 31 chars; the plan's grouping key truncates
+    # to 30 so both variants of the same device fall in the same bucket.
+    long_name = "Microphone (Realtek High Definition Audio)"
+    raw = [
+        _endpoint(0, long_name[:31], "MME"),
+        _endpoint(1, long_name, "Windows WASAPI"),
+    ]
+    grouped = mics.group_inputs(raw)
+    assert len(grouped) == 1
+
+
+def test_recommend_prefers_the_default_device():
+    grouped = [
+        {"index": 0, "name": "A", "hostapi": "Windows WASAPI", "channels": 2,
+         "default_samplerate": 48000.0, "is_default": False, "is_virtual": False},
+        {"index": 1, "name": "B", "hostapi": "Windows WASAPI", "channels": 1,
+         "default_samplerate": 48000.0, "is_default": True, "is_virtual": False},
+    ]
+    assert mics.recommend(grouped)["name"] == "B"
+
+
+def test_recommend_never_picks_a_virtual_or_loopback_endpoint():
+    grouped = [
+        {"index": 0, "name": "Stereo Mix", "hostapi": "MME", "channels": 2,
+         "default_samplerate": 48000.0, "is_default": True, "is_virtual": True},
+        {"index": 1, "name": "Real Mic", "hostapi": "Windows WASAPI", "channels": 1,
+         "default_samplerate": 48000.0, "is_default": False, "is_virtual": False},
+    ]
+    assert mics.recommend(grouped)["name"] == "Real Mic"
+
+
+def test_recommend_returns_none_on_an_empty_list_rather_than_raising():
+    assert mics.recommend([]) is None
+
+
+def test_recommend_returns_none_when_only_virtual_devices_exist():
+    grouped = [{"index": 0, "name": "Stereo Mix", "hostapi": "MME", "channels": 2,
+                "default_samplerate": 48000.0, "is_default": True, "is_virtual": True}]
+    assert mics.recommend(grouped) is None
+
+
+def test_virtual_markers_are_matched_case_insensitively():
+    grouped = mics.group_inputs([_endpoint(0, "CABLE Output (VB-Audio)", "Windows WASAPI")])
+    assert grouped[0]["is_virtual"] is True
+
+
+def test_nvidia_broadcast_is_not_excluded_as_virtual():
+    grouped = mics.group_inputs([_endpoint(0, "NVIDIA Broadcast", "Windows WASAPI")])
+    assert grouped[0]["is_virtual"] is False
+
+
+# -- measure() / verdict() ----------------------------------------------------
+
+def _sine(dbfs, seconds=0.5, rate=16_000):
+    amplitude = 10.0 ** (dbfs / 20.0)
+    t = np.linspace(0, seconds, int(rate * seconds), endpoint=False)
+    return (np.sin(2 * np.pi * 220 * t) * amplitude).astype(np.float32)
+
+
+def test_verdict_too_loud_on_clipping():
+    m = {"clipping_pct": 1.0, "rms_dbfs": -10, "snr_db": 30}
+    assert mics.verdict(m) == "Too loud — turn the mic gain down"
+
+
+def test_verdict_nothing_heard_on_very_low_rms():
+    m = {"clipping_pct": 0.0, "rms_dbfs": -50, "snr_db": 30}
+    assert mics.verdict(m) == "Nothing heard — is this the right mic?"
+
+
+def test_verdict_too_quiet():
+    m = {"clipping_pct": 0.0, "rms_dbfs": -35, "snr_db": 30}
+    assert mics.verdict(m) == "Too quiet — move closer or raise the gain"
+
+
+def test_verdict_noisy_on_low_snr():
+    m = {"clipping_pct": 0.0, "rms_dbfs": -10, "snr_db": 5}
+    assert mics.verdict(m) == "Noisy — a lot of background for the level of your voice"
+
+
+def test_verdict_good():
+    m = {"clipping_pct": 0.0, "rms_dbfs": -10, "snr_db": 30}
+    assert mics.verdict(m) == "Good"
+
+
+def test_measure_reports_clipping_percentage():
+    samples = np.full(1000, 0.995, dtype=np.float32)
+    m = mics.measure(samples, 16_000)
+    assert m["clipping_pct"] == 100.0
+
+
+def test_measure_on_silence_does_not_raise():
+    m = mics.measure(np.zeros(1000, dtype=np.float32), 16_000)
+    assert m["clipping_pct"] == 0.0
+    assert math.isinf(m["peak_dbfs"])
+
+
+def test_measure_on_empty_array_does_not_raise():
+    m = mics.measure(np.array([], dtype=np.float32), 16_000)
+    assert m["clipping_pct"] == 0.0

--- a/tests/test_screenrec.py
+++ b/tests/test_screenrec.py
@@ -731,3 +731,33 @@ def test_the_pill_naming_hands_back_what_was_typed_and_never_blocks_for_ever():
     ui.answer_name("")
     assert ui.take_name() == ""
     assert ui.snapshot()["phase"] == "working"
+
+
+def test_a_quiet_recording_comes_out_of_the_mux_normalised():
+    """The pure normalisation maths being right proves nothing about whether
+    _mux actually CALLS it. Sabotaging the call site left the whole suite green,
+    which is how a feature ships built-but-not-mounted."""
+    with tempfile.TemporaryDirectory() as tmp:
+        rec = _recording(tmp, fps=10)
+        _feed(rec, _frames(10))
+        # -26 dBFS: quiet enough to correct, inside the 8x cap.
+        quiet = (np.sin(np.linspace(0, 220 * 2 * np.pi, screenrec.AUDIO_RATE))
+                 * (32767 * 10 ** (-26 / 20))).astype("<i2")
+        with wave.open(str(rec.audio_path), "wb") as handle:
+            handle.setparams((1, 2, screenrec.AUDIO_RATE, 0, "NONE", "not compressed"))
+            handle.writeframes(quiet.tobytes())
+
+        out = rec._mux()
+
+        assert out is not None, rec.errors
+        with av.open(str(out)) as container:
+            decoded = np.concatenate([
+                f.to_ndarray().reshape(-1) for f in container.decode(audio=0)
+            ])
+        # AAC decodes to float32 in [-1, 1], not int16.
+        # AAC is lossy, so assert the LEVEL moved, not the exact sample values.
+        peak_dbfs = 20 * np.log10(np.abs(decoded).max())
+        assert peak_dbfs > -10, (
+            f"quiet narration reached the mp4 at {peak_dbfs:.1f} dBFS — "
+            "_mux is not normalising"
+        )

--- a/tests/test_screenrec.py
+++ b/tests/test_screenrec.py
@@ -77,6 +77,20 @@ def test_it_produces_an_mp4_that_decodes_back_to_the_frames_put_in():
         assert decoded == 20, f"put in 20 frames, got {decoded} back"
 
 
+def test_the_recording_rate_is_48khz_not_the_16khz_speech_rate():
+    """16kHz is a speech-recognition rate; a file people LISTEN to needs treble."""
+    assert screenrec.AUDIO_RATE == 48_000
+    with tempfile.TemporaryDirectory() as tmp:
+        rec = _recording(tmp, fps=10)
+        _feed(rec, _frames(10))
+        _write_wav(rec.audio_path, seconds=1.0)
+
+        out = rec._mux()
+
+        with av.open(str(out)) as container:
+            assert container.streams.audio[0].codec_context.sample_rate == 48_000
+
+
 def test_the_narration_survives_into_the_mp4():
     with tempfile.TemporaryDirectory() as tmp:
         rec = _recording(tmp, fps=10)

--- a/wisprlite/__init__.py
+++ b/wisprlite/__init__.py
@@ -1,3 +1,3 @@
 """Pipevoice — push-to-talk voice typing for Windows."""
 
-__version__ = "2.40.6"
+__version__ = "2.41.0"

--- a/wisprlite/app.py
+++ b/wisprlite/app.py
@@ -944,7 +944,7 @@ class App:
         if not getattr(cfg, "pipefocus", False) or cfg.engine != "deepgram":
             return
         try:
-            from . import cleanup, focus
+            from . import cleanup, focus, meeting
             from .engines.deepgram_engine import focus_stream
 
             def completion(messages):
@@ -953,7 +953,9 @@ class App:
                 )
 
             session = focus.FocusSession(
-                connect=lambda on_text: focus_stream(cfg, on_text),
+                connect=lambda on_text: focus_stream(
+                    cfg, on_text, sample_rate=meeting.SAMPLE_RATE
+                ),
                 completion=completion,
                 on_tip=self._show_focus_tip,
             )

--- a/wisprlite/engines/deepgram_engine.py
+++ b/wisprlite/engines/deepgram_engine.py
@@ -134,7 +134,7 @@ class DeepgramEngine(Engine):
         return _DeepgramSession(self, on_partial)
 
 
-def focus_stream(cfg, on_text):
+def focus_stream(cfg, on_text, *, sample_rate=16_000):
     """Open a MULTICHANNEL live connection for PipeFocus.
 
     channels=2 with multichannel=True means Deepgram reports which channel each
@@ -182,7 +182,7 @@ def focus_stream(cfg, on_text):
         model=getattr(cfg, "deepgram_model", "") or "nova-3",
         language=getattr(cfg, "language", "") or "en-US",
         encoding="linear16",
-        sample_rate=16_000,
+        sample_rate=sample_rate,
         channels=2,
         multichannel=False,
         interim_results=False,

--- a/wisprlite/loudness.py
+++ b/wisprlite/loudness.py
@@ -1,0 +1,79 @@
+"""Peak normalisation for recorded audio, not dictation.
+
+Monotonic gain only: a quiet take is boosted towards a usable level, a take
+that is already hot is left alone, and gain is capped so a near-silent take
+is not blown up into a wall of hiss. No compression, no EQ, no noise
+suppression — see the plan this implements for why.
+"""
+
+from __future__ import annotations
+
+import wave
+
+import numpy as np
+
+TARGET_DBFS = -1.0
+THRESHOLD_DBFS = -3.0
+MAX_GAIN = 8.0  # +18 dB
+FULL_SCALE = 32767.0
+
+
+def peak_dbfs(samples: np.ndarray) -> float:
+    """dBFS of the loudest sample. -inf for silence."""
+    if samples.size == 0:
+        return float("-inf")
+    peak = float(np.abs(samples).max())
+    if peak <= 0:
+        return float("-inf")
+    return 20.0 * np.log10(peak / FULL_SCALE)
+
+
+def normalize_peak(
+    samples: np.ndarray,
+    *,
+    target_dbfs: float = TARGET_DBFS,
+    threshold_dbfs: float = THRESHOLD_DBFS,
+    max_gain: float = MAX_GAIN,
+) -> np.ndarray:
+    """Boost a quiet int16 PCM buffer towards `target_dbfs`, gain-capped.
+
+    Already-hot audio (peak >= threshold_dbfs) and digital silence both come
+    back unchanged.
+    """
+    if samples.size == 0:
+        return samples
+    peak = float(np.abs(samples).max())
+    if peak <= 0:
+        return samples
+    current_dbfs = 20.0 * np.log10(peak / FULL_SCALE)
+    if current_dbfs >= threshold_dbfs:
+        return samples
+    target_peak = FULL_SCALE * (10.0 ** (target_dbfs / 20.0))
+    gain = min(target_peak / peak, max_gain)
+    if gain <= 1.0:
+        return samples
+    boosted = np.clip(samples.astype(np.float64) * gain, -32768, 32767)
+    return boosted.astype(samples.dtype if samples.dtype.kind == "i" else "<i2")
+
+
+def normalize_wav_file(path) -> None:
+    """Rewrite a mono int16 wav in place at its normalised peak.
+
+    Best-effort: a missing/corrupt/empty file is left untouched rather than
+    raising, since this runs after the recording is already safely on disk.
+    """
+    try:
+        with wave.open(str(path), "rb") as handle:
+            params = handle.getparams()
+            raw = handle.readframes(handle.getnframes())
+        if params.sampwidth != 2:
+            return  # only int16 PCM is supported; leave anything else alone
+        samples = np.frombuffer(raw, dtype="<i2")
+        normalized = normalize_peak(samples)
+        if normalized is samples:
+            return
+        with wave.open(str(path), "wb") as handle:
+            handle.setparams(params)
+            handle.writeframes(normalized.tobytes())
+    except Exception:
+        pass

--- a/wisprlite/loudness.py
+++ b/wisprlite/loudness.py
@@ -8,9 +8,12 @@ suppression — see the plan this implements for why.
 
 from __future__ import annotations
 
+import logging
 import wave
 
 import numpy as np
+
+log = logging.getLogger("wisprlite")
 
 TARGET_DBFS = -1.0
 THRESHOLD_DBFS = -3.0
@@ -53,7 +56,9 @@ def normalize_peak(
     if gain <= 1.0:
         return samples
     boosted = np.clip(samples.astype(np.float64) * gain, -32768, 32767)
-    return boosted.astype(samples.dtype if samples.dtype.kind == "i" else "<i2")
+    # Same dtype in, same dtype out. The old branch silently handed a float
+    # caller int16 back, which is a conversion wearing a normaliser's name.
+    return boosted.astype(samples.dtype)
 
 
 def normalize_wav_file(path) -> None:
@@ -76,4 +81,7 @@ def normalize_wav_file(path) -> None:
             handle.setparams(params)
             handle.writeframes(normalized.tobytes())
     except Exception:
-        pass
+        # Best-effort by design - the recording is already safely on disk and
+        # must not be lost to a normalisation problem. But swallowing silently
+        # would hide a real regression in the maths, so say so.
+        log.warning("could not normalise %s", path, exc_info=True)

--- a/wisprlite/meeting.py
+++ b/wisprlite/meeting.py
@@ -24,11 +24,11 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Callable
 
-SAMPLE_RATE = 16_000
+SAMPLE_RATE = 48_000
 CHANNELS = 1
 SAMPLE_WIDTH = 2
-MIC_BLOCKSIZE = 800
-DESKTOP_BLOCKSIZE = 1_600
+MIC_BLOCKSIZE = 2400  # 50ms of frames at SAMPLE_RATE, unchanged from 16kHz
+DESKTOP_BLOCKSIZE = 4_800  # 100ms of frames at SAMPLE_RATE, unchanged from 16kHz
 CAPTURE_JOIN_TIMEOUT = 3.0
 HEADER_PATCH_INTERVAL = 5.0
 # ~30s of audio in hand before we start dropping. Dropping is a last resort,
@@ -969,6 +969,10 @@ class MeetingRecorder:
         self._finish_writer()
 
         self._close_waves()
+        if self.session_dir is not None:
+            from . import loudness
+            loudness.normalize_wav_file(self.session_dir / "mic.wav")
+            loudness.normalize_wav_file(self.session_dir / "desktop.wav")
         stopped_at = datetime.now(timezone.utc)
         duration = max(0.0, time.monotonic() - started) if started is not None else 0.0
         self._write_meta(stopped_at.isoformat(), duration)

--- a/wisprlite/mics.py
+++ b/wisprlite/mics.py
@@ -97,9 +97,11 @@ def recommend(grouped: list[dict]) -> dict | None:
         return None
     return min(
         candidates,
+        # Deliberately NOT ranked by channel count. A stereo endpoint is not a
+        # better microphone than a mono one - webcams and headsets report both -
+        # so the count carries no signal and ordering by it just picks wrong.
         key=lambda g: (
             0 if g.get("is_default") else 1,
-            -g.get("channels", 0),
             -g.get("default_samplerate", 0.0),
             g.get("index", 0),
         ),
@@ -136,7 +138,12 @@ def measure(samples: np.ndarray, rate: int) -> dict:
 
     rms_db = to_dbfs(rms)
     noise_floor_db = to_dbfs(noise_floor)
-    snr_db = (rms_db - noise_floor_db) if noise_floor_db != float("-inf") else float("inf")
+    if rms_db == float("-inf"):
+        snr_db = 0.0          # digital silence: 0/0, not infinite signal
+    elif noise_floor_db == float("-inf"):
+        snr_db = float("inf")  # real signal, immeasurably quiet floor
+    else:
+        snr_db = rms_db - noise_floor_db
 
     return {
         "peak_dbfs": to_dbfs(peak),

--- a/wisprlite/mics.py
+++ b/wisprlite/mics.py
@@ -1,0 +1,160 @@
+"""A microphone picker that recommends, instead of dumping raw PortAudio endpoints.
+
+Pure functions over plain dicts/arrays so the grouping, ranking, and level
+maths are all testable without a sound card. Only `list_inputs` touches
+`sounddevice`.
+"""
+
+from __future__ import annotations
+
+import re
+
+import numpy as np
+
+# Best endpoint first. Anything not listed (rare host APIs) sorts last.
+_HOSTAPI_PREFERENCE = ["Windows WASAPI", "Windows WDM-KS", "Windows DirectSound", "MME"]
+
+# Loopback/virtual endpoints: real inputs, but never the recommendation.
+_VIRTUAL_MARKERS = [
+    "stereo mix", "what u hear", "cable output", "voicemeeter out", "wave out mix",
+]
+
+
+def _normalize_name(name: str) -> str:
+    # Truncate the RAW name first, then strip punctuation — MME truncates to
+    # 31 raw chars, so cutting our own key at 30 raw chars (one shorter) keeps
+    # it a prefix of whatever the other host APIs report for the same device.
+    # Stripping symbols before truncating would instead cut at a different
+    # point depending on how many symbols fell inside each window.
+    return re.sub(r"[^a-z0-9]", "", (name or "")[:30].lower())
+
+
+def _hostapi_rank(hostapi: str) -> int:
+    try:
+        return _HOSTAPI_PREFERENCE.index(hostapi)
+    except ValueError:
+        return len(_HOSTAPI_PREFERENCE)
+
+
+def _is_virtual(name: str) -> bool:
+    lowered = (name or "").lower()
+    return any(marker in lowered for marker in _VIRTUAL_MARKERS)
+
+
+def list_inputs() -> list[dict]:
+    """Every raw input endpoint PortAudio reports, undeduplicated."""
+    import sounddevice as sd
+
+    hostapis = sd.query_hostapis()
+    try:
+        default_index = sd.default.device[0]
+    except Exception:
+        default_index = None
+
+    out = []
+    for i, d in enumerate(sd.query_devices()):
+        if d.get("max_input_channels", 0) <= 0:
+            continue
+        hostapi_idx = d.get("hostapi")
+        hostapi_name = hostapis[hostapi_idx]["name"] if hostapi_idx is not None else ""
+        out.append({
+            "index": i,
+            "name": d.get("name", ""),
+            "hostapi": hostapi_name,
+            "channels": d.get("max_input_channels", 0),
+            "default_samplerate": d.get("default_samplerate", 0.0),
+            "is_default": i == default_index,
+        })
+    return out
+
+
+def group_inputs(raw: list[dict]) -> list[dict]:
+    """One entry per physical mic: the best-hostapi endpoint from each group."""
+    groups: dict[str, list[dict]] = {}
+    for entry in raw:
+        key = _normalize_name(entry.get("name", ""))
+        groups.setdefault(key, []).append(entry)
+
+    grouped = []
+    for endpoints in groups.values():
+        best = min(endpoints, key=lambda e: _hostapi_rank(e.get("hostapi", "")))
+        grouped.append({
+            "index": best["index"],
+            "name": best["name"],
+            "hostapi": best.get("hostapi", ""),
+            "channels": best.get("channels", 0),
+            "default_samplerate": best.get("default_samplerate", 0.0),
+            "is_default": any(e.get("is_default") for e in endpoints),
+            "is_virtual": _is_virtual(best["name"]),
+        })
+    return grouped
+
+
+def recommend(grouped: list[dict]) -> dict | None:
+    """The one grouped entry to suggest, or None if nothing qualifies."""
+    candidates = [g for g in grouped if not g.get("is_virtual")]
+    if not candidates:
+        return None
+    return min(
+        candidates,
+        key=lambda g: (
+            0 if g.get("is_default") else 1,
+            -g.get("channels", 0),
+            -g.get("default_samplerate", 0.0),
+            g.get("index", 0),
+        ),
+    )
+
+
+# -- "Test my mic" ------------------------------------------------------------
+
+FRAME_MS = 20
+
+
+def measure(samples: np.ndarray, rate: int) -> dict:
+    """Peak/RMS/noise-floor/clipping/SNR over a float32 [-1, 1] buffer."""
+    samples = np.asarray(samples, dtype=np.float64).reshape(-1)
+    if samples.size == 0:
+        return {"peak_dbfs": float("-inf"), "rms_dbfs": float("-inf"),
+                "noise_floor_dbfs": float("-inf"), "clipping_pct": 0.0, "snr_db": 0.0}
+
+    def to_dbfs(value: float) -> float:
+        return 20.0 * np.log10(value) if value > 0 else float("-inf")
+
+    peak = float(np.abs(samples).max())
+    rms = float(np.sqrt(np.mean(samples ** 2)))
+    clipping_pct = float(np.mean(np.abs(samples) >= 0.99) * 100.0)
+
+    frame_len = max(1, int(rate * FRAME_MS / 1000))
+    frame_count = samples.size // frame_len
+    if frame_count > 0:
+        frames = samples[: frame_count * frame_len].reshape(frame_count, frame_len)
+        frame_rms = np.sqrt(np.mean(frames ** 2, axis=1))
+        noise_floor = float(np.percentile(frame_rms, 10))
+    else:
+        noise_floor = rms
+
+    rms_db = to_dbfs(rms)
+    noise_floor_db = to_dbfs(noise_floor)
+    snr_db = (rms_db - noise_floor_db) if noise_floor_db != float("-inf") else float("inf")
+
+    return {
+        "peak_dbfs": to_dbfs(peak),
+        "rms_dbfs": rms_db,
+        "noise_floor_dbfs": noise_floor_db,
+        "clipping_pct": clipping_pct,
+        "snr_db": snr_db,
+    }
+
+
+def verdict(measurement: dict) -> str:
+    """First-match-wins verdict string for a `measure()` result."""
+    if measurement["clipping_pct"] > 0.1:
+        return "Too loud — turn the mic gain down"
+    if measurement["rms_dbfs"] < -40:
+        return "Nothing heard — is this the right mic?"
+    if measurement["rms_dbfs"] < -30:
+        return "Too quiet — move closer or raise the gain"
+    if measurement["snr_db"] < 15:
+        return "Noisy — a lot of background for the level of your voice"
+    return "Good"

--- a/wisprlite/screenrec.py
+++ b/wisprlite/screenrec.py
@@ -27,7 +27,7 @@ from pathlib import Path
 
 log = logging.getLogger("wisprlite")
 
-AUDIO_RATE = 16_000
+AUDIO_RATE = 48_000
 AUDIO_CHANNELS = 1
 AUDIO_WIDTH = 2
 DEFAULT_FPS = 12
@@ -195,6 +195,9 @@ class ScreenRecording:
         # audio track is always declared, even if it ends up empty.
         audio = self._container.add_stream("aac", rate=AUDIO_RATE)
         audio.layout = "mono"
+        # PyAV's default bitrate for a 48kHz mono AAC stream isn't guaranteed
+        # to be high enough to keep the point of recording at 48kHz.
+        audio.bit_rate = 128_000
         self._audio_stream = audio
 
     def _encode_frame(self, frame) -> None:
@@ -279,7 +282,9 @@ class ScreenRecording:
                 samplerate=AUDIO_RATE,
                 channels=AUDIO_CHANNELS,
                 dtype="float32",
-                blocksize=800,
+                # 50ms of frames at AUDIO_RATE — keeps the callback rate and
+                # queue pressure the same as it was at 16kHz.
+                blocksize=2400,
                 callback=self._on_mic_block,
                 device=self.device,
             )
@@ -372,8 +377,11 @@ class ScreenRecording:
                 for packet in video.encode():          # flush the encoder
                     container.mux(packet)
 
+                from . import loudness
+
                 samples = self._trim_lead(self._read_wav())
                 if audio is not None and samples is not None and samples.size:
+                    samples = loudness.normalize_peak(samples)
                     frame = av.AudioFrame.from_ndarray(
                         samples.reshape(1, -1), format="s16", layout="mono"
                     )

--- a/wisprlite/settings.py
+++ b/wisprlite/settings.py
@@ -1088,25 +1088,60 @@ def main(first_run: bool = False) -> None:
             value = dict((lbl, val) for lbl, val in devices).get(device_var.get(), "")
             return int(value) if value else None
 
+        def _show(text, fg):
+            # Recording happens on a worker thread, so every UI write comes back
+            # through the main loop. A destroyed dialog would abort the whole
+            # interpreter, not just this callback - see the about.py incident.
+            def apply():
+                if result.winfo_exists():
+                    result.config(text=text, fg=fg)
+            try:
+                if dialog.winfo_exists():
+                    dialog.after(0, apply)
+            except Exception:
+                pass
+
+        def _in_background(fn):
+            # sd.rec + sd.wait blocks for 3s, or 1.5s PER DEVICE. On the UI
+            # thread that is a frozen, "Not Responding" window for the whole
+            # test - on the one feature that exists to feel reassuring.
+            for button in (single_btn, all_btn):
+                button.config(state="disabled")
+
+            def done():
+                for button in (single_btn, all_btn):
+                    if button.winfo_exists():
+                        button.config(state="normal")
+
+            def work():
+                try:
+                    fn()
+                finally:
+                    try:
+                        if dialog.winfo_exists():
+                            dialog.after(0, done)
+                    except Exception:
+                        pass
+
+            threading.Thread(target=work, daemon=True).start()
+
         def run_single():
-            result.config(text="Recording 3s…", fg=MUTED)
-            dialog.update()
+            _show("Recording 3s…", MUTED)
             try:
                 samples, rate = _record_seconds(_selected_device(), 3.0)
                 m = mics.measure(samples, rate)
                 v = mics.verdict(m)
                 fg = GOOD if v == "Good" else (ACCENT if "loud" in v or "Nothing" in v else WARN)
-                result.config(
-                    text=f"{v}\npeak {m['peak_dbfs']:.1f} dBFS · rms {m['rms_dbfs']:.1f} dBFS · "
-                         f"snr {m['snr_db']:.1f} dB · clipping {m['clipping_pct']:.2f}%",
-                    fg=fg,
+                _show(
+                    f"{v}\npeak {m['peak_dbfs']:.1f} dBFS · rms {m['rms_dbfs']:.1f} dBFS · "
+                    f"snr {m['snr_db']:.1f} dB · clipping {m['clipping_pct']:.2f}%",
+                    fg,
                 )
             except Exception as exc:
-                result.config(text=f"Microphone unavailable: {exc}", fg=ACCENT)
+                _show(f"Microphone unavailable: {exc}", ACCENT)
 
         def run_all():
-            result.config(text="Testing every microphone— keep talking…", fg=MUTED)
-            dialog.update()
+            _show("Testing every microphone — keep talking…", MUTED)
             try:
                 grouped = mics.group_inputs(mics.list_inputs())
                 scored = []
@@ -1119,11 +1154,8 @@ def main(first_run: bool = False) -> None:
                     in_band = -30 <= m["rms_dbfs"] <= -6
                     scored.append((g, m, in_band))
                 if not heard_any:
-                    result.config(
-                        text="Nothing heard on any device — inconclusive, "
-                             "keep talking and try again.",
-                        fg=WARN,
-                    )
+                    _show("Nothing heard on any device — inconclusive, "
+                          "keep talking and try again.", WARN)
                     return
                 best_g, best_m, _ = max(scored, key=lambda t: (t[2], t[1]["snr_db"]))
                 best_label = next(
@@ -1131,14 +1163,18 @@ def main(first_run: bool = False) -> None:
                 )
                 if best_label:
                     device_var.set(best_label)
-                result.config(text=f"Picked {best_g['name']} — {mics.verdict(best_m)}", fg=GOOD)
+                _show(f"Picked {best_g['name']} — {mics.verdict(best_m)}", GOOD)
             except Exception as exc:
-                result.config(text=f"Test failed: {exc}", fg=ACCENT)
+                _show(f"Test failed: {exc}", ACCENT)
 
         btns = tk.Frame(dialog, bg=BG)
         btns.pack(pady=(0, 8))
-        ttk.Button(btns, text="Test mic (3s)", command=run_single).pack(side="left", padx=4)
-        ttk.Button(btns, text="Test all and pick the best", command=run_all).pack(side="left", padx=4)
+        single_btn = ttk.Button(btns, text="Test mic (3s)",
+                                command=lambda: _in_background(run_single))
+        single_btn.pack(side="left", padx=4)
+        all_btn = ttk.Button(btns, text="Test all and pick the best",
+                             command=lambda: _in_background(run_all))
+        all_btn.pack(side="left", padx=4)
         ttk.Button(dialog, text="Close", command=dialog.destroy).pack(pady=(0, 16))
 
     ttk.Button(mic_row, text="Test my mic", command=test_mic).pack(side="left", padx=(8, 0))

--- a/wisprlite/settings.py
+++ b/wisprlite/settings.py
@@ -51,18 +51,47 @@ MUTED = "#94a3b8"
 ACCENT = "#e06c75"
 
 
-def _input_devices():
-    """Return [(label, value)] for the device picker; never raises."""
+def _input_devices(show_all: bool = False):
+    """Return [(label, value)] for the device picker; never raises.
+
+    Grouped by default — one entry per physical mic, best host-API endpoint,
+    the recommended one labelled. `show_all` returns every raw PortAudio
+    endpoint instead, for anyone who needs a specific host API.
+    """
     items = [("System default", "")]
     try:
-        import sounddevice as sd
+        from . import mics
 
-        for i, d in enumerate(sd.query_devices()):
-            if d.get("max_input_channels", 0) > 0:
-                items.append((f"[{i}] {d['name']}", str(i)))
+        raw = mics.list_inputs()
+        if show_all:
+            for d in raw:
+                items.append((f"[{d['index']}] {d['name']} ({d['hostapi']})", str(d["index"])))
+        else:
+            grouped = mics.group_inputs(raw)
+            best = mics.recommend(grouped)
+            best_index = best["index"] if best else None
+            for g in sorted(grouped, key=lambda g: g["index"]):
+                label = f"[{g['index']}] {g['name']}"
+                if g["index"] == best_index:
+                    label += " (recommended)"
+                items.append((label, str(g["index"])))
     except Exception:
         pass
     return items
+
+
+def _record_seconds(device, seconds: float, rate: int | None = None):
+    """Record `seconds` of float32 mono audio from `device`. Blocks."""
+    import sounddevice as sd
+
+    if rate is None:
+        try:
+            rate = int(sd.query_devices(device, "input")["default_samplerate"]) or 16_000
+        except Exception:
+            rate = 16_000
+    data = sd.rec(int(seconds * rate), samplerate=rate, channels=1, dtype="float32", device=device)
+    sd.wait()
+    return data.reshape(-1), rate
 
 
 GOOD = "#98c379"
@@ -640,6 +669,7 @@ def main(first_run: bool = False) -> None:
     bookmark_sensitivity_var = tk.DoubleVar(value=cfg.bookmark_sensitivity)
     bookmark_phrases_var = tk.StringVar(value=cfg.bookmark_phrases)
     lang_var = tk.StringVar(value=dict(LANGUAGES).get(cfg.language, LANGUAGES[0][1]))
+    show_all_devices_var = tk.BooleanVar(value=False)
     devices = _input_devices()
     dev_label = next((lbl for lbl, val in devices if val == cfg.device), devices[0][0])
     device_var = tk.StringVar(value=dev_label)
@@ -1040,7 +1070,91 @@ def main(first_run: bool = False) -> None:
           screenrec_fps_var, width=6)
 
     c = card("Audio")
-    combo(row(c, "Microphone"), device_var, [lbl for lbl, _ in devices], width=30)
+    mic_row = row(c, "Microphone")
+    device_combo = combo(mic_row, device_var, [lbl for lbl, _ in devices], width=30)
+
+    def test_mic():
+        from . import mics
+
+        dialog = tk.Toplevel(root)
+        dialog.title("Test my mic")
+        dialog.configure(bg=BG)
+        tk.Label(dialog, text="Keep talking while this runs…", bg=BG, fg=FG,
+                 font=("Segoe UI", 11, "bold")).pack(padx=18, pady=(16, 6))
+        result = tk.Label(dialog, text="", bg=BG, fg=MUTED, wraplength=320, justify="left")
+        result.pack(padx=18, pady=(0, 12))
+
+        def _selected_device():
+            value = dict((lbl, val) for lbl, val in devices).get(device_var.get(), "")
+            return int(value) if value else None
+
+        def run_single():
+            result.config(text="Recording 3s…", fg=MUTED)
+            dialog.update()
+            try:
+                samples, rate = _record_seconds(_selected_device(), 3.0)
+                m = mics.measure(samples, rate)
+                v = mics.verdict(m)
+                fg = GOOD if v == "Good" else (ACCENT if "loud" in v or "Nothing" in v else WARN)
+                result.config(
+                    text=f"{v}\npeak {m['peak_dbfs']:.1f} dBFS · rms {m['rms_dbfs']:.1f} dBFS · "
+                         f"snr {m['snr_db']:.1f} dB · clipping {m['clipping_pct']:.2f}%",
+                    fg=fg,
+                )
+            except Exception as exc:
+                result.config(text=f"Microphone unavailable: {exc}", fg=ACCENT)
+
+        def run_all():
+            result.config(text="Testing every microphone— keep talking…", fg=MUTED)
+            dialog.update()
+            try:
+                grouped = mics.group_inputs(mics.list_inputs())
+                scored = []
+                heard_any = False
+                for g in grouped:
+                    samples, rate = _record_seconds(g["index"], 1.5)
+                    m = mics.measure(samples, rate)
+                    if m["rms_dbfs"] >= -40:
+                        heard_any = True
+                    in_band = -30 <= m["rms_dbfs"] <= -6
+                    scored.append((g, m, in_band))
+                if not heard_any:
+                    result.config(
+                        text="Nothing heard on any device — inconclusive, "
+                             "keep talking and try again.",
+                        fg=WARN,
+                    )
+                    return
+                best_g, best_m, _ = max(scored, key=lambda t: (t[2], t[1]["snr_db"]))
+                best_label = next(
+                    (lbl for lbl, val in devices if val == str(best_g["index"])), None
+                )
+                if best_label:
+                    device_var.set(best_label)
+                result.config(text=f"Picked {best_g['name']} — {mics.verdict(best_m)}", fg=GOOD)
+            except Exception as exc:
+                result.config(text=f"Test failed: {exc}", fg=ACCENT)
+
+        btns = tk.Frame(dialog, bg=BG)
+        btns.pack(pady=(0, 8))
+        ttk.Button(btns, text="Test mic (3s)", command=run_single).pack(side="left", padx=4)
+        ttk.Button(btns, text="Test all and pick the best", command=run_all).pack(side="left", padx=4)
+        ttk.Button(dialog, text="Close", command=dialog.destroy).pack(pady=(0, 16))
+
+    ttk.Button(mic_row, text="Test my mic", command=test_mic).pack(side="left", padx=(8, 0))
+
+    def _on_show_all(*_):
+        nonlocal devices
+        current_value = dict((lbl, val) for lbl, val in devices).get(device_var.get(), "")
+        devices = _input_devices(show_all_devices_var.get())
+        device_combo.configure(values=[lbl for lbl, _ in devices])
+        new_label = next((lbl for lbl, val in devices if val == current_value), devices[0][0])
+        device_var.set(new_label)
+
+    show_all_devices_var.trace_add("write", _on_show_all)
+    check(c, "Show all endpoints", show_all_devices_var,
+          "Every raw device PortAudio reports, including duplicates across host "
+          "APIs (MME/DirectSound/WASAPI/WDM-KS) and virtual/loopback inputs.")
     combo(row(c, "Accent / language", "Pick yours for better accuracy, including non-native accents."),
           lang_var, [l for _, l in LANGUAGES])
 


### PR DESCRIPTION
Fixes two things James reported: recordings sound muffled, and the mic dropdown is an unrankable wall of choices.

Spec: `vault/Plans/pipevoice-audio-quality-and-mic-picker.md`

### 1. Recordings were captured at 16 kHz mono
`screenrec.py` and `meeting.py` both recorded at a speech-*recognition* rate, which hard-cuts everything above 8 kHz — the sibilance and "air" that make a voice sound present. Both now record at **48 kHz**, with the AAC bitrate pinned at 128k and blocksizes scaled 3x so callback cadence and queue wall-clock are unchanged.

Dictation stays at 16 kHz on purpose (`audio.py` + the three engines) — that audio is never played back. `ARCHITECTURE.md` now documents the split so "unify the sample rates" doesn't look like an obvious cleanup later.

**No resampling was needed:** both transcription backends take a file path and resample internally. The one exception is PipeFocus, which streams live PCM — `focus_stream()` took a hardcoded `sample_rate=16_000`, now a parameter that `app.py` fills from `meeting.SAMPLE_RATE`. A mismatch there makes every PipeFocus transcript garbage, so it's pinned by a test.

### 2. Quiet mics produced quiet recordings
New `loudness.py`: peak normalisation at finalise (never in an audio callback). Boosts towards -1 dBFS, gain capped at 8x so a near-silent take isn't blown into hiss, and audio already above -3 dBFS is untouched. Monotonic gain only — no compression, no EQ, no noise suppression — so it cannot hurt transcription accuracy.

### 3. The picker dumped every PortAudio endpoint
New `mics.py`: collapses per-host-API duplicates to one entry per physical mic (preferring WASAPI > WDM-KS > DirectSound > MME), excludes loopback/virtual endpoints from the recommendation, and marks exactly one `(recommended)`. `Show all endpoints` still reveals the raw list.

### 4. "Test my mic"
Records 3s and reports peak/RMS/noise floor/clipping/SNR with a plain-language verdict. "Test all and pick the best" ranks every mic and selects the winner, or reports the run inconclusive if nothing was heard. Recording runs on a worker thread — on the UI thread this froze the window for 3s, or 1.5s per device.

### Review
Built by a Sonnet builder; reviewed here by the brain, not by the builder.

- **Full suite re-run independently: 353 passed**, same 15 pre-existing failures `main` already has (baselined in a clean worktree). `verify-build` reports FAIL on this repo because it's Node/TS-oriented (`runner: none`) — that's "can't check", not "tests failed".
- **Sabotage battery of 7** run against the returned build. Five caught it; **two did not** — the normalisation was built but its call sites were untested, so deleting the call in `_mux()` or `stop()` left all 349 tests green. Two call-site tests added and verified red.
- **UI-freeze defect** found and fixed in review (see 4).
- **`/jury`** raised a P1 and four P2s. The P1 was mine: `git add -A` had committed a `node_modules` symlink pointing at `/root/intentos/node_modules`. Removed and gitignored. Three P2s fixed (silence reporting `+inf` SNR; `recommend()` ranking by channel count, which came from my own plan and is wrong; a silent float→int16 downcast; a bare `except: pass`). One P3 refuted on the code with reasoning, recorded in the commit.

### Not verified — hand these to James
No audio device and no Windows on this VPS. **How it actually sounds**, and **how the real Windows device list groups**, are unproven. Everything else is tested headlessly from synthesised buffers and fixtures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WStiFEE9AHoF4esPCaKiYD