### PR TITLE
fix(mic-test): grade on speech level, survive unopenable devices, offer a remedy

### DIFF
--- a/tests/test_mics.py
+++ b/tests/test_mics.py
@@ -171,3 +171,46 @@ def test_a_stereo_endpoint_does_not_outrank_a_mono_one():
     ]
     assert mics.recommend(grouped)["index"] == 3, \
         "the stereo endpoint won purely on channel count"
+
+
+def _speech_with_pauses(level_dbfs, rate=16_000, seconds=3.0, duty=0.4):
+    """Talking for `duty` of the window, silent the rest — a real 3s test."""
+    amplitude = 10 ** (level_dbfs / 20)
+    n = int(rate * seconds)
+    t = np.arange(n) / rate
+    tone = np.sin(2 * np.pi * 180 * t) * amplitude
+    # 500ms on / off blocks, so the buffer is `duty` speech and the rest quiet.
+    block = int(rate * 0.5)
+    gate = np.zeros(n)
+    for start in range(0, n, block):
+        if (start // block) % 5 < duty * 5:
+            gate[start:start + block] = 1.0
+    return (tone * gate).astype(np.float32)
+
+
+def test_pauses_between_sentences_do_not_read_as_a_quiet_microphone():
+    """James, 2026-09-04: "it kept on saying that it was too quiet."
+
+    A speaking level of -20 dBFS is fine. Whole-buffer RMS over a 3s window
+    that is 60% silence reports it far lower, so a good mic was graded on how
+    much the user happened to pause.
+    """
+    # -25 dBFS peak is about -28 dBFS of actual speech RMS: usable. Talking for
+    # a fifth of a 3s window drops whole-buffer RMS past -32, so the two grading
+    # methods DISAGREE here — the only kind of fixture that proves which is used.
+    m = mics.measure(_speech_with_pauses(-25.0, duty=0.2), 16_000)
+
+    assert m["rms_dbfs"] < -32, (
+        f"fixture does not exercise the averaging problem: rms {m['rms_dbfs']:.1f}"
+    )
+    assert m["speech_dbfs"] > -30, f"speech level lost to the pauses: {m['speech_dbfs']:.1f}"
+    assert mics.verdict(m) != "Too quiet — move closer or raise the gain"
+
+
+def test_a_genuinely_quiet_microphone_is_still_called_out():
+    """The fix must not make the verdict useless — a real problem still shows."""
+    m = mics.measure(_speech_with_pauses(-45.0), 16_000)
+    assert mics.verdict(m) in (
+        "Too quiet — move closer or raise the gain",
+        "Nothing heard — is this the right mic?",
+    ), mics.verdict(m)

--- a/wisprlite/__init__.py
+++ b/wisprlite/__init__.py
@@ -1,3 +1,3 @@
 """Pipevoice — push-to-talk voice typing for Windows."""
 
-__version__ = "2.41.0"
+__version__ = "2.41.1"

--- a/wisprlite/mics.py
+++ b/wisprlite/mics.py
@@ -133,8 +133,15 @@ def measure(samples: np.ndarray, rate: int) -> dict:
         frames = samples[: frame_count * frame_len].reshape(frame_count, frame_len)
         frame_rms = np.sqrt(np.mean(frames ** 2, axis=1))
         noise_floor = float(np.percentile(frame_rms, 10))
+        # The level of the SPEECH, not of the recording. Whole-buffer RMS
+        # averages in every pause between words, which drags a perfectly good
+        # microphone 10-15 dB down and reports it as "too quiet" - the level
+        # you would measure depends mostly on how much you paused. The loudest
+        # quarter of the frames is where the talking is.
+        speech = float(np.mean(frame_rms[frame_rms >= np.percentile(frame_rms, 75)]))
     else:
         noise_floor = rms
+        speech = rms
 
     rms_db = to_dbfs(rms)
     noise_floor_db = to_dbfs(noise_floor)
@@ -147,6 +154,7 @@ def measure(samples: np.ndarray, rate: int) -> dict:
 
     return {
         "peak_dbfs": to_dbfs(peak),
+        "speech_dbfs": to_dbfs(speech),
         "rms_dbfs": rms_db,
         "noise_floor_dbfs": noise_floor_db,
         "clipping_pct": clipping_pct,
@@ -155,12 +163,18 @@ def measure(samples: np.ndarray, rate: int) -> dict:
 
 
 def verdict(measurement: dict) -> str:
-    """First-match-wins verdict string for a `measure()` result."""
+    """First-match-wins verdict string for a `measure()` result.
+
+    Judged on `speech_dbfs`, never on whole-buffer RMS: a pause is not a quiet
+    microphone, and grading on the average made a normal test with gaps between
+    sentences come back "too quiet" however good the mic was.
+    """
+    level = measurement.get("speech_dbfs", measurement["rms_dbfs"])
     if measurement["clipping_pct"] > 0.1:
         return "Too loud — turn the mic gain down"
-    if measurement["rms_dbfs"] < -40:
+    if level < -45:
         return "Nothing heard — is this the right mic?"
-    if measurement["rms_dbfs"] < -30:
+    if level < -32:
         return "Too quiet — move closer or raise the gain"
     if measurement["snr_db"] < 15:
         return "Noisy — a lot of background for the level of your voice"

--- a/wisprlite/settings.py
+++ b/wisprlite/settings.py
@@ -1083,6 +1083,53 @@ def main(first_run: bool = False) -> None:
                  font=("Segoe UI", 11, "bold")).pack(padx=18, pady=(16, 6))
         result = tk.Label(dialog, text="", bg=BG, fg=MUTED, wraplength=320, justify="left")
         result.pack(padx=18, pady=(0, 12))
+        remedy_row = tk.Frame(dialog, bg=BG)
+        remedy_row.pack()
+
+        def _aim_for(m):
+            """Turn the numbers into the one instruction they imply.
+
+            "Too quiet" on its own is a diagnosis with no treatment - it tells
+            you something is wrong and leaves you holding it. Say how far off
+            it is and in which direction."""
+            rms = m["rms_dbfs"]
+            if rms == float("-inf"):
+                return "Aim for -20 dBFS. Nothing is reaching this device at all."
+            if rms < -30:
+                return f"Aim for -20 dBFS — about {abs(-20 - rms):.0f} dB louder than this."
+            if m["clipping_pct"] > 0.1:
+                return "Aim for -20 dBFS — turn the level down until clipping is 0%."
+            return "Aim for -20 dBFS. This is in range."
+
+        def _open_sound_settings():
+            # Recording tab of the classic Sound panel: the level slider lives
+            # in Properties > Levels, which is the thing that actually fixes it.
+            import subprocess
+            for command in (
+                ["rundll32.exe", "shell32.dll,Control_RunDLL", "mmsys.cpl,,1"],
+                ["cmd", "/c", "start", "", "ms-settings:sound"],
+            ):
+                try:
+                    subprocess.Popen(command)
+                    return
+                except Exception:
+                    continue
+            _show("Could not open Windows sound settings — open Sound > "
+                  "Recording > your mic > Properties > Levels.", WARN)
+
+        def _offer_remedy(verdict_text):
+            def apply():
+                for child in remedy_row.winfo_children():
+                    child.destroy()
+                if verdict_text.startswith("Good"):
+                    return
+                ttk.Button(remedy_row, text="Open Windows sound settings",
+                           command=_open_sound_settings).pack(pady=(0, 8))
+            try:
+                if remedy_row.winfo_exists():
+                    remedy_row.after(0, apply)
+            except Exception:
+                pass
 
         def _selected_device():
             value = dict((lbl, val) for lbl, val in devices).get(device_var.get(), "")
@@ -1134,9 +1181,11 @@ def main(first_run: bool = False) -> None:
                 fg = GOOD if v == "Good" else (ACCENT if "loud" in v or "Nothing" in v else WARN)
                 _show(
                     f"{v}\npeak {m['peak_dbfs']:.1f} dBFS · rms {m['rms_dbfs']:.1f} dBFS · "
-                    f"snr {m['snr_db']:.1f} dB · clipping {m['clipping_pct']:.2f}%",
+                    f"snr {m['snr_db']:.1f} dB · clipping {m['clipping_pct']:.2f}%\n"
+                    f"{_aim_for(m)}",
                     fg,
                 )
+                _offer_remedy(v)
             except Exception as exc:
                 _show(f"Microphone unavailable: {exc}", ACCENT)
 
@@ -1145,17 +1194,31 @@ def main(first_run: bool = False) -> None:
             try:
                 grouped = mics.group_inputs(mics.list_inputs())
                 scored = []
+                skipped = []
                 heard_any = False
                 for g in grouped:
-                    samples, rate = _record_seconds(g["index"], 1.5)
+                    # PER DEVICE. Windows always enumerates endpoints that will
+                    # not open - in use by another app, disconnected, or simply
+                    # refusing mono float32. One try around the whole loop meant
+                    # the first such device killed the run with "Test failed"
+                    # and every mic after it went untested.
+                    try:
+                        samples, rate = _record_seconds(g["index"], 1.5)
+                    except Exception as exc:
+                        skipped.append(f"{g['name']} ({exc.__class__.__name__})")
+                        continue
                     m = mics.measure(samples, rate)
                     if m["rms_dbfs"] >= -40:
                         heard_any = True
                     in_band = -30 <= m["rms_dbfs"] <= -6
                     scored.append((g, m, in_band))
+                note = f"\nSkipped {len(skipped)}: {', '.join(skipped)}" if skipped else ""
+                if not scored:
+                    _show("No microphone could be opened." + note, ACCENT)
+                    return
                 if not heard_any:
                     _show("Nothing heard on any device — inconclusive, "
-                          "keep talking and try again.", WARN)
+                          "keep talking and try again." + note, WARN)
                     return
                 best_g, best_m, _ = max(scored, key=lambda t: (t[2], t[1]["snr_db"]))
                 best_label = next(
@@ -1163,7 +1226,8 @@ def main(first_run: bool = False) -> None:
                 )
                 if best_label:
                     device_var.set(best_label)
-                _show(f"Picked {best_g['name']} — {mics.verdict(best_m)}", GOOD)
+                _show(f"Picked {best_g['name']} — {mics.verdict(best_m)}" + note, GOOD)
+                _offer_remedy(mics.verdict(best_m))
             except Exception as exc:
                 _show(f"Test failed: {exc}", ACCENT)
 


### PR DESCRIPTION
James on v2.41.0: *"it kept on saying that it was too quiet. I didn't adjust anything in order to increase the mic sound… And the second one was me testing all of the mics, and it came up with an error."*

### 1. "Too quiet" was a false positive — and my spec caused it
`verdict()` graded on whole-buffer RMS, which averages in **every pause between words**. Talk for a fifth of a 3-second window and the reading lands ~7 dB below your actual speaking level, so the grade depended mostly on how much you paused rather than on the microphone.

`measure()` now reports `speech_dbfs` — the mean of the loudest quarter of 20 ms frames — and `verdict()` judges on that. Thresholds moved with it: -45 / -32 on speech level, replacing -40 / -30 on the average.

### 2. "Test all" died on the first device that wouldn't open
One `try` wrapped the whole loop. Windows always enumerates endpoints that refuse to open — in use by another app, disconnected, or rejecting mono float32 — so the first such device aborted the run with `Test failed: …` and every mic after it went untested. Now per-device: a device that won't open is skipped and named, the run continues, and "no device could be opened" is distinguished from "nothing heard".

### 3. A verdict that names a problem now offers the fix
"Too quiet" alone is a diagnosis with no treatment. The dialog now says how far off you are and in which direction — *"Aim for -20 dBFS — about 12 dB louder than this"* — and shows an **Open Windows sound settings** button that goes to the Recording tab, where the level slider actually lives.

### Verification
The pause test is deliberately built so the two grading methods **disagree** on the fixture (whole-buffer RMS -35.8, speech level -28.0). My first attempt at it did not discriminate — reverting the fix left it green — so it was rebuilt until sabotage turns it red, which it now does. A genuinely quiet mic is still called out by a separate test, so the fix cannot have made the verdict useless.

Suite 355 passed, same 15 pre-existing failures `main` already has.

**Still unverified here:** no audio device, no Windows. Whether the false positive is actually gone on James's mic is his check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WStiFEE9AHoF4esPCaKiYD