### PR TITLE
feat(read-aloud): hotkey, OCR the screen, speak it

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,6 +48,7 @@ jobs:
           --collect-all pystray
           --collect-all PIL
           --collect-all mss
+          --collect-all winrt
           --collect-all mcp
           --collect-all pydantic
           --collect-all anyio
@@ -83,6 +84,21 @@ jobs:
           } else {
             Write-Host "MCP server produced no JSON-RPC reply."
             Write-Host "stdout:`n$out"
+            exit 1
+          }
+
+      # Spike 1, made permanent: verifying winrt-* on PyPI is a VERSION check.
+      # This is the BUNDLING check — the same half-verification shipped a
+      # broken exe this week (--collect-all missed FastMCP's module-level
+      # imports). A frozen exe that cannot activate WinRT must never reach
+      # beta as a silent "nothing happens" — it must be a red CI build.
+      - name: Self-test WinRT (OCR + speech) in the built exe
+        shell: pwsh
+        run: |
+          $exe = "dist/Pipevoice/Pipevoice.exe"
+          & $exe --winrt-selftest
+          if ($LASTEXITCODE -ne 0) {
+            Write-Host "winrt self-test failed — Read Aloud would silently do nothing."
             exit 1
           }
 

--- a/GATES.md
+++ b/GATES.md
@@ -1,88 +1,140 @@
-# Gates — vocabulary you control, and output that fits the app
+# Gates — Read Aloud (`vault/Plans/pipevoice-read-aloud.md`)
 
-Bound to the code tree (`wisprlite/`, `tests/`), not to a commit id. Committed
-last, after every gate below is checked.
+Bound to the code tree (`wisprlite/`, `tests/`), not to a commit id.
 
-1. Existing `cfg.replacements` from a pre-upgrade config load unchanged into the
-   new list editor, and still apply.
-   CHECK: `python3 -m pytest -q tests/test_word_fixes.py`
-   EXPECT: pass. `test_sabotage_broken_round_trip_would_fail` is the positive
-   control — it deliberately corrupts a round-tripped value and asserts the
-   corruption is detectable.
-   RESULT: PASS (5 tests). Storage format (`cfg.replacements`, a plain dict) was
-   never touched — only the editor widget changed from a comma-string Entry to
-   a two-column Listbox — so no config migration exists or is needed.
+1. Spike 1 passes on a clean Windows Sandbox — a frozen exe activating both
+   WinRT namespaces.
+   NOT VERIFIABLE ON THIS VPS: no Windows, no display, no Windows Sandbox.
+   Per the plan's DECISION 2026-09-04, this is relocated to CI instead of a
+   one-off spike run: `--winrt-selftest` (wisprlite/readaloud.py:113,
+   wired in `wisprlite/__main__.py`) activates both `Windows.Media.Ocr` and
+   `Windows.Media.SpeechSynthesis` from the code that will actually ship, and
+   `.github/workflows/build.yml`'s new "Self-test WinRT" step runs it against
+   the BUILT exe and fails the build on a non-zero exit. This step itself has
+   not run yet — it runs on the next push to `main`/CI trigger, on a real
+   Windows runner. Cannot be claimed PASS from here.
 
-2. The three new presets appear in `STYLES` and each produces materially
-   different output from `tidy` on the same input. Sabotage: point two presets
-   at the same prompt and confirm the test fails.
-   CHECK: `python3 -m pytest -q tests/test_cleanup_styles.py`
+2. Spike 2's CER table, >25% kill criterion.
+   NOT VERIFIABLE ON THIS VPS: needs real screenshots and a human transcribing
+   ground truth. Per the plan's DECISION, this moved to James testing the real
+   build, not a script's number. Not attempted here.
+
+3. The hotkey does not collide with the six existing chords.
+   CHECK: `python3 -m pytest -q tests/test_readaloud.py -k hotkey`
    EXPECT: pass.
-   RESULT: PASS (9 tests, incl.
-   `test_new_presets_are_materially_different_from_tidy_and_each_other` and its
-   sabotage control). `email`/`code_comment`/`meeting_actions` added to
-   `STYLES` in both `settings.py` and `voices_editor.py` (voices_editor.py:19).
+   RESULT: PASS. `read_aloud_hotkey` defaults to `""` (off), same convention as
+   meeting/screenrec/bookmark/voice-picker hotkeys. All three capture modes
+   (window/screen/region) live on ONE hotkey field — the modifier held at
+   trigger time picks the mode (`readaloud.capture_mode_for`,
+   `app.py:_read_aloud_run`) — so there is nothing else to collide.
+   `test_read_aloud_default_hotkey_does_not_collide_with_the_six_existing_chords`
+   and its sabotage twin
+   `test_a_user_configured_read_aloud_hotkey_does_not_shadow_the_others` (which
+   deliberately collides one first, to prove the check can fail) both pass.
 
-3. A per-app profile setting `cleanup_style=email` overrides the global style
-   for that app only. Sabotage: remove the override and confirm red.
-   CHECK: `python3 -m pytest -q tests/test_profiles_style.py`
+4. Capture never touches disk.
+   CHECK: `python3 -m pytest -q tests/test_readaloud.py -k grab_png`
    EXPECT: pass.
-   RESULT: PASS (6 tests). No code change was needed here — `profiles.resolve()`
-   already dispatches through a named Voice (`voices.py`), and Voices carry
-   `cleanup_style` generically, so any new style value is a free per-app
-   override the moment it exists in `STYLES`. Added
-   `test_per_app_profile_overrides_cleanup_style_for_that_app_only` and its
-   sabotage twin to make that explicit for `email` specifically.
+   RESULT: PASS. `readaloud.grab_png` builds the PNG with `mss.tools.to_png`
+   in memory and returns bytes; never opens a file.
+   `test_grab_png_never_writes_a_temp_file` runs it in an empty `tmp_path` cwd
+   (with `mss` stubbed in `sys.modules`, since it isn't installed on this
+   Linux box) and asserts the directory is still empty afterward.
 
-4. Ollama latency benchmark recorded as a number in the PR, not a claim.
-   RESULT: NOT MEASURED. Ollama is not installed or running on this VPS
-   (`curl localhost:11434/api/tags` fails to connect, no `ollama` binary).
-   Installing a local-LLM daemon plus pulling a model on a machine already
-   shared by a dozen sessions (CLAUDE.md's swap-thrashing warning) was not
-   attempted without explicit authorization. No number is asserted here —
-   fabricating one would be worse than leaving it open. This build does not
-   default any new preset to Ollama or to any provider other than the user's
-   existing `cleanup_provider` (default `gemini`), so the "must not default to
-   local if slow" constraint is not at risk from anything shipped in this PR;
-   the benchmark still needs to be run before anyone proposes such a default.
-   NEEDS: James's machine, or explicit go-ahead to install Ollama here.
+5. Speaking is interruptible: Esc during a long read stops within ~200ms.
+   CHECK: `python3 -m pytest -q tests/test_readaloud.py -k stop`
+   EXPECT: pass.
+   RESULT: PASS. `readaloud.Speaker.stop()` calls the WinRT `MediaPlayer`'s own
+   `pause()` SYNCHRONOUSLY on the calling thread — not after the current
+   sentence, not via a flag checked later — so the interrupt latency is bounded
+   by how fast `MediaPlayer.pause()` returns, not by text length or poll rate.
+   `test_stop_pauses_the_player_synchronously_not_after_the_text_finishes`
+   injects a fake player whose `play()` calls `stop()` mid-call and asserts
+   `pause` was already recorded by the time `speak()` returns. The actual
+   keyboard polling loop (`app.py:_read_aloud_watch_interrupt`) runs at ~50Hz
+   (20ms), well under the 200ms budget, and calls this same `stop()`.
+   NOT MEASURED end-to-end with real audio: no Windows, no speakers, no WinRT
+   here. The synchronous-call guarantee is what the real ~200ms bound rests on;
+   an actual stopwatch measurement needs James's machine.
 
-5. Full suite: `python3 -m pytest -q --ignore=tests/test_transcribe_deepgram_e2e.py`.
-   Baseline on `main` first — it currently carries 15 pre-existing failures
-   and the run must not add a sixteenth.
+6. Full suite, baselined on `main` first (15 pre-existing failures; must not
+   add a sixteenth).
    CHECK: `python3 -m pytest -q --ignore=tests/test_transcribe_deepgram_e2e.py`
    EXPECT: same 15 pre-existing failures (test_env_precedence.py x8,
    test_transcribe_window.py x7), 0 new failures.
-   RESULT: PASS. Baseline (before any edit): 15 failed, 372 passed, 24 skipped
-   (no display). After changes: 15 failed (identical set), 384 passed, 24
-   skipped. Under `xvfb-run` (real display, so nothing is skipped): 15 failed
-   (identical set), 408 passed, 0 new failures either way.
+   RESULT: PASS. Baseline (before any edit, this worktree): 15 failed, 402
+   passed, 25 skipped. After changes: 15 failed (identical set), 423 passed
+   (402 + 21 new in tests/test_readaloud.py), 25 skipped.
+   Settings UI also verified under `xvfb-run` (real Tk, real display):
+   `tests/test_ui_smoke.py` builds every settings tab including the new "Read
+   Aloud" card — 39 passed, no new widget errors.
+   NOT CLEAN: running the FULL suite (not just ui_smoke) under `xvfb-run`
+   aborts with a native `Fatal Python error: Aborted` inside PyAV's H.264
+   encoder, in `tests/test_screenrec.py::test_a_long_recording_does_not_hold_
+   every_frame_in_memory` (`wisprlite/screenrec.py:207 _encode_frame`) — a
+   file this PR does not touch. Reproduced twice, always at the same test.
+   Excluding `tests/test_readaloud.py` from the same xvfb run, the full suite
+   passes cleanly (427 passed, same 15 failures, no crash) — so the crash only
+   appears once the suite is large enough, under xvfb, on this VPS's
+   run-limited 4GB memory cap; nothing in the crash's own stack trace touches
+   `readaloud.py`, `app.py`'s read-aloud code, or the settings/overlay edits.
+   Read as a resource-pressure artifact of this shared, capped VPS, not a
+   defect in this diff — but flagging it plainly rather than omitting it,
+   since I could not get a fully clean xvfb run with the new test file
+   present. The gate as WRITTEN in the plan (non-xvfb `pytest -q`) is clean.
 
-## Blocker fixed before building
+## What was built
 
-`requirements.txt:12` pinned `faster-whisper>=1.0`; `hotwords` did not exist
-until 1.0.2. Bumped to `>=1.0.2`. `hotwords` itself is NOT built anywhere in
-this codebase (grep confirms 0 occurrences) — the plan's flip-rate gate for it
-was never cleared, so this pin bump is purely defensive against a future
-change, not cover for code that ships in this PR.
+- `wisprlite/readaloud.py` — capture (focused-window rect via ctypes, `mss`
+  grab to PNG bytes in memory), OCR via `Windows.Media.Ocr`, speech via
+  `Windows.Media.SpeechSynthesis` + `MediaPlayer` (interruptible), screen-reader
+  detection (informational only, never gates speaking), `--winrt-selftest`.
+- `wisprlite/config.py`: `read_aloud_hotkey` (`""` = off, matches the
+  meeting/screenrec/bookmark convention), `read_aloud_voice`, `read_aloud_rate`,
+  `read_aloud_ocr_language`, `read_aloud_clipboard` (default True),
+  `read_aloud_quiet_with_screenreader` (default **False** — speaks always,
+  per the panel's decision).
+- `wisprlite/app.py`: one `HotkeyManager` (`read_aloud_hotkeys`), started in
+  `run()`; `_read_aloud_trigger` / `_read_aloud_run` /
+  `_read_aloud_watch_interrupt` — capture mode picked by which modifier is ALSO
+  held (Shift = whole screen, Ctrl = drag a region via the existing
+  `screenrec.select_region()`, neither = focused window); clipboard copy
+  (never silent about it); everything wrapped so a `ReadAloudError` shows on
+  the overlay instead of raising into the hotkey loop.
+- `wisprlite/overlay.py`: a `"reading"` accent color, reusing the existing
+  generic `show`/`set_state` status-pill mechanism — no new custom-drawn phase,
+  since the pill already renders arbitrary state+text (`_draw_status`).
+- `wisprlite/settings.py`: a "Read Aloud" card (hotkey + Capture button, voice,
+  speed, OCR language, clipboard toggle, "stay quiet" toggle — default off,
+  with copy explaining why).
+- `wisprlite/__main__.py`: routes `--winrt-selftest` to `readaloud.main`.
+- `.github/workflows/build.yml`: `--collect-all winrt` added to the PyInstaller
+  build, and a new "Self-test WinRT" step runs `Pipevoice.exe --winrt-selftest`
+  against the built exe and fails the build on it (spike 1, made permanent).
+- `requirements.txt`: `winrt-*` at `3.2.1` (not `winsdk`, which is a beta),
+  each `; sys_platform == "win32"` so this Linux test suite still installs.
+- `tests/test_readaloud.py`: 21 tests — mode selection, hotkey-collision
+  (with a sabotage twin), no-disk-write capture (with a sabotage twin),
+  degrade-without-WinRT (import failure, no OCR engine, no voices — each
+  distinct), interrupt latency mechanism, speak-always-by-default with the
+  screen-reader opt-out. WinRT and `mss` are stubbed in `sys.modules` the same
+  way `tests/test_deepgram_bias.py` stubs the Deepgram SDK, per the plan's
+  "Tests must import on Linux" instruction.
 
 ## Explicitly not built (per the plan)
 
-- **Hotword biasing / "learns your words" claim.** Gated behind the flip-rate
-  measurement in the plan (≥30% flip on 20 real misheard proper nouns). That
-  measurement needs a real mic, Windows, and faster-whisper installed — none
-  of which exist on this VPS. Not attempted here; needs James's machine.
-- **Automatic correction capture.** Explicitly rejected in the plan
-  (RichEdit/UIA/terminal/IME landmines, contradicts logged automation-vs-control
-  decisions). Not implemented.
-- **Session 3 (site copy, comparison table, winget submission).** Lives in the
-  separate private `pipevoice-site` repo, not this one (this repo's own
-  CLAUDE.md: "The pipevoice.app website + marketing live in a separate private
-  repo"). No artifact for it exists in this worktree — there is nothing to
-  build here for that item.
+- **Piper, ElevenLabs.** Not touched.
+- **"Re-OCR the last region."** Cut by the panel; not built.
+- **Custom UI Automation provider for the overlay.** Cut by the panel; the
+  overlay stays ordinary Tk.
+- **NVDA/JAWS-based auto-silencing.** The opposite was built on purpose: speak
+  always, opt-out setting only, default off.
 
 ## Not verifiable on this VPS
 
-- The Ollama latency number (gate 4).
-- The hotword flip-rate test (needs James's machine — no mic, no Windows, no
-  faster-whisper installed here, and the feature itself is not built).
+- Gate 1 (Windows Sandbox activation) and Gate 2 (OCR CER table) — no Windows.
+- The real end-to-end ~200ms interrupt latency with actual audio — no
+  speakers, no WinRT, no Windows.
+- Whether the CI `--winrt-selftest` step actually passes on a GitHub Actions
+  Windows runner (language pack / voice availability there is untested from
+  here) — it will report PASS/FAIL for real the next time CI runs.

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,20 @@ mss>=9.0              # grabs a screen region; ~0.1 MB
 # H.264 encoding uses PyAV, which faster-whisper already pulls in (av>=11) and
 # whose wheels ship libx264 — so the encoder costs nothing extra in the build.
 
+# --- Read Aloud (OCR + speech) ---
+# winrt-*, NOT winsdk (that's 1.0.0b10, a beta). The project split into
+# maintained per-namespace packages at 3.2.1. Windows-only: sys_platform
+# marker so the Linux test suite (mocks winrt in sys.modules) can still install.
+winrt-runtime>=3.2.1; sys_platform == "win32"
+winrt-Windows.Media.Ocr>=3.2.1; sys_platform == "win32"
+winrt-Windows.Media.SpeechSynthesis>=3.2.1; sys_platform == "win32"
+winrt-Windows.Media.Playback>=3.2.1; sys_platform == "win32"
+winrt-Windows.Media.Core>=3.2.1; sys_platform == "win32"
+winrt-Windows.Graphics.Imaging>=3.2.1; sys_platform == "win32"
+winrt-Windows.Storage.Streams>=3.2.1; sys_platform == "win32"
+winrt-Windows.Foundation>=3.2.1; sys_platform == "win32"
+winrt-Windows.Globalization>=3.2.1; sys_platform == "win32"
+
 # --- UI niceties ---
 pystray>=0.19         # system tray icon + menu
 Pillow>=10.0          # renders the tray icon

--- a/tests/test_readaloud.py
+++ b/tests/test_readaloud.py
@@ -1,0 +1,328 @@
+"""Read Aloud: capture -> OCR -> speech, all guarded so a missing WinRT bundle
+degrades instead of raising into the hotkey loop. WinRT and mss are stubbed in
+sys.modules exactly the way test_deepgram_bias.py stubs the deepgram SDK — this
+suite must import and pass with neither package installed, since neither is
+present on this Linux box (see requirements.txt: winrt-* is win32-only).
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+import types
+from unittest import mock
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent))
+
+from wisprlite import config
+from wisprlite import readaloud
+
+
+# ---- mode selection (pure logic) -------------------------------------------
+
+def test_plain_press_captures_the_focused_window():
+    assert readaloud.capture_mode_for(shift=False, ctrl=False) == "window"
+
+
+def test_shift_captures_the_whole_screen():
+    assert readaloud.capture_mode_for(shift=True, ctrl=False) == "screen"
+
+
+def test_ctrl_drags_a_region():
+    assert readaloud.capture_mode_for(shift=False, ctrl=True) == "region"
+
+
+def test_ctrl_wins_over_shift_if_somehow_both_are_held():
+    assert readaloud.capture_mode_for(shift=True, ctrl=True) == "region"
+
+
+# ---- hotkey collision (gate 3: testable headlessly) ------------------------
+
+def test_read_aloud_default_hotkey_does_not_collide_with_the_six_existing_chords():
+    cfg = config.Config()
+    existing = [
+        cfg.hotkey, cfg.clipboard_hotkey, cfg.meeting_hotkey,
+        cfg.bookmark_hotkey, cfg.screenrec_hotkey, cfg.voice_picker_hotkey,
+    ]
+    non_empty = [h for h in existing if h]
+    assert len(non_empty) == len(set(non_empty)), "two existing defaults already collide"
+    assert cfg.read_aloud_hotkey not in non_empty
+
+
+def test_a_user_configured_read_aloud_hotkey_does_not_shadow_the_others():
+    """The three capture modes live on ONE base combo (modifiers are read at
+    trigger time, not baked into three separate hotkey strings), so the one
+    new field is the only thing that can collide."""
+    cfg = config.Config(read_aloud_hotkey="ctrl+\\")  # deliberately colliding
+    assert cfg.read_aloud_hotkey == cfg.hotkey, "sabotage fixture did not actually collide"
+    cfg2 = config.Config(read_aloud_hotkey="alt+r")
+    assert cfg2.read_aloud_hotkey not in (
+        cfg2.hotkey, cfg2.clipboard_hotkey, cfg2.meeting_hotkey,
+        cfg2.bookmark_hotkey, cfg2.screenrec_hotkey, cfg2.voice_picker_hotkey,
+    )
+
+
+# ---- capture never touches disk (gate 4) -----------------------------------
+
+def _fake_mss_module(png_bytes: bytes = b"\x89PNG-fake"):
+    grabbed = {}
+
+    class _Shot:
+        rgb = b"\x00" * 12
+        size = (2, 2)
+
+    class _Sct:
+        monitors = [{"left": 0, "top": 0, "width": 1920, "height": 1080}]
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_exc):
+            return False
+
+        def grab(self, area):
+            grabbed["area"] = area
+            return _Shot()
+
+    mss_mod = types.ModuleType("mss")
+    mss_mod.mss = lambda: _Sct()
+    tools_mod = types.ModuleType("mss.tools")
+    tools_mod.to_png = lambda rgb, size: png_bytes
+    mss_mod.tools = tools_mod
+    return mss_mod, tools_mod, grabbed
+
+
+def test_grab_png_never_writes_a_temp_file(tmp_path, monkeypatch):
+    mss_mod, tools_mod, grabbed = _fake_mss_module(b"totally-a-png")
+    monkeypatch.chdir(tmp_path)
+    with mock.patch.dict(sys.modules, {"mss": mss_mod, "mss.tools": tools_mod}):
+        result = readaloud.grab_png(None)
+    assert result == b"totally-a-png"
+    assert grabbed["area"] == {"left": 0, "top": 0, "width": 1920, "height": 1080}
+    assert list(tmp_path.iterdir()) == [], "grab_png left a file on disk"
+
+
+def test_grab_png_uses_the_given_region_not_the_whole_desktop(tmp_path, monkeypatch):
+    mss_mod, tools_mod, grabbed = _fake_mss_module()
+    monkeypatch.chdir(tmp_path)
+    with mock.patch.dict(sys.modules, {"mss": mss_mod, "mss.tools": tools_mod}):
+        readaloud.grab_png((10, 20, 300, 400))
+    assert grabbed["area"] == {"left": 10, "top": 20, "width": 300, "height": 400}
+    assert list(tmp_path.iterdir()) == []
+
+
+# ---- degrades without WinRT -------------------------------------------------
+
+def test_winrt_available_is_false_without_the_package():
+    with mock.patch.dict(sys.modules, {"winrt": None, "winrt.windows.media.ocr": None,
+                                        "winrt.windows.media.speechsynthesis": None}):
+        assert readaloud.winrt_available() is False
+
+
+def test_ocr_without_winrt_raises_readaloud_error_not_a_bare_import_error():
+    with mock.patch.dict(sys.modules, {"winrt": None, "winrt.windows.globalization": None}):
+        try:
+            readaloud.ocr_png(b"fake-png")
+        except readaloud.ReadAloudError as exc:
+            assert "OCR unavailable" in str(exc)
+        else:
+            raise AssertionError("expected ReadAloudError")
+
+
+def test_winrt_selftest_fails_closed_without_the_package():
+    with mock.patch.dict(sys.modules, {"winrt": None, "winrt.windows.media.ocr": None,
+                                        "winrt.windows.media.speechsynthesis": None}):
+        ok, message = readaloud.winrt_selftest()
+    assert ok is False
+    assert message.startswith("FAIL:")
+
+
+def test_winrt_selftest_reports_no_engine_distinctly_from_a_bundling_failure():
+    """The spike's README calls this out explicitly: a language-pack miss and a
+    bundling miss mean different things and must not read the same."""
+    ocr_mod = types.ModuleType("winrt.windows.media.ocr")
+    ocr_mod.OcrEngine = types.SimpleNamespace(
+        try_create_from_user_profile_languages=lambda: None)
+    speech_mod = types.ModuleType("winrt.windows.media.speechsynthesis")
+    speech_mod.SpeechSynthesizer = types.SimpleNamespace(all_voices=["a voice"])
+    with mock.patch.dict(sys.modules, {
+        "winrt.windows.media.ocr": ocr_mod,
+        "winrt.windows.media.speechsynthesis": speech_mod,
+    }):
+        ok, message = readaloud.winrt_selftest()
+    assert ok is False
+    assert "no OCR engine" in message
+
+
+def test_winrt_selftest_passes_when_both_namespaces_activate():
+    ocr_mod = types.ModuleType("winrt.windows.media.ocr")
+    ocr_mod.OcrEngine = types.SimpleNamespace(
+        try_create_from_user_profile_languages=lambda: object())
+    speech_mod = types.ModuleType("winrt.windows.media.speechsynthesis")
+    speech_mod.SpeechSynthesizer = types.SimpleNamespace(all_voices=["Voice A", "Voice B"])
+    with mock.patch.dict(sys.modules, {
+        "winrt.windows.media.ocr": ocr_mod,
+        "winrt.windows.media.speechsynthesis": speech_mod,
+    }):
+        ok, message = readaloud.winrt_selftest()
+    assert ok is True
+    assert "2 voice" in message
+
+
+# ---- speaking is interruptible (gate 5) ------------------------------------
+
+class _FakePlayer:
+    def __init__(self):
+        self.calls = []
+
+    def play(self):
+        self.calls.append("play")
+
+    def pause(self):
+        self.calls.append("pause")
+
+
+def test_stop_pauses_the_player_synchronously_not_after_the_text_finishes():
+    """The whole interrupt-latency claim rests on this: stop() must call the
+    player's own pause() on the calling thread, not defer it until speak()
+    would otherwise have returned."""
+    player = _FakePlayer()
+    speaker = readaloud.Speaker(player_factory=lambda: player)
+
+    played = {"done": False}
+    real_play = player.play
+
+    def play_and_get_stopped():
+        real_play()
+        # a real long utterance would still be "playing" here — stop() must
+        # still take effect immediately, not wait for this to return.
+        speaker.stop()
+        played["done"] = True
+
+    player.play = play_and_get_stopped
+    speaker.speak("hello world, this is a long thing to read aloud")
+
+    assert played["done"] is True
+    assert "pause" in player.calls, "stop() never reached the player"
+
+
+def test_stop_before_any_speech_starts_still_prevents_playback():
+    player = _FakePlayer()
+    speaker = readaloud.Speaker(player_factory=lambda: player)
+    speaker.stop()
+    speaker.speak("never should play")
+    assert "play" not in player.calls
+    assert "pause" in player.calls
+
+
+def test_pause_and_resume_toggle_the_paused_flag_and_call_the_player():
+    player = _FakePlayer()
+    speaker = readaloud.Speaker(player_factory=lambda: player)
+    speaker._player = player  # normally set inside speak(); simulate mid-read
+    assert speaker.paused is False
+    speaker.pause()
+    assert speaker.paused is True
+    assert player.calls[-1] == "pause"
+    speaker.resume()
+    assert speaker.paused is False
+    assert player.calls[-1] == "play"
+
+
+def test_speaking_empty_text_raises_instead_of_silently_doing_nothing():
+    speaker = readaloud.Speaker(player_factory=lambda: _FakePlayer())
+    try:
+        speaker.speak("   ")
+    except readaloud.ReadAloudError:
+        pass
+    else:
+        raise AssertionError("expected ReadAloudError for empty text")
+
+
+# ---- speak ALWAYS, screen reader running or not (the panel's decision) -----
+
+def test_should_speak_defaults_to_true_even_with_a_screen_reader_running():
+    assert readaloud.should_speak(quiet_with_screenreader=False) is True
+
+
+def test_should_speak_respects_the_opt_out_when_a_screen_reader_is_detected():
+    with mock.patch.object(readaloud, "screen_reader_running", lambda: True):
+        assert readaloud.should_speak(quiet_with_screenreader=True) is False
+
+
+def test_should_speak_opt_out_still_speaks_when_no_screen_reader_is_detected():
+    with mock.patch.object(readaloud, "screen_reader_running", lambda: False):
+        assert readaloud.should_speak(quiet_with_screenreader=True) is True
+
+
+def test_config_defaults_speak_always():
+    """Sabotage-style regression guard: if this default ever flips to True,
+    Read Aloud goes silent by default at the exact moment it's needed."""
+    assert config.Config().read_aloud_quiet_with_screenreader is False
+
+
+# ---- review findings (brain, not builder) -----------------------------------
+
+def test_a_player_is_released_not_just_paused():
+    """Pause makes the interrupt instant. Close is what stops every single read
+    leaking a MediaPlayer and its audio resources."""
+    from unittest import mock
+    from wisprlite import readaloud
+
+    player = mock.Mock()
+    speaker = readaloud.Speaker(player_factory=lambda: player)
+    speaker.speak("hello")
+    speaker.stop()
+
+    player.pause.assert_called()
+    player.close.assert_called_once(), "the player was paused but never released"
+
+
+def test_a_failed_play_does_not_stay_the_live_player():
+    """Otherwise stop() later pauses a player that never played, and the real
+    failure is masked by a no-op."""
+    from unittest import mock
+    import pytest
+    from wisprlite import readaloud
+
+    player = mock.Mock()
+    player.play.side_effect = RuntimeError("no audio device")
+    speaker = readaloud.Speaker(player_factory=lambda: player)
+
+    with pytest.raises(readaloud.ReadAloudError):
+        speaker.speak("hello")
+
+    assert speaker._player is None, "a dead player was left assigned as live"
+
+
+def test_stopping_before_speaking_never_starts_playback():
+    """Esc during the OCR pass, before speech begins."""
+    from unittest import mock
+    from wisprlite import readaloud
+
+    player = mock.Mock()
+    speaker = readaloud.Speaker(player_factory=lambda: player)
+    speaker.stop()
+    speaker.speak("hello")
+
+    player.play.assert_not_called()
+
+
+def test_screen_reader_check_uses_a_four_byte_bool():
+    """SPI_GETSCREENREADER writes a Win32 BOOL - four bytes. ctypes.c_bool is
+    ONE, so the original wrote three bytes past the buffer: a silent stack
+    smash, in an accessibility code path of all places."""
+    source = (pathlib.Path(__file__).resolve().parent.parent
+              / "wisprlite" / "readaloud.py").read_text(encoding="utf-8")
+    reader = source[source.index("def screen_reader_running"):]
+    reader = reader[:reader.index("\ndef ")]
+    assert "wintypes.BOOL()" in reader, "the screen-reader probe is not using a Win32 BOOL"
+    assert "c_bool()" not in reader, "ctypes.c_bool is one byte; Windows writes four"
+
+
+def test_the_png_is_not_expanded_into_a_python_list_first():
+    """A whole-screen PNG is megabytes; list(png_bytes) built a list of millions
+    of ints before a single byte was written."""
+    source = (pathlib.Path(__file__).resolve().parent.parent
+              / "wisprlite" / "readaloud.py").read_text(encoding="utf-8")
+    assert "writer.write_bytes(png_bytes)" in source, \
+        "the raw bytes are not passed straight to the writer"

--- a/tests/test_readaloud.py
+++ b/tests/test_readaloud.py
@@ -326,3 +326,57 @@ def test_the_png_is_not_expanded_into_a_python_list_first():
               / "wisprlite" / "readaloud.py").read_text(encoding="utf-8")
     assert "writer.write_bytes(png_bytes)" in source, \
         "the raw bytes are not passed straight to the writer"
+
+
+def test_a_second_press_during_the_ocr_pass_does_not_start_a_second_read():
+    """The mid-read check reads _read_aloud_speaker, which is still None while
+    OCR runs - seconds on a full-screen grab. Without a lock, two threads race
+    to own the speaker and you hear both reads at once."""
+    import threading
+    from unittest import mock
+
+    from uistub import install_platform_stubs
+    install_platform_stubs()          # app.py imports sounddevice/keyboard at module scope
+    from wisprlite.app import App
+
+    app = App.__new__(App)
+    app._read_aloud_speaker = None
+    app._read_aloud_busy = threading.Lock()
+
+    with mock.patch("wisprlite.app.threading.Thread") as thread:
+        App._read_aloud_trigger(app)   # first press starts a read
+        App._read_aloud_trigger(app)   # second press, still mid-OCR
+    assert thread.call_count == 1, "a second press started a second read"
+
+
+def test_the_read_lock_is_released_on_every_path_out():
+    """A read that finds no text, or raises, must not leave the hotkey dead for
+    the rest of the session."""
+    import threading
+    from unittest import mock
+
+    from uistub import install_platform_stubs
+    install_platform_stubs()
+    from wisprlite.app import App
+
+    app = App.__new__(App)
+    app._read_aloud_busy = threading.Lock()
+    app._read_aloud_busy.acquire()
+
+    with mock.patch.object(App, "_read_aloud_body", side_effect=RuntimeError("boom")):
+        try:
+            App._read_aloud_run(app)
+        except RuntimeError:
+            pass
+
+    assert app._read_aloud_busy.acquire(blocking=False), \
+        "the lock survived an exception - the hotkey is now dead"
+
+
+def test_a_speaker_is_one_shot_and_says_so():
+    """stop() is latched so an Esc during OCR is honoured. That makes the class
+    one-shot, which must be documented rather than left as a silent no-op."""
+    from wisprlite import readaloud
+
+    assert "ONE-SHOT" in readaloud.Speaker.speak.__doc__, \
+        "the one-shot contract is not documented on speak()"

--- a/wisprlite/__init__.py
+++ b/wisprlite/__init__.py
@@ -1,3 +1,3 @@
 """Pipevoice — push-to-talk voice typing for Windows."""
 
-__version__ = "2.44.1"
+__version__ = "2.45.0"

--- a/wisprlite/__main__.py
+++ b/wisprlite/__main__.py
@@ -18,6 +18,8 @@ elif "--mcp" in sys.argv:
     from .mcp_shim import main
 elif "--feedback" in sys.argv:
     from .feedback import main
+elif "--winrt-selftest" in sys.argv:
+    from .readaloud import main
 else:
     from .app import main
 

--- a/wisprlite/app.py
+++ b/wisprlite/app.py
@@ -142,6 +142,17 @@ class App:
             on_stop=lambda: None,
             is_paused=lambda: not self._meeting_active,
         )
+        # Read Aloud: one press captures + OCRs + speaks. Which modifiers were
+        # ALSO held at that moment (checked inside the trigger, not encoded as a
+        # separate hotkey) picks the mode — see readaloud.capture_mode_for.
+        self.read_aloud_hotkeys = HotkeyManager(
+            get_hotkey=lambda: self.cfg.read_aloud_hotkey,
+            get_mode=lambda: "ptt",
+            on_start=self._read_aloud_trigger,
+            on_stop=lambda: None,
+            is_paused=lambda: self.paused or self._meeting_active,
+        )
+        self._read_aloud_speaker = None   # the live readaloud.Speaker, None when idle
 
         self._screenrec = None        # the live ScreenRecording, None when idle
         self._screenrec_selecting = False   # the region selector is open
@@ -319,6 +330,101 @@ class App:
             threading.Timer(12.0, _disarm).start()
         else:
             self.overlay.hide()
+
+    # ---- read aloud ---------------------------------------------------------
+    def _read_aloud_trigger(self) -> None:
+        speaker = self._read_aloud_speaker
+        if speaker is not None:
+            # Pressed again mid-read: the hotkey itself is also a stop.
+            speaker.stop()
+            return
+        threading.Thread(target=self._read_aloud_run, daemon=True).start()
+
+    def _read_aloud_run(self) -> None:
+        from . import readaloud
+
+        try:
+            import keyboard
+            shift, ctrl = keyboard.is_pressed("shift"), keyboard.is_pressed("ctrl")
+        except Exception:
+            shift = ctrl = False
+        mode = readaloud.capture_mode_for(shift=shift, ctrl=ctrl)
+
+        region = None
+        if mode == "window":
+            region = readaloud.focused_window_rect()
+        elif mode == "region":
+            from . import screenrec
+            region = screenrec.select_region()
+            if region is None:
+                return  # cancelled
+        # mode == "screen" keeps region=None -> the whole virtual desktop
+
+        self.overlay.show("transcribing", "Reading…")
+        try:
+            png = readaloud.grab_png(region)
+            text = readaloud.ocr_png(png, language=self.cfg.read_aloud_ocr_language)
+        except readaloud.ReadAloudError as exc:
+            self.overlay.set_state("error", str(exc)[:80])
+            return
+        except Exception as exc:
+            self.overlay.set_state("error", f"Read Aloud failed: {exc}"[:80])
+            return
+
+        if not text:
+            self.overlay.set_state("done", "No text found")
+            return
+
+        copied = bool(self.cfg.read_aloud_clipboard)
+        if copied:
+            copy_clipboard(text)
+        preview = text if len(text) <= 160 else text[:157] + "…"
+        self.overlay.set_state("reading", preview + (" (copied)" if copied else ""))
+
+        if not readaloud.should_speak(quiet_with_screenreader=self.cfg.read_aloud_quiet_with_screenreader):
+            self.overlay.set_state("done", "Copied — staying quiet (screen reader running)")
+            return
+
+        speaker = readaloud.Speaker(voice=self.cfg.read_aloud_voice, rate=self.cfg.read_aloud_rate)
+        self._read_aloud_speaker = speaker
+        threading.Thread(target=self._read_aloud_watch_interrupt, args=(speaker,), daemon=True).start()
+        try:
+            speaker.speak(text)
+        except readaloud.ReadAloudError as exc:
+            self.overlay.set_state("error", str(exc)[:80])
+        finally:
+            self._read_aloud_speaker = None
+            self.overlay.set_state("done", "")
+
+    def _read_aloud_watch_interrupt(self, speaker) -> None:
+        """Esc stops, Space pauses/resumes, the hotkey again stops. Polled at
+        ~50Hz so an interrupt lands well inside the ~200ms budget — stopping
+        itself (readaloud.Speaker.stop) pauses playback synchronously rather
+        than waiting for the current sentence, which is what actually keeps
+        the latency down regardless of poll rate."""
+        import keyboard
+
+        from .hotkey import _all_pressed
+
+        prev_space = False
+        prev_hotkey = True   # already down to have triggered this; arm on release
+        while self._read_aloud_speaker is speaker:
+            try:
+                if keyboard.is_pressed("esc"):
+                    speaker.stop()
+                    return
+                space = keyboard.is_pressed("space")
+                if space and not prev_space:
+                    (speaker.resume if speaker.paused else speaker.pause)()
+                prev_space = space
+                hotkey_down = _all_pressed(self.cfg.read_aloud_hotkey)
+                if hotkey_down and not prev_hotkey:
+                    speaker.stop()
+                    return
+                prev_hotkey = hotkey_down
+            except Exception:
+                pass
+            time.sleep(0.02)
 
     # ---- hotkey callbacks (run on the hotkey thread) ----------------------
     def _on_start(self, clipboard: bool = False, voice: str | None = None) -> None:
@@ -1655,6 +1761,7 @@ class App:
         self.meeting_hotkeys.start()
         self.screenrec_hotkeys.start()
         self.bookmark_hotkeys.start()
+        self.read_aloud_hotkeys.start()
         self._start_voice_hotkeys()
         if self.cfg.mcp_enabled:
             self.start_mcp_bridge()

--- a/wisprlite/app.py
+++ b/wisprlite/app.py
@@ -153,6 +153,7 @@ class App:
             is_paused=lambda: self.paused or self._meeting_active,
         )
         self._read_aloud_speaker = None   # the live readaloud.Speaker, None when idle
+        self._read_aloud_busy = threading.Lock()   # one read at a time
 
         self._screenrec = None        # the live ScreenRecording, None when idle
         self._screenrec_selecting = False   # the region selector is open
@@ -338,9 +339,29 @@ class App:
             # Pressed again mid-read: the hotkey itself is also a stop.
             speaker.stop()
             return
+        # A second press during the OCR pass - seconds on a full-screen grab -
+        # arrives while _read_aloud_speaker is still None, so the check above
+        # does not catch it. Without this, two threads race to own the speaker
+        # and you hear both reads at once over a torn overlay. Dictation has
+        # guarded this since forever; read-aloud needs its own, since the two
+        # are independent and either may be running.
+        if not self._read_aloud_busy.acquire(blocking=False):
+            return
         threading.Thread(target=self._read_aloud_run, daemon=True).start()
 
     def _read_aloud_run(self) -> None:
+        try:
+            self._read_aloud_body()
+        finally:
+            # Released HERE, not at any early return inside the body. Every path
+            # out of a read - no text, no engine, an exception - must free the
+            # lock, or the hotkey is dead for the rest of the session.
+            try:
+                self._read_aloud_busy.release()
+            except RuntimeError:
+                pass
+
+    def _read_aloud_body(self) -> None:
         from . import readaloud
 
         try:

--- a/wisprlite/config.py
+++ b/wisprlite/config.py
@@ -200,6 +200,14 @@ class Config:
     screenrec_keep_local: bool = True # keep the files after a successful send
     screenrec_dir: str = ""           # blank = %USERPROFILE%\\Videos\\PipeVoice
     screenrec_fps: int = 12           # pure-python capture; 10-15 is realistic at 1080p
+    # Read Aloud — OCR + speech via WinRT. "" = off, like meeting/screenrec hotkeys.
+    # Base = focused window, +Shift = whole screen, +Ctrl = drag a region.
+    read_aloud_hotkey: str = ""
+    read_aloud_voice: str = ""        # "" = the system default WinRT voice
+    read_aloud_rate: float = 1.0      # 0.5-2.0, passed straight to SpeechSynthesisStream
+    read_aloud_ocr_language: str = "" # "" = user's profile languages
+    read_aloud_clipboard: bool = True # also copy the recognized text; never silent about it
+    read_aloud_quiet_with_screenreader: bool = False  # default OFF: speak even with NVDA/JAWS running
 
     @property
     def meetings_keep(self) -> int:

--- a/wisprlite/overlay.py
+++ b/wisprlite/overlay.py
@@ -45,6 +45,7 @@ ACCENT = {
     "picker": PALETTE["picker"],
     "meeting": PALETTE["meeting"],
     "screenrec": PALETTE["meeting"],
+    "reading": PALETTE["done"],
 }
 
 

--- a/wisprlite/readaloud.py
+++ b/wisprlite/readaloud.py
@@ -146,7 +146,10 @@ def ocr_png(png_bytes: bytes, *, language: str = "") -> str:
             writer.write_bytes(list(png_bytes))
         await writer.store_async()
         await writer.flush_async()
-        stream.seek(0)
+        try:
+            stream.seek(0)
+        except AttributeError:
+            stream.position = 0    # projection versions differ on which exists
         decoder = await BitmapDecoder.create_async(stream)
         bitmap = await decoder.get_software_bitmap_async()
         engine = (
@@ -193,6 +196,15 @@ class Speaker:
         self.paused = False
 
     def speak(self, text: str) -> None:
+        """Speak once. A Speaker is ONE-SHOT by design.
+
+        `stop()` is latched, so that pressing Esc DURING the OCR pass - before
+        speech has started - still prevents it speaking. Resetting the latch
+        here would silently discard that Esc. The cost is that a stopped Speaker
+        cannot be reused, so say that loudly rather than no-op'ing: a "repeat
+        last" button built on a reused Speaker would otherwise just do nothing.
+        The app builds a fresh Speaker per read.
+        """
         text = " ".join((text or "").split())
         if not text:
             raise ReadAloudError("nothing to read")
@@ -204,6 +216,7 @@ class Speaker:
             raise ReadAloudError(f"speech unavailable: {exc}") from exc
         with self._lock:
             if self._stopped:
+                # Stopped before playback began - an Esc during OCR. Honour it.
                 self._stop_player(player)
                 return
             self._player = player

--- a/wisprlite/readaloud.py
+++ b/wisprlite/readaloud.py
@@ -1,0 +1,341 @@
+"""Read Aloud — capture a region of the screen, OCR it, speak it.
+
+For people who struggle to read, and for accessibility generally. OCR and speech
+both come from WinRT (`Windows.Media.Ocr` / `Windows.Media.SpeechSynthesis`):
+offline, no key, no extra download, and the modern natural voices SAPI's legacy
+ones do not reach.
+
+Everything here degrades: no WinRT, no OCR engine for the profile's languages,
+no voices, or any WinRT failure returns a message through the normal error path
+instead of raising into the hotkey loop. Read Aloud is additive and must never
+be able to break dictation, which is why every import is lazy (see CLAUDE.md's
+"Lazy, fault-tolerant imports" rule) and every winrt call is wrapped.
+
+Speak ALWAYS, even with a screen reader running — the OCR hotkey is triggered
+*because* the screen reader cannot read that region (an image, a canvas, a
+scanned PDF). Going silent there defeats the feature at the exact moment it is
+needed. `Config.read_aloud_quiet_with_screenreader` is an opt-out, default OFF.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import logging
+import threading
+from typing import Callable, Optional
+
+log = logging.getLogger("wisprlite")
+
+
+class ReadAloudError(Exception):
+    """A degraded-but-handled failure: no engine, no bundle, bad frame, etc."""
+
+
+# ---- capture -----------------------------------------------------------------
+
+def focused_window_rect() -> Optional[tuple[int, int, int, int]]:
+    """(left, top, width, height) of the foreground window, or None.
+
+    ctypes straight to user32 rather than adding pywin32/pygetwindow for one
+    struct's worth of API.
+    """
+    try:
+        import ctypes.wintypes as wintypes
+
+        user32 = ctypes.windll.user32
+        hwnd = user32.GetForegroundWindow()
+        if not hwnd:
+            return None
+        rect = wintypes.RECT()
+        if not user32.GetWindowRect(hwnd, ctypes.byref(rect)):
+            return None
+        left, top, right, bottom = rect.left, rect.top, rect.right, rect.bottom
+        if right <= left or bottom <= top:
+            return None
+        return (left, top, right - left, bottom - top)
+    except Exception as exc:
+        log.info("read-aloud: could not read the focused window rect: %s", exc)
+        return None
+
+
+def capture_mode_for(*, shift: bool, ctrl: bool) -> str:
+    """Which of the three modes a hotkey press means, by which modifiers were
+    ALSO held. Pure function so the mode-selection logic is testable without a
+    keyboard: focused window is the default because it needs no mouse."""
+    if ctrl:
+        return "region"
+    if shift:
+        return "screen"
+    return "window"
+
+
+def grab_png(region: Optional[tuple[int, int, int, int]]) -> bytes:
+    """PNG bytes of a screen region, or the whole virtual desktop if None.
+
+    In memory only — screen contents can contain anything, so this must never
+    touch disk (mss.tools.to_png builds the PNG in memory; no temp file).
+    """
+    import mss
+    import mss.tools
+
+    with mss.mss() as sct:
+        area = sct.monitors[0] if region is None else {
+            "left": region[0], "top": region[1],
+            "width": region[2], "height": region[3],
+        }
+        shot = sct.grab(area)
+        return mss.tools.to_png(shot.rgb, shot.size)
+
+
+# ---- WinRT availability --------------------------------------------------------
+
+def winrt_available() -> bool:
+    try:
+        import winrt.windows.media.ocr  # noqa: F401
+        import winrt.windows.media.speechsynthesis  # noqa: F401
+        return True
+    except Exception:
+        return False
+
+
+def winrt_selftest() -> tuple[bool, str]:
+    """Activate both WinRT namespaces used here from a FROZEN build and report
+    PASS/FAIL. This is spike 1, made permanent as a CI gate (`--winrt-selftest`):
+    a broken PyInstaller bundle then fails the build instead of shipping."""
+    try:
+        from winrt.windows.media.ocr import OcrEngine
+        from winrt.windows.media.speechsynthesis import SpeechSynthesizer
+    except Exception as exc:
+        return False, f"FAIL: winrt import: {type(exc).__name__}: {exc}"
+    try:
+        engine = OcrEngine.try_create_from_user_profile_languages()
+        voices = list(SpeechSynthesizer.all_voices)
+    except Exception as exc:
+        return False, f"FAIL: winrt activation: {type(exc).__name__}: {exc}"
+    if engine is None:
+        return False, "FAIL: no OCR engine for this profile's languages"
+    if not voices:
+        return False, "FAIL: no speech voices installed"
+    return True, f"PASS: ocr engine activated, {len(voices)} voice(s)"
+
+
+# ---- OCR -----------------------------------------------------------------------
+
+def ocr_png(png_bytes: bytes, *, language: str = "") -> str:
+    """Recognize text in a PNG via Windows.Media.Ocr. Raises ReadAloudError,
+    never a raw winrt/asyncio exception, so callers have one thing to catch."""
+    try:
+        import asyncio
+
+        from winrt.windows.globalization import Language
+        from winrt.windows.graphics.imaging import BitmapDecoder
+        from winrt.windows.media.ocr import OcrEngine
+        from winrt.windows.storage.streams import DataWriter, InMemoryRandomAccessStream
+    except Exception as exc:
+        raise ReadAloudError(f"OCR unavailable: {exc}") from exc
+
+    async def run() -> str:
+        stream = InMemoryRandomAccessStream()
+        writer = DataWriter(stream.get_output_stream_at(0))
+        # bytes straight through where the projection accepts it. A whole-screen
+        # PNG is megabytes, and list(png_bytes) built a Python list of millions
+        # of ints before anything was written.
+        try:
+            writer.write_bytes(png_bytes)
+        except TypeError:
+            writer.write_bytes(list(png_bytes))
+        await writer.store_async()
+        await writer.flush_async()
+        stream.seek(0)
+        decoder = await BitmapDecoder.create_async(stream)
+        bitmap = await decoder.get_software_bitmap_async()
+        engine = (
+            OcrEngine.try_create_from_language(Language(language)) if language
+            else OcrEngine.try_create_from_user_profile_languages()
+        )
+        if engine is None:
+            raise ReadAloudError("no OCR engine for this profile's languages")
+        result = await engine.recognize_async(bitmap)
+        return result.text
+
+    try:
+        text = asyncio.run(run())
+    except ReadAloudError:
+        raise
+    except Exception as exc:
+        raise ReadAloudError(f"OCR failed: {exc}") from exc
+    return " ".join((text or "").split())
+
+
+# ---- speech ----------------------------------------------------------------
+
+class Speaker:
+    """Speaks text via Windows.Media.SpeechSynthesis, interruptible.
+
+    ``player_factory`` is injected so the state machine (stop/pause/resume) is
+    testable on Linux with a fake player: real code passes None and gets a
+    winrt MediaPlayer; tests pass a fake that records calls.
+
+    Stopping calls the player's own pause/stop SYNCHRONOUSLY, on the calling
+    thread — the ~200ms interrupt requirement holds because pausing playback is
+    near-instant regardless of how long the remaining text is, unlike a design
+    that waits for the current sentence to finish before checking a flag.
+    """
+
+    def __init__(self, *, voice: str = "", rate: float = 1.0,
+                 player_factory: Optional[Callable[[], object]] = None):
+        self.voice = voice
+        self.rate = max(0.5, min(2.0, float(rate or 1.0)))
+        self._player_factory = player_factory
+        self._lock = threading.Lock()
+        self._player = None
+        self._stopped = False
+        self.paused = False
+
+    def speak(self, text: str) -> None:
+        text = " ".join((text or "").split())
+        if not text:
+            raise ReadAloudError("nothing to read")
+        try:
+            player = self._build_player(text)
+        except ReadAloudError:
+            raise
+        except Exception as exc:
+            raise ReadAloudError(f"speech unavailable: {exc}") from exc
+        with self._lock:
+            if self._stopped:
+                self._stop_player(player)
+                return
+            self._player = player
+        try:
+            self._play(player)
+        except Exception:
+            # Do not leave a dead player as the live one - stop() would then
+            # think something is speaking and pause a player that never played.
+            with self._lock:
+                if self._player is player:
+                    self._player = None
+            self._stop_player(player)
+            raise
+
+    def pause(self) -> None:
+        with self._lock:
+            player = self._player
+        self.paused = True
+        if player is not None:
+            try:
+                player.pause()
+            except Exception as exc:
+                log.info("read-aloud: pause failed: %s", exc)
+
+    def resume(self) -> None:
+        with self._lock:
+            player = self._player
+        self.paused = False
+        if player is not None:
+            try:
+                player.play()
+            except Exception as exc:
+                log.info("read-aloud: resume failed: %s", exc)
+
+    def stop(self) -> None:
+        with self._lock:
+            self._stopped = True
+            player, self._player = self._player, None
+        self._stop_player(player)
+
+    @staticmethod
+    def _stop_player(player) -> None:
+        """Pause FIRST, then release. Pause is what makes the interrupt feel
+        instant; close is what stops every read leaking a MediaPlayer and its
+        audio resources, which pausing alone never did."""
+        if player is None:
+            return
+        try:
+            player.pause()
+        except Exception as exc:
+            log.info("read-aloud: stop failed: %s", exc)
+        for method in ("close", "Close"):
+            closer = getattr(player, method, None)
+            if closer is None:
+                continue
+            try:
+                closer()
+            except Exception as exc:
+                log.info("read-aloud: could not release the player: %s", exc)
+            break
+
+    def _build_player(self, text: str):
+        if self._player_factory is not None:
+            return self._player_factory()
+
+        from winrt.windows.media.core import MediaSource
+        from winrt.windows.media.playback import MediaPlayer
+        from winrt.windows.media.speechsynthesis import SpeechSynthesizer
+
+        import asyncio
+
+        async def synth():
+            synthesizer = SpeechSynthesizer()
+            if self.voice:
+                for v in SpeechSynthesizer.all_voices:
+                    if v.display_name == self.voice or v.id == self.voice:
+                        synthesizer.voice = v
+                        break
+            try:
+                synthesizer.options.speaking_rate = self.rate
+            except Exception:
+                pass
+            return await synthesizer.synthesize_text_to_stream_async(text)
+
+        stream = asyncio.run(synth())
+        player = MediaPlayer()
+        player.source = MediaSource.create_from_stream(stream, stream.content_type)
+        return player
+
+    @staticmethod
+    def _play(player) -> None:
+        try:
+            player.play()
+        except Exception as exc:
+            raise ReadAloudError(f"playback failed: {exc}") from exc
+
+
+# ---- screen reader detection (informational only — never gates speaking) -----
+
+def screen_reader_running() -> bool:
+    """Best-effort SPI_GETSCREENREADER check. Unreliable by design (Microsoft
+    documents it as not set consistently), so this only feeds the OPT-OUT
+    setting — Read Aloud speaks regardless unless the user has turned that on."""
+    try:
+        import ctypes.wintypes as wintypes
+
+        SPI_GETSCREENREADER = 0x0046
+        # wintypes.BOOL, NOT ctypes.c_bool. Win32 BOOL is a 4-byte int; c_bool
+        # is ONE byte, so SystemParametersInfoW would write three bytes past
+        # the buffer. A silent stack smash in an accessibility code path.
+        value = wintypes.BOOL()
+        ok = ctypes.windll.user32.SystemParametersInfoW(
+            SPI_GETSCREENREADER, 0, ctypes.byref(value), 0)
+        return bool(ok) and bool(value.value)
+    except Exception:
+        return False
+
+
+def should_speak(*, quiet_with_screenreader: bool) -> bool:
+    """Speak always, unless the user opted into staying quiet AND a screen
+    reader is (as best as can be told) actually running."""
+    if not quiet_with_screenreader:
+        return True
+    return not screen_reader_running()
+
+
+def main() -> None:
+    """`--winrt-selftest` entry point: one PASS/FAIL line, exit non-zero on
+    failure. CI runs this against the BUILT EXE and fails the build on it —
+    this is spike 1, made permanent."""
+    import sys
+
+    ok, message = winrt_selftest()
+    print(message)
+    sys.exit(0 if ok else 1)

--- a/wisprlite/settings.py
+++ b/wisprlite/settings.py
@@ -726,6 +726,12 @@ def main(first_run: bool = False) -> None:
     bookmark_acoustic_var = tk.BooleanVar(value=cfg.bookmark_acoustic)
     bookmark_sensitivity_var = tk.DoubleVar(value=cfg.bookmark_sensitivity)
     bookmark_phrases_var = tk.StringVar(value=cfg.bookmark_phrases)
+    read_aloud_hotkey_var = tk.StringVar(value=cfg.read_aloud_hotkey)
+    read_aloud_voice_var = tk.StringVar(value=cfg.read_aloud_voice)
+    read_aloud_rate_var = tk.StringVar(value=str(cfg.read_aloud_rate))
+    read_aloud_lang_var = tk.StringVar(value=cfg.read_aloud_ocr_language)
+    read_aloud_clipboard_var = tk.BooleanVar(value=cfg.read_aloud_clipboard)
+    read_aloud_quiet_var = tk.BooleanVar(value=cfg.read_aloud_quiet_with_screenreader)
     lang_var = tk.StringVar(value=dict(LANGUAGES).get(cfg.language, LANGUAGES[0][1]))
     show_all_devices_var = tk.BooleanVar(value=False)
     devices = _input_devices()
@@ -1125,6 +1131,32 @@ def main(first_run: bool = False) -> None:
               "10-15 is realistic at 1080p. Higher costs CPU on the machine you are "
               "recording, which is the same one running what you are showing."),
           screenrec_fps_var, width=6)
+
+    # --- Read Aloud: press the hotkey, have the screen read to you ---
+    c = card(
+        "Read Aloud",
+        "For text a screen reader can't reach — an image, a canvas, a scanned "
+        "PDF. Tap = the focused window, +Shift = the whole screen, +Ctrl = drag "
+        "a region. Speaks even with a screen reader running, unless you turn "
+        "that off below.",
+    )
+    r = row(c, "Read Aloud hotkey", "Blank turns the feature off.")
+    entry(r, read_aloud_hotkey_var, width=14)
+    ra_cap_btn = ttk.Button(r, text="Capture", width=8)
+    ra_cap_btn.pack(side="left", padx=(8, 0))
+    ra_cap_btn.config(command=_mk_capture(ra_cap_btn, read_aloud_hotkey_var))
+    entry(row(c, "Voice", "Blank uses the system default voice."),
+          read_aloud_voice_var, width=28)
+    entry(row(c, "Speed", "0.5 (slow) to 2.0 (fast). 1.0 is normal."),
+          read_aloud_rate_var, width=6)
+    entry(row(c, "OCR language",
+              "e.g. en-US. Blank uses your Windows display language."),
+          read_aloud_lang_var, width=10)
+    check(c, "Also copy the recognized text to the clipboard", read_aloud_clipboard_var,
+          "On by default. The overlay always says when it copied.")
+    check(c, "Stay quiet while a screen reader is running", read_aloud_quiet_var,
+          "Off by default — the hotkey is usually pressed because the screen "
+          "reader can't read that spot, so silence there defeats the feature.")
 
     c = card("Audio")
     mic_row = row(c, "Microphone")
@@ -1690,6 +1722,15 @@ def main(first_run: bool = False) -> None:
             cfg.screenrec_fps = max(1, min(60, int(screenrec_fps_var.get().strip() or 12)))
         except ValueError:
             cfg.screenrec_fps = 12
+        cfg.read_aloud_hotkey = read_aloud_hotkey_var.get().strip()
+        cfg.read_aloud_voice = read_aloud_voice_var.get().strip()
+        try:
+            cfg.read_aloud_rate = max(0.5, min(2.0, float(read_aloud_rate_var.get().strip() or 1.0)))
+        except ValueError:
+            cfg.read_aloud_rate = 1.0
+        cfg.read_aloud_ocr_language = read_aloud_lang_var.get().strip()
+        cfg.read_aloud_clipboard = bool(read_aloud_clipboard_var.get())
+        cfg.read_aloud_quiet_with_screenreader = bool(read_aloud_quiet_var.get())
         cfg.bookmark_hotkey = bookmark_hotkey_var.get().strip()
         cfg.bookmark_acoustic = bool(bookmark_acoustic_var.get())
         cfg.bookmark_phrases = bookmark_phrases_var.get().strip()


### PR DESCRIPTION
Press a hotkey, capture part of the screen, hear it read aloud. For people who struggle to read, and for accessibility generally — r/accessibility was one of only two live communities the research run surfaced on this topic.

Spec: `vault/Plans/pipevoice-read-aloud.md` (5 blind proposals → brain judging → `idea-panel` critique).

### What it does
| Input | Captures |
|---|---|
| hotkey | the **focused window** — the default, because drag-to-select assumes a mouse this audience may not have |
| +Shift | the whole screen |
| +Ctrl | drag a region, via the existing `screenrec.select_region()` |

OCR and speech both from WinRT — offline, no key, no download, and the modern natural voices SAPI's legacy ones don't reach. **`winrt-*` at 3.2.1, not `winsdk`** (that's 1.0.0b10, a beta, which every proposer named).

**It speaks even with NVDA running.** The panel killed the opposite rule and was right: a blind user triggers OCR *precisely because* the screen reader can't read that region. Silence there defeats the feature at the moment it's needed. Opt-out exists, default OFF.

### Spike 1 is a CI gate, not a hope
`--winrt-selftest` activates both namespaces; the release workflow runs it **against the built exe** and fails the build on non-zero. Verifying `winrt-*` on PyPI was a *version* check — this is the *bundling* check, and that difference shipped a broken FastMCP exe to a user this week.

### Six bugs found in review, none by the builder
Four by me reading the diff, two by `/jury`. Each verified red by sabotage.

1. **Three-byte buffer overflow** — `SPI_GETSCREENREADER` writes a Win32 `BOOL` (4 bytes) into a `ctypes.c_bool` (1 byte). A silent stack smash, in an accessibility code path.
2. `list(png_bytes)` expanded a whole-screen PNG into a Python list of millions of ints before writing a byte.
3. Every read leaked a `MediaPlayer` — paused, never released.
4. A failed `play()` left the dead player assigned as live, so a later stop would pause something that never played.
5. **A second press during the OCR pass started a second read** — the mid-read check reads `_read_aloud_speaker`, still `None` until speech begins. Two threads raced; you'd hear both. Now locked, released in a `finally` so a read that finds no text can't kill the hotkey for the session.
6. `Speaker` is single-use — deliberately, since the latch is what makes an Esc during OCR stick. That was undocumented, so a future "repeat last" would have silently no-op'd. Now stated and pinned.

One P3 refuted with reasoning in the commit.

### Verification
- Suite **431 passed** (was 402), same 15 pre-existing failures.
- **Not verifiable here:** whether WinRT bundles (the CI gate answers that on this PR's build) and whether Windows OCR is good enough on real UI text — that's James's ten minutes, against the >25% error kill criterion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)