### PR TITLE
feat: land on About after an update, and show recording buttons before transcription

### DIFF
--- a/tests/test_overlay.py
+++ b/tests/test_overlay.py
@@ -310,3 +310,28 @@ def test_the_pill_actually_uses_the_drag_binding():
         "a raw <Button-1> binding on the pill toggles the meeting on the press "
         "that starts a drag"
     )
+
+
+def test_a_fourth_done_button_still_fits_inside_the_pill():
+    """The width was a fixed 108px. A fourth button measured 456px inside a
+    380px pill, so two would have been drawn off the edge — and the hit test
+    would still have claimed they were there."""
+    from wisprlite.overlay import Overlay, WIN_W
+
+    ov = Overlay.__new__(Overlay)   # geometry reads class attributes only
+    boxes = [ov._done_button_box(i) for i in range(len(Overlay.SCREENREC_DONE))]
+    assert boxes[0][0] >= 0, f"the first button starts off the left edge: {boxes[0]}"
+    assert boxes[-1][2] <= WIN_W, f"the last button runs off the right edge: {boxes[-1]}"
+    for left, right in zip(boxes, boxes[1:]):
+        assert left[2] <= right[0], "the buttons overlap"
+
+
+def test_every_done_button_is_reachable_by_a_click():
+    """A button drawn but not hit-testable is worse than no button."""
+    from wisprlite.overlay import Overlay
+
+    ov = Overlay.__new__(Overlay)
+    for index, (action, _label) in enumerate(Overlay.SCREENREC_DONE):
+        x1, y1, x2, y2 = ov._done_button_box(index)
+        hit = ov._screenrec_hit((x1 + x2) // 2, (y1 + y2) // 2, "done")
+        assert hit == action, f"clicking the {action!r} button returned {hit!r}"

--- a/tests/test_ui_smoke.py
+++ b/tests/test_ui_smoke.py
@@ -1001,23 +1001,119 @@ def test_a_failed_send_does_not_strand_the_pill_on_a_progress_bar():
     app._screenrec = recording
     app._transcribe_recording = mock.Mock(return_value=None)
 
+    recording.transcript_path = pathlib.Path("/out/clip.txt")
+    app.cfg.screenrec_destination = "user@host:/inbox"
+    app.cfg.screenrec_keep_local = True
+
     with mock.patch.object(App, "_ask_name_in_pill", return_value=""), \
-         mock.patch.object(screenrec, "send", return_value=(False, "connection refused")):
+         mock.patch.object(screenrec, "send", return_value=(False, "connection refused")), \
+         mock.patch("wisprlite.app.copy_clipboard"):
         App._finish_screen_recording(app)
+        _join_screenrec_threads()
 
-    assert app._screenrec_ui.snapshot()["phase"] == "recording", \
-        "a failed send left the pill mid-flight"
-    assert app.overlay.hide.called, "the pill must be put away, not left up"
-    assert app._fail.called, "and the failure must still be reported"
+    # The clip is muxed and on disk BEFORE the send is attempted, so a failed
+    # send must not take the buttons away with it - the user still wants to
+    # play it, open it, and press Send again. What must never happen is the
+    # pill left on a sweeping progress bar, which is what this test is for.
+    snap = app._screenrec_ui.snapshot()
+    assert snap["phase"] == "done", "a failed send left the pill mid-flight"
+    assert "connection refused" in (snap.get("subtitle") or ""), \
+        "a failed send must say so, not look like success"
+    assert "not sent" in (snap.get("title") or "").lower(), \
+        f"the title must not claim it was sent: {snap.get('title')!r}"
 
-    # An exception anywhere in the flow must land the same way.
+    # An exception anywhere in the background half must land the same way, and
+    # must never leave the pill on the progress bar either.
     app2 = _agent_app()
     app2._screenrec_agent = None
     app2._screenrec = recording
+    app2.cfg.screenrec_destination = ""
     app2._transcribe_recording = mock.Mock(side_effect=RuntimeError("boom"))
-    with mock.patch.object(App, "_ask_name_in_pill", return_value=""):
+    with mock.patch.object(App, "_ask_name_in_pill", return_value=""), \
+         mock.patch("wisprlite.app.copy_clipboard"):
         App._finish_screen_recording(app2)
-    assert app2._screenrec_ui.snapshot()["phase"] == "recording"
+        _join_screenrec_threads()
+    assert app2._screenrec_ui.snapshot()["phase"] == "done"
+    assert "failed" in (app2._screenrec_ui.snapshot().get("subtitle") or "").lower()
+
+
+def _join_screenrec_threads(timeout=5.0):
+    """The delivery half runs on its own thread now, so a test that asserts on
+    the outcome has to wait for it rather than racing it."""
+    import threading
+    for t in threading.enumerate():
+        if t.name in ("screenrec-deliver", "screenrec-send"):
+            t.join(timeout)
+
+
+def test_the_buttons_appear_before_the_transcription_not_after():
+    """James, 2026-09-04: "it's stuck on transcribing what I just said. Then I
+    have to wait for ages." Whisper over a two-minute clip ran BEFORE the pill
+    ever reached "done", so no button existed until it finished."""
+    import threading
+    from unittest import mock
+    from wisprlite.app import App
+    from wisprlite import screenrec
+
+    app = _agent_app()
+    app._screenrec_agent = None
+    app.cfg.screenrec_destination = ""
+    recording = mock.Mock()
+    recording.errors = []
+    recording.stem = "2026-09-04 19-02-11"
+    recording.stop.return_value = pathlib.Path("/out/clip.mp4")
+    recording.audio_path = pathlib.Path("/out/clip.wav")
+    recording.transcript_path = pathlib.Path("/out/clip.txt")
+    app._screenrec = recording
+
+    phase_when_transcription_started = {}
+    started = threading.Event()
+
+    def slow_transcribe(_rec):
+        phase_when_transcription_started["phase"] = app._screenrec_ui.snapshot()["phase"]
+        started.set()
+        return None
+
+    app._transcribe_recording = slow_transcribe
+    with mock.patch.object(App, "_ask_name_in_pill", return_value=""), \
+         mock.patch("wisprlite.app.copy_clipboard"):
+        App._finish_screen_recording(app)
+        assert started.wait(5), "the transcription never ran"
+        _join_screenrec_threads()
+
+    assert phase_when_transcription_started["phase"] == "done", (
+        "the pill was still on the progress bar when transcription began — "
+        "the buttons must be up first"
+    )
+
+
+def test_an_agent_still_waits_for_the_transcript():
+    import threading
+    """An agent is BLOCKED on the text; handing it a clip with an empty
+    transcript because we went async would break the thing it asked for."""
+    from unittest import mock
+    from wisprlite.app import App
+
+    app = _agent_app()
+    waiter = threading.Event()
+    app._screenrec_agent = waiter
+    app.cfg.screenrec_destination = ""
+    recording = mock.Mock()
+    recording.errors = []
+    recording.stem = "2026-09-04 19-02-11"
+    recording.stop.return_value = pathlib.Path("/out/clip.mp4")
+    recording.audio_path = pathlib.Path("/out/clip.wav")
+    recording.transcript_path = pathlib.Path("/out/clip.txt")
+    app._screenrec = recording
+    app._transcribe_recording = mock.Mock(return_value=pathlib.Path("/out/clip.txt"))
+    app._read_text = mock.Mock(return_value="what I said")
+
+    with mock.patch("wisprlite.app.copy_clipboard"):
+        App._finish_screen_recording(app)
+
+    assert waiter.is_set(), "the agent was never released"
+    assert app._screenrec_agent_result["transcript"] == "what I said", \
+        "the agent must still get the transcript, not an empty one"
 
 
 def test_a_failed_paste_still_leaves_the_words_in_history_and_on_the_clipboard():

--- a/tests/test_ui_smoke.py
+++ b/tests/test_ui_smoke.py
@@ -971,9 +971,16 @@ def test_the_finished_pill_never_announces_the_scp_destination():
     app._screenrec = recording
     app._transcribe_recording = mock.Mock(return_value=None)
 
+    recording.transcript_path = pathlib.Path("/out/2026-08-12 17-32-18.txt")
+    app.cfg.screenrec_keep_local = True
+
     with mock.patch.object(App, "_ask_name_in_pill", return_value=""), \
+         mock.patch("wisprlite.app.copy_clipboard"), \
          mock.patch.object(screenrec, "send", return_value=(True, "ok")):
         App._finish_screen_recording(app)
+        # Sending happens behind the pill now, so the closing message is
+        # written by that thread rather than before this call returns.
+        _join_screenrec_threads()
 
     state = app._screenrec_ui.snapshot()
     assert state["phase"] == "done"
@@ -1428,3 +1435,138 @@ def test_one_thread_s_failure_does_not_overwrite_another_s():
     t.join()
 
     assert last_error() == "the dictation's reason"
+
+
+def test_the_send_button_ships_the_real_transcript_not_a_guessed_path():
+    """It derived the transcript as video.with_suffix(".txt"), which is only
+    right while the transcript sits beside the clip under the same stem. Get it
+    wrong and the video ships alone while the pill says the transcript went."""
+    import threading
+    from unittest import mock
+    from wisprlite.app import App
+    from wisprlite import screenrec
+
+    app = _agent_app()
+    app.cfg.screenrec_destination = "user@host:/inbox"
+    app._sending_recording = False
+    app._finished_recording = pathlib.Path("/out/clip.mp4")
+    app._finished_transcript = pathlib.Path("/notes/spoken-2026-09-04.txt")
+
+    sent = {}
+    with mock.patch.object(pathlib.Path, "exists", return_value=True), \
+         mock.patch.object(screenrec, "send",
+                           side_effect=lambda files, dest: (sent.update(files=list(files)), (True, ""))[1]):
+        App._send_finished_recording(app)
+        for t in threading.enumerate():
+            if t.name == "screenrec-send":
+                t.join(5)
+
+    assert pathlib.Path("/notes/spoken-2026-09-04.txt") in sent["files"], \
+        f"the real transcript was not sent: {sent.get('files')}"
+
+
+def test_a_second_send_click_does_not_start_a_second_upload():
+    """Two rapid clicks started two threads racing to write the same status."""
+    from unittest import mock
+    from wisprlite.app import App
+
+    app = _agent_app()
+    app.cfg.screenrec_destination = "user@host:/inbox"
+    app._finished_recording = pathlib.Path("/out/clip.mp4")
+    app._finished_transcript = None
+    app._sending_recording = True          # one is already in flight
+
+    # exists() must be True: otherwise the early "nothing to send" return makes
+    # this pass whether the guard is there or not, which is exactly how the
+    # first version of this test survived having the guard deleted.
+    with mock.patch.object(pathlib.Path, "exists", return_value=True), \
+         mock.patch("wisprlite.app.threading.Thread") as thread:
+        App._send_finished_recording(app)
+    thread.assert_not_called()
+
+    # Positive control: with nothing in flight it MUST send, or the test above
+    # would pass for a function that never sends at all.
+    app._sending_recording = False
+    with mock.patch.object(pathlib.Path, "exists", return_value=True), \
+         mock.patch("wisprlite.app.threading.Thread") as thread:
+        App._send_finished_recording(app)
+    thread.assert_called_once()
+
+
+def test_a_recording_with_no_transcript_still_deletes_the_rest(tmp_path):
+    """Path(None) raises TypeError, which `except OSError` does not catch — so
+    a missing transcript aborted the delete loop partway and left the audio
+    file behind. Uses REAL files: mocking unlink cannot show what survived."""
+    import threading
+    from unittest import mock
+    from wisprlite.app import App
+    from wisprlite import screenrec
+
+    video = tmp_path / "clip.mp4"
+    audio = tmp_path / "clip.wav"
+    video.write_bytes(b"mp4")
+    audio.write_bytes(b"wav")
+
+    app = _agent_app()
+    app._screenrec_agent = None
+    app.cfg.screenrec_destination = "user@host:/inbox"
+    app.cfg.screenrec_keep_local = False
+    recording = mock.Mock()
+    recording.stem = "clip"
+    recording.transcript_path = None       # never produced one
+    recording.audio_path = audio
+    app._transcribe_recording = mock.Mock(return_value=None)
+
+    with mock.patch.object(screenrec, "send", return_value=(True, "")), \
+         mock.patch("wisprlite.app.copy_clipboard"):
+        App._hand_over_then_transcribe(app, recording, video)
+        for t in threading.enumerate():
+            if t.name == "screenrec-deliver":
+                t.join(5)
+
+    assert not video.exists(), "the video was not cleaned up"
+    assert not audio.exists(), \
+        "the delete loop aborted on the missing transcript and left the audio"
+    snap = app._screenrec_ui.snapshot()
+    assert "failed" not in (snap.get("subtitle") or "").lower(), \
+        f"a missing transcript was reported as a failure: {snap}"
+
+
+def test_a_transcript_that_failed_to_upload_is_not_called_sent():
+    """The video went, the transcript did not. Saying "Recording saved and
+    sent" beside "transcript not sent" is two answers to one question, and the
+    reassuring one is on top."""
+    import threading
+    from unittest import mock
+    from wisprlite.app import App
+    from wisprlite import screenrec
+
+    app = _agent_app()
+    app._screenrec_agent = None
+    app.cfg.screenrec_destination = "user@host:/inbox"
+    app.cfg.screenrec_keep_local = True
+    recording = mock.Mock()
+    recording.stem = "clip"
+    recording.transcript_path = pathlib.Path("/out/clip.txt")
+    recording.audio_path = pathlib.Path("/out/clip.wav")
+    app._transcribe_recording = mock.Mock(return_value=pathlib.Path("/out/clip.txt"))
+
+    calls = {"n": 0}
+
+    def send(files, dest):
+        calls["n"] += 1
+        return (True, "") if calls["n"] == 1 else (False, "disk full")
+
+    with mock.patch.object(screenrec, "send", side_effect=send), \
+         mock.patch("wisprlite.app.copy_clipboard"), \
+         mock.patch.object(pathlib.Path, "exists", return_value=True):
+        App._hand_over_then_transcribe(app, recording, pathlib.Path("/out/clip.mp4"))
+        for t in threading.enumerate():
+            if t.name == "screenrec-deliver":
+                t.join(5)
+
+    snap = app._screenrec_ui.snapshot()
+    assert "sent" not in (snap.get("title") or "").lower(), \
+        f"the title claims it was sent while the transcript failed: {snap}"
+    assert "disk full" in (snap.get("subtitle") or ""), \
+        f"the reason must survive to the pill: {snap}"

--- a/tests/test_update_lands_on_about.py
+++ b/tests/test_update_lands_on_about.py
@@ -1,0 +1,90 @@
+"""After an update the app must SHOW what changed, not just change.
+
+James, 2026-09-04: "I clicked update, and they opened in the minimised toolbar
+thing, but it didn't open fully. When updating, it should probably update the
+full thing and then land on the about page, so I can see what's just been
+updated."
+
+The installer relaunches with /RESTARTAPPLICATIONS, which restores the app
+exactly as it was — a tray icon and nothing else — so an update the user asked
+for completed with no visible sign it had happened.
+"""
+
+import json
+import pathlib
+import sys
+import time
+from unittest import mock
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent))
+
+from wisprlite import updater
+
+
+def _redirect(tmp_path):
+    return mock.patch.object(updater.config, "config_dir", return_value=tmp_path)
+
+
+def test_the_first_start_after_our_own_update_reports_it_once(tmp_path):
+    with _redirect(tmp_path):
+        updater.mark_pending("2.41.0")
+        assert updater.take_pending("2.41.1") is True
+        # Once. A marker that survived would open About on every start.
+        assert updater.take_pending("2.41.1") is False
+
+
+def test_a_failed_install_does_not_claim_an_update_happened(tmp_path):
+    """The installer ran but the version did not move — nothing was updated,
+    and the marker must still be cleared rather than firing forever."""
+    with _redirect(tmp_path):
+        updater.mark_pending("2.41.1")
+        assert updater.take_pending("2.41.1") is False
+        assert not (tmp_path / "update" / updater.PENDING).exists(), \
+            "a failed update left its marker behind"
+
+
+def test_a_hand_reinstall_is_not_treated_as_our_update(tmp_path):
+    """No marker means we did not do it. A tray app that starts at boot must
+    not open a window because someone reinstalled or restored a backup."""
+    with _redirect(tmp_path):
+        assert updater.take_pending("2.41.1") is False
+
+
+def test_a_stale_marker_does_not_ambush_the_user_days_later(tmp_path):
+    with _redirect(tmp_path):
+        updater.mark_pending("2.40.0")
+        path = tmp_path / "update" / updater.PENDING
+        data = json.loads(path.read_text(encoding="utf-8"))
+        data["at"] = time.time() - (updater.PENDING_MAX_AGE + 60)
+        path.write_text(json.dumps(data), encoding="utf-8")
+
+        assert updater.take_pending("2.41.1") is False
+
+
+def test_a_corrupt_marker_is_swallowed_not_raised(tmp_path):
+    """This runs during startup. It must never be able to stop the app."""
+    with _redirect(tmp_path):
+        path = tmp_path / "update" / updater.PENDING
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("{not json", encoding="utf-8")
+
+        assert updater.take_pending("2.41.1") is False
+        assert not path.exists()
+
+
+def test_download_and_run_marks_the_update_before_handing_over():
+    """The marker has to be written BEFORE the installer starts: it force-closes
+    this process, so anything written afterwards never runs."""
+    order = []
+    info = {"url": "https://example.test/Setup.exe", "sha256": ""}
+
+    with mock.patch.object(updater, "mark_pending", side_effect=lambda v: order.append("mark")), \
+         mock.patch.object(updater.subprocess, "Popen", side_effect=lambda *a, **k: order.append("spawn")), \
+         mock.patch.object(updater.urllib.request, "urlopen") as urlopen, \
+         mock.patch("builtins.open", mock.mock_open()), \
+         mock.patch.object(updater.config, "config_dir", return_value=pathlib.Path("/tmp")):
+        urlopen.return_value.__enter__.return_value.read.side_effect = [b"data", b""]
+        updater.download_and_run(info)
+
+    assert order == ["mark", "spawn"], \
+        f"the marker must be written before the installer is spawned, got {order}"

--- a/tests/test_update_lands_on_about.py
+++ b/tests/test_update_lands_on_about.py
@@ -88,3 +88,39 @@ def test_download_and_run_marks_the_update_before_handing_over():
 
     assert order == ["mark", "spawn"], \
         f"the marker must be written before the installer is spawned, got {order}"
+
+
+def test_a_marker_that_cannot_be_deleted_is_emptied_not_trusted(tmp_path):
+    """If unlink fails and the marker survives, claiming "we updated" turns a
+    one-shot window into a pop-up on every boot that nobody can switch off."""
+    with _redirect(tmp_path):
+        updater.mark_pending("2.41.0")
+        path = tmp_path / "update" / updater.PENDING
+
+        with mock.patch.object(pathlib.Path, "unlink", side_effect=PermissionError("held")):
+            first = updater.take_pending("2.41.1")
+
+        assert first is True, "an emptied marker still counts as consumed once"
+        assert path.read_text(encoding="utf-8") == "", "the marker must be neutered"
+        assert updater.take_pending("2.41.1") is False, "it must never fire twice"
+
+
+def test_an_unclearable_marker_stays_silent(tmp_path):
+    """Neither delete nor write works — read-only folder. Say nothing rather
+    than open About on every start for ever."""
+    with _redirect(tmp_path):
+        updater.mark_pending("2.41.0")
+        with mock.patch.object(pathlib.Path, "unlink", side_effect=PermissionError("held")), \
+             mock.patch.object(pathlib.Path, "write_text", side_effect=PermissionError("ro")):
+            assert updater.take_pending("2.41.1") is False
+
+
+def test_a_non_string_from_field_is_not_a_version(tmp_path):
+    """`1 != "2.41.1"` is True, so an unvalidated field fires About on a marker
+    that means nothing."""
+    with _redirect(tmp_path):
+        path = tmp_path / "update" / updater.PENDING
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps({"from": 1, "at": time.time()}), encoding="utf-8")
+
+        assert updater.take_pending("2.41.1") is False

--- a/wisprlite/__init__.py
+++ b/wisprlite/__init__.py
@@ -1,3 +1,3 @@
 """Pipevoice — push-to-talk voice typing for Windows."""
 
-__version__ = "2.41.2"
+__version__ = "2.42.0"

--- a/wisprlite/__init__.py
+++ b/wisprlite/__init__.py
@@ -1,3 +1,3 @@
 """Pipevoice — push-to-talk voice typing for Windows."""
 
-__version__ = "2.41.1"
+__version__ = "2.41.2"

--- a/wisprlite/app.py
+++ b/wisprlite/app.py
@@ -1500,8 +1500,23 @@ class App:
             pass
         # If the version changed since last run, we were just updated -> tell the user.
         from . import __version__ as _ver
-        if self.cfg.last_version and self.cfg.last_version != _ver:
-            self._notify(f"Updated to Pipevoice {_ver}. Tray menu, About, to see what's new.")
+        # Did WE just install this? The installer relaunches with
+        # /RESTARTAPPLICATIONS, which brings the app back the way it was - a
+        # tray icon, nothing open - so an update the user asked for finished
+        # with no window and no way to see what changed. Land on About instead.
+        # Gated on the marker, not on the version alone: a hand reinstall or a
+        # restored backup also changes the version, and a tray app that starts
+        # at boot must not open a window uninvited.
+        try:
+            from . import updater as _upd
+            if _upd.take_pending(_ver):
+                self.open_settings(tab="About")
+            elif self.cfg.last_version and self.cfg.last_version != _ver:
+                self._notify(f"Updated to Pipevoice {_ver}. Tray menu, About, to see what's new.")
+        except Exception:
+            log.exception("post-update About failed")
+            if self.cfg.last_version and self.cfg.last_version != _ver:
+                self._notify(f"Updated to Pipevoice {_ver}. Tray menu, About, to see what's new.")
         if self.cfg.last_version != _ver:
             self.cfg.last_version = _ver
             try:

--- a/wisprlite/app.py
+++ b/wisprlite/app.py
@@ -614,6 +614,9 @@ class App:
         if action in ("save", "skip"):
             self._screenrec_ui.answer_name(value if action == "save" else "")
             return
+        if action == "send":
+            self._send_finished_recording()
+            return
         if action in ("play", "copy", "open"):
             self._screenrec_done_action(action)
             return
@@ -733,6 +736,15 @@ class App:
             if typed:
                 recording.rename(screenrec.stamped_stem(recording.stem, typed))
                 video = recording.video_path
+            # An agent is BLOCKED on the transcript, so that one path still
+            # waits for it. A person is not: they recorded a clip and want to
+            # watch or send it, and Whisper over a two-minute video kept them
+            # staring at "Writing down what you said..." before a single button
+            # appeared. For them the buttons come first and the text follows.
+            if self._screenrec_agent is None:
+                self._hand_over_then_transcribe(recording, video)
+                return
+
             files = [video]
             self._screenrec_ui.update(phase="working", status="Writing down what you said\u2026")
             transcript = self._transcribe_recording(recording)
@@ -812,6 +824,113 @@ class App:
                     "error": "; ".join(recording.errors[:2]) or "the recording produced no file",
                 }
                 waiter.set()
+
+    def _hand_over_then_transcribe(self, recording, video) -> None:
+        """Show the finished clip NOW; transcribe and deliver behind it.
+
+        Everything here is best-effort and must never take the clip down with
+        it: the file is already muxed and on disk by the time this runs.
+        """
+        self._finished_recording = video
+        try:
+            copy_clipboard(str(video))
+        except Exception as exc:
+            log.info("screenrec: could not copy the path: %s", exc)
+
+        destination = (self.cfg.screenrec_destination or "").strip()
+        self._screenrec_ui.update(
+            phase="done",
+            title="Recording saved",
+            subtitle=(recording.stem + " · transcribing…").strip(),
+        )
+
+        def work():
+            from . import screenrec
+
+            note = ""
+            # The finally below writes the closing message. Without this it also
+            # overwrote the send-failure one with "Recording saved and sent" -
+            # a failed upload reported as a success, which is the single worst
+            # thing this flow can say.
+            reported = False
+            try:
+                # The video goes FIRST and on its own. Waiting for Whisper before
+                # sending anything is what made the whole finish feel slow, and
+                # the clip is the part that is actually wanted at the far end.
+                if destination:
+                    ok, message = screenrec.send([video], destination)
+                    if not ok:
+                        # Never delete on failure, and never claim it arrived.
+                        reported = True
+                        self._screenrec_ui.update(
+                            phase="done", title="Recording saved (not sent)",
+                            subtitle=f"{recording.stem} · send failed: {message}"[:120])
+                        return
+
+                transcript = self._transcribe_recording(recording)
+                note = "" if transcript is not None else " · no transcript (check the mic)"
+                if transcript is not None and destination:
+                    ok, message = screenrec.send([transcript], destination)
+                    if not ok:
+                        note = f" · transcript not sent: {message}"
+
+                # Deleting is LAST, and only once everything that was going to
+                # be sent has been. The Play and Open buttons on the pill point
+                # at this file, so removing it earlier would leave the user
+                # pressing buttons that open nothing.
+                if destination and not self.cfg.screenrec_keep_local and not note:
+                    for path in [video, recording.transcript_path, recording.audio_path]:
+                        try:
+                            Path(path).unlink()
+                        except OSError:
+                            pass
+                    self._finished_recording = None
+            except Exception:
+                log.exception("screenrec: background finish failed")
+                note = " · finishing failed, the clip is safe on disk"
+            finally:
+                if not reported and self._screenrec_ui.snapshot().get("phase") == "done":
+                    self._screenrec_ui.update(
+                        phase="done",
+                        title="Recording saved" + (" and sent" if destination else ""),
+                        subtitle=(recording.stem + note).strip()[:120],
+                    )
+
+        threading.Thread(target=work, name="screenrec-deliver", daemon=True).start()
+
+    def _send_finished_recording(self) -> None:
+        """The Send button. Re-sends on demand, and is the only route when no
+        destination is configured — in which case say that, rather than
+        silently doing nothing."""
+        from . import screenrec
+
+        video = self._finished_recording
+        destination = (self.cfg.screenrec_destination or "").strip()
+        if video is None or not Path(video).exists():
+            self._screenrec_ui.update(phase="done", title="Nothing to send",
+                                      subtitle="the clip is no longer on disk")
+            return
+        if not destination:
+            self._screenrec_ui.update(
+                phase="done", title="No destination set",
+                subtitle="Settings › Recordings › where to send clips")
+            return
+
+        def work():
+            files = [Path(video)]
+            transcript = Path(video).with_suffix(".txt")
+            if transcript.exists():
+                files.append(transcript)
+            ok, message = screenrec.send(files, destination)
+            self._screenrec_ui.update(
+                phase="done",
+                title="Sent" if ok else "Send failed",
+                subtitle=(Path(video).stem if ok else message)[:120],
+            )
+
+        self._screenrec_ui.update(phase="done", title="Sending\u2026",
+                                  subtitle=Path(video).stem)
+        threading.Thread(target=work, name="screenrec-send", daemon=True).start()
 
     def _handoff_recording(self, video, stem: str) -> None:
         """Clipboard, then the Recordings tab open on this clip.

--- a/wisprlite/app.py
+++ b/wisprlite/app.py
@@ -160,6 +160,8 @@ class App:
         self._session = None
         self._clipboard_only = False
         self._polish_error: str | None = None
+        self._finished_transcript = None
+        self._sending_recording = False
         self._active = {}             # per-utterance profile overrides (never mutates cfg)
         self._fg_ctx = {}             # foreground window captured at hotkey-press time
         self._started_at = 0.0
@@ -832,6 +834,11 @@ class App:
         it: the file is already muxed and on disk by the time this runs.
         """
         self._finished_recording = video
+        # The REAL path, not video.with_suffix(".txt"). Guessing it happens to
+        # work only while the transcript sits beside the clip under the same
+        # stem, and the Send button would otherwise ship the video alone while
+        # saying the transcript went with it.
+        self._finished_transcript = None
         try:
             copy_clipboard(str(video))
         except Exception as exc:
@@ -848,6 +855,11 @@ class App:
             from . import screenrec
 
             note = ""
+            # Whether everything that was going to be sent actually went. A
+            # MISSING transcript is not a send failure - the video still
+            # arrived, and the title must say so - but a transcript that failed
+            # to upload is, and then "and sent" would be a lie.
+            sent_all = bool(destination)
             # The finally below writes the closing message. Without this it also
             # overwrote the send-failure one with "Recording saved and sent" -
             # a failed upload reported as a success, which is the single worst
@@ -869,32 +881,57 @@ class App:
 
                 transcript = self._transcribe_recording(recording)
                 note = "" if transcript is not None else " · no transcript (check the mic)"
+                if transcript is not None and not Path(transcript).exists():
+                    # Returned a path to a file that is not there. Say the
+                    # friendly thing rather than letting scp fail on it.
+                    transcript, note = None, " · no transcript (check the mic)"
+                self._finished_transcript = transcript
                 if transcript is not None and destination:
                     ok, message = screenrec.send([transcript], destination)
                     if not ok:
+                        sent_all = False
                         note = f" · transcript not sent: {message}"
 
                 # Deleting is LAST, and only once everything that was going to
                 # be sent has been. The Play and Open buttons on the pill point
                 # at this file, so removing it earlier would leave the user
                 # pressing buttons that open nothing.
-                if destination and not self.cfg.screenrec_keep_local and not note:
+                # Gated on the SEND, not on the note. "no transcript" is a
+                # note but not a delivery failure - the video did arrive - and
+                # keying the cleanup off any note at all meant a clip with no
+                # narration was never tidied up, however keep_local was set.
+                if sent_all and not self.cfg.screenrec_keep_local:
                     for path in [video, recording.transcript_path, recording.audio_path]:
+                        if path is None:
+                            continue     # a recording that produced no transcript
                         try:
                             Path(path).unlink()
-                        except OSError:
-                            pass
+                        except (OSError, TypeError, ValueError):
+                            pass         # TypeError is not an OSError, and it
+                                         # used to abort the whole loop
                     self._finished_recording = None
+                    self._finished_transcript = None
             except Exception:
                 log.exception("screenrec: background finish failed")
                 note = " · finishing failed, the clip is safe on disk"
             finally:
-                if not reported and self._screenrec_ui.snapshot().get("phase") == "done":
-                    self._screenrec_ui.update(
-                        phase="done",
-                        title="Recording saved" + (" and sent" if destination else ""),
-                        subtitle=(recording.stem + note).strip()[:120],
-                    )
+                try:
+                    if not reported and self._screenrec_ui.snapshot().get("phase") == "done":
+                        # "and sent" only when everything that was going to be
+                        # sent actually was. Saying it beside "finishing failed"
+                        # is two answers to one question.
+                        self._screenrec_ui.update(
+                            phase="done",
+                            title="Recording saved" + (" and sent" if sent_all else ""),
+                            subtitle=" · ".join(
+                                part for part in (recording.stem, note.lstrip(" ·").strip())
+                                if part
+                            )[:120],
+                        )
+                except Exception:
+                    # The window can be gone by now (quit mid-transcribe). This
+                    # is a daemon thread, so an escape here dies unseen.
+                    log.exception("screenrec: could not write the closing message")
 
         threading.Thread(target=work, name="screenrec-deliver", daemon=True).start()
 
@@ -906,6 +943,9 @@ class App:
 
         video = self._finished_recording
         destination = (self.cfg.screenrec_destination or "").strip()
+        if self._sending_recording:
+            return                    # a second click is impatience, not a
+                                      # request for a second parallel upload
         if video is None or not Path(video).exists():
             self._screenrec_ui.update(phase="done", title="Nothing to send",
                                       subtitle="the clip is no longer on disk")
@@ -917,17 +957,25 @@ class App:
             return
 
         def work():
-            files = [Path(video)]
-            transcript = Path(video).with_suffix(".txt")
-            if transcript.exists():
-                files.append(transcript)
-            ok, message = screenrec.send(files, destination)
-            self._screenrec_ui.update(
-                phase="done",
-                title="Sent" if ok else "Send failed",
-                subtitle=(Path(video).stem if ok else message)[:120],
-            )
+            try:
+                files = [Path(video)]
+                transcript = self._finished_transcript
+                if transcript is not None and Path(transcript).exists():
+                    files.append(Path(transcript))
+                ok, message = screenrec.send(files, destination)
+                self._screenrec_ui.update(
+                    phase="done",
+                    title="Sent" if ok else "Send failed",
+                    subtitle=(Path(video).stem if ok else message)[:120],
+                )
+            except Exception as exc:
+                log.exception("screenrec: send failed")
+                self._screenrec_ui.update(phase="done", title="Send failed",
+                                          subtitle=str(exc)[:120])
+            finally:
+                self._sending_recording = False
 
+        self._sending_recording = True
         self._screenrec_ui.update(phase="done", title="Sending\u2026",
                                   subtitle=Path(video).stem)
         threading.Thread(target=work, name="screenrec-send", daemon=True).start()

--- a/wisprlite/overlay.py
+++ b/wisprlite/overlay.py
@@ -606,15 +606,14 @@ class Overlay:
     DONE_GAP, DONE_EDGE = 8, 8
     SCREENREC_H = {"recording": WIN_H, "naming": 88, "working": WIN_H, "done": 100}
 
-    @classmethod
-    def _done_button_w(cls):
+    def _done_button_w(self):
         # Derived from the count, never a constant. A fourth button at the old
         # fixed 108px measured 456px inside a 380px pill, so two of them would
         # have been drawn off the edge - and the hit test would still have
         # claimed they were there.
-        count = len(cls.SCREENREC_DONE)
-        gaps = (count - 1) * cls.DONE_GAP
-        return max(48, (WIN_W - 2 * cls.DONE_EDGE - gaps) // count)
+        count = len(self.SCREENREC_DONE)
+        gaps = (count - 1) * self.DONE_GAP
+        return max(48, (WIN_W - 2 * self.DONE_EDGE - gaps) // count)
 
     def _done_button_box(self, index: int):
         width = self._done_button_w()

--- a/wisprlite/overlay.py
+++ b/wisprlite/overlay.py
@@ -600,15 +600,28 @@ class Overlay:
     SCREENREC_BUTTON_R = 15
     # The finished-recording row: three named actions, because glyphs alone do
     # not say "open PipeVoice".
-    SCREENREC_DONE = (("play", "Play"), ("copy", "Copy path"), ("open", "Open"))
-    DONE_BTN_W, DONE_BTN_H, DONE_BTN_Y = 108, 30, 62
+    SCREENREC_DONE = (("play", "Play"), ("send", "Send"),
+                      ("copy", "Copy path"), ("open", "Open"))
+    DONE_BTN_H, DONE_BTN_Y = 30, 62
+    DONE_GAP, DONE_EDGE = 8, 8
     SCREENREC_H = {"recording": WIN_H, "naming": 88, "working": WIN_H, "done": 100}
 
+    @classmethod
+    def _done_button_w(cls):
+        # Derived from the count, never a constant. A fourth button at the old
+        # fixed 108px measured 456px inside a 380px pill, so two of them would
+        # have been drawn off the edge - and the hit test would still have
+        # claimed they were there.
+        count = len(cls.SCREENREC_DONE)
+        gaps = (count - 1) * cls.DONE_GAP
+        return max(48, (WIN_W - 2 * cls.DONE_EDGE - gaps) // count)
+
     def _done_button_box(self, index: int):
-        gap = 8
-        total = len(self.SCREENREC_DONE) * self.DONE_BTN_W + (len(self.SCREENREC_DONE) - 1) * gap
-        x1 = (WIN_W - total) // 2 + index * (self.DONE_BTN_W + gap)
-        return x1, self.DONE_BTN_Y, x1 + self.DONE_BTN_W, self.DONE_BTN_Y + self.DONE_BTN_H
+        width = self._done_button_w()
+        count = len(self.SCREENREC_DONE)
+        total = count * width + (count - 1) * self.DONE_GAP
+        x1 = (WIN_W - total) // 2 + index * (width + self.DONE_GAP)
+        return x1, self.DONE_BTN_Y, x1 + width, self.DONE_BTN_Y + self.DONE_BTN_H
 
     def _screenrec_hit(self, x, y, phase: str = "recording") -> str:
         """Which control a click at (x, y) landed on, or "" for the pill body."""

--- a/wisprlite/updater.py
+++ b/wisprlite/updater.py
@@ -311,16 +311,38 @@ def take_pending(current_version: str) -> bool:
         data = json.loads(path.read_text(encoding="utf-8"))
     except Exception:
         data = {}
-    try:
-        path.unlink()
-    except Exception:
-        pass
+    if not _consume(path):
+        # We could not clear the marker - antivirus holding the file, a
+        # read-only folder. Saying "yes, we updated" now would re-fire on every
+        # single start from here on, turning a one-shot window into a boot
+        # pop-up nobody can switch off. Stay quiet instead.
+        log.warning("could not clear the pending-update marker; skipping the About window")
+        return False
     try:
         if time.time() - float(data.get("at") or 0) > PENDING_MAX_AGE:
             return False
     except Exception:
         return False
-    return bool(data.get("from")) and data["from"] != current_version
+    previous = data.get("from")
+    # Must be a version STRING. A truthy non-string compares unequal to every
+    # version and would fire About on a marker that means nothing.
+    return isinstance(previous, str) and bool(previous) and previous != current_version
+
+
+def _consume(path) -> bool:
+    """Delete the marker, or failing that neuter it. True if it is gone for good."""
+    try:
+        path.unlink()
+        return True
+    except Exception:
+        pass
+    try:
+        # Could not remove it, so empty it: an unreadable marker is treated as
+        # no marker, and this needs only write permission, not delete.
+        path.write_text("", encoding="utf-8")
+        return True
+    except Exception:
+        return False
 
 
 def cleanup_old() -> None:

--- a/wisprlite/updater.py
+++ b/wisprlite/updater.py
@@ -13,6 +13,7 @@ import json
 import logging
 import os
 import subprocess
+import time
 import urllib.request
 
 from . import __version__, config
@@ -244,6 +245,13 @@ def download_and_run(info: dict) -> bool:
             except Exception:
                 pass
             return False
+    # Say that WE are doing this, before handing over. The installer relaunches
+    # us with /RESTARTAPPLICATIONS, which brings the app back exactly as it was
+    # - a tray icon and nothing else - so without this the update finishes with
+    # no visible sign that anything happened.
+    from . import __version__ as _current
+    mark_pending(_current)
+
     # Let the installer (not us) close + replace + relaunch the running exe.
     # FORCECLOSEAPPLICATIONS is essential: the tray app and any open settings
     # window don't answer Windows' Restart Manager (Tk/pystray ignore the close
@@ -261,6 +269,58 @@ def download_and_run(info: dict) -> bool:
     except Exception as exc:
         log.warning("could not launch installer: %s", exc)
         return False
+
+
+PENDING = "pending-update.json"
+# A marker older than this is from an update that never completed. Landing on
+# About days later, out of nowhere, would be worse than saying nothing.
+PENDING_MAX_AGE = 24 * 3600
+
+
+def _pending_path():
+    return config.config_dir() / "update" / PENDING
+
+
+def mark_pending(from_version: str) -> None:
+    """Record that WE are installing an update, so the next start can say so.
+
+    A bare version comparison cannot: it also fires when someone reinstalls by
+    hand or restores a backup, and opening a window uninvited on a tray app
+    that starts at boot is the wrong answer to "did anything change?".
+    """
+    try:
+        path = _pending_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps({"from": from_version, "at": time.time()}),
+                        encoding="utf-8")
+    except Exception:
+        log.warning("could not record the pending update", exc_info=True)
+
+
+def take_pending(current_version: str) -> bool:
+    """True exactly once, on the first start after an update we performed.
+
+    Always clears the marker, including when the install failed and the version
+    did not move — a marker that survives its own failure would open About on
+    every start from then on.
+    """
+    path = _pending_path()
+    try:
+        if not path.exists():
+            return False
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        data = {}
+    try:
+        path.unlink()
+    except Exception:
+        pass
+    try:
+        if time.time() - float(data.get("at") or 0) > PENDING_MAX_AGE:
+            return False
+    except Exception:
+        return False
+    return bool(data.get("from")) and data["from"] != current_version
 
 
 def cleanup_old() -> None:


### PR DESCRIPTION
Two things James reported.

### 1. "I clicked update… it didn't open fully"
The installer relaunches with `/RESTARTAPPLICATIONS`, which restores the app exactly as it was — a tray icon and nothing else. An update the user explicitly asked for finished with no window, and the only signal was a toast telling them to go find a menu.

`download_and_run` now writes a pending-update marker **before** spawning the installer (after would never run — the installer force-closes the process), and the next start consumes it and opens Settings on the **About** tab, where the changelog already renders.

Gated on the marker, not the version number: a hand reinstall or a restored backup also changes the version, and a tray app that starts at boot must not open a window uninvited. The marker is always consumed — including when the install failed and the version didn't move — and a marker that can't be deleted is emptied instead. If neither works it stays silent, because missing the window once beats opening it on every boot for ever.

### 2. "It's stuck on transcribing… then I have to wait for ages"
The finish ran **mux → name → transcribe → send → show buttons**, in sequence. Whisper over a two-minute clip sat in the middle, so the first button appeared minutes after the recording that produced it.

Now the pill reaches `done` as soon as the file is muxed and named, with **Play / Send / Copy path / Open** live, and a worker behind it sends the video, transcribes, then sends the transcript. The video goes first and on its own — the clip is the part wanted at the far end.

An **agent** still waits, because it's blocked on the text it asked for. Auto-send stays automatic (James's call); the Send button re-sends on demand and is the only route when no destination is configured, in which case it now says so rather than silently doing nothing.

### Bugs found while building and reviewing this
- The `finally` block overwrote a send failure with **"Recording saved and sent"** — a failed upload reported as success.
- With `keep_local` off, the local file was deleted **before** the pill appeared, so Play and Open pointed at a file already gone.
- The cleanup was gated on `not note`, and "no transcript" sets a note — so **a clip with no narration was never tidied up**, however `screenrec_keep_local` was set. The jury didn't find this one; chasing its `Path(None)` finding did.
- `Path(None).unlink()` raises `TypeError`, which `except OSError` doesn't catch, so a missing transcript aborted the delete loop partway.
- The Send button needed a fourth slot in a row with a hardcoded 108px width: 4×108 + gaps is 456px inside a 380px pill, so two buttons would have been drawn off the edge while the hit test still claimed they were there.

### Verification
- Suite **372 passed**, same 15 pre-existing failures `main` has.
- Sabotage battery run on every claim; **three of my own tests initially passed with the fix deleted** and were rebuilt until they didn't — the in-flight guard test returned early for an unrelated reason, and the `Path(None)` test mocked `unlink`, which cannot show which file survived (it uses real files in `tmp_path` now).
- `/jury` run twice across the branch. No P1. Three P2s fixed, one P3 refuted with reasoning in the commit.

**Unverified here:** no Windows, no audio device. Whether the update actually lands on About, and whether the buttons feel immediate, are James's checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WStiFEE9AHoF4esPCaKiYD