### PR TITLE
fix(ci): make the WinRT gate say why it failed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,9 +96,19 @@ jobs:
         shell: pwsh
         run: |
           $exe = "dist/Pipevoice/Pipevoice.exe"
+          # The exe is built --noconsole, so its stdout does not reach this log.
+          # Have it write the verdict to a file and print that, or a failure here
+          # is a red build with no reason attached.
+          $env:PV_SELFTEST_OUT = "$PWD\winrt-selftest.txt"
           & $exe --winrt-selftest
-          if ($LASTEXITCODE -ne 0) {
-            Write-Host "winrt self-test failed — Read Aloud would silently do nothing."
+          $code = $LASTEXITCODE
+          if (Test-Path $env:PV_SELFTEST_OUT) {
+            Write-Host "winrt self-test: $(Get-Content $env:PV_SELFTEST_OUT -Raw)"
+          } else {
+            Write-Host "winrt self-test wrote no result file (exit $code)"
+          }
+          if ($code -ne 0) {
+            Write-Host "Read Aloud would silently do nothing in this build."
             exit 1
           }
 

--- a/tests/test_readaloud.py
+++ b/tests/test_readaloud.py
@@ -380,3 +380,36 @@ def test_a_speaker_is_one_shot_and_says_so():
 
     assert "ONE-SHOT" in readaloud.Speaker.speak.__doc__, \
         "the one-shot contract is not documented on speak()"
+
+
+def test_the_selftest_writes_its_verdict_to_a_file():
+    """The release exe is built --noconsole, so stdout does not reach the CI log.
+    The first real run of this gate failed the build correctly and printed
+    nothing - a red build with no reason attached."""
+    import os
+    from unittest import mock
+    import pytest
+    from wisprlite import readaloud
+
+    with mock.patch.object(readaloud, "winrt_selftest", return_value=(False, "FAIL: no voices")):
+        import tempfile
+        path = os.path.join(tempfile.mkdtemp(), "verdict.txt")
+        with mock.patch.dict(os.environ, {"PV_SELFTEST_OUT": path}):
+            with pytest.raises(SystemExit) as exit_info:
+                readaloud.main()
+        assert exit_info.value.code == 1
+        assert open(path, encoding="utf-8").read().strip() == "FAIL: no voices"
+
+
+def test_a_failure_to_write_the_verdict_does_not_change_it():
+    """Reporting must never turn a FAIL into a PASS or vice versa."""
+    import os
+    from unittest import mock
+    import pytest
+    from wisprlite import readaloud
+
+    with mock.patch.object(readaloud, "winrt_selftest", return_value=(True, "PASS: ok")), \
+         mock.patch.dict(os.environ, {"PV_SELFTEST_OUT": "/nonexistent-dir/verdict.txt"}):
+        with pytest.raises(SystemExit) as exit_info:
+            readaloud.main()
+    assert exit_info.value.code == 0, "a write failure flipped the verdict"

--- a/wisprlite/__init__.py
+++ b/wisprlite/__init__.py
@@ -1,3 +1,3 @@
 """Pipevoice — push-to-talk voice typing for Windows."""
 
-__version__ = "2.45.0"
+__version__ = "2.45.1"

--- a/wisprlite/readaloud.py
+++ b/wisprlite/readaloud.py
@@ -346,9 +346,24 @@ def should_speak(*, quiet_with_screenreader: bool) -> bool:
 def main() -> None:
     """`--winrt-selftest` entry point: one PASS/FAIL line, exit non-zero on
     failure. CI runs this against the BUILT EXE and fails the build on it —
-    this is spike 1, made permanent."""
+    this is spike 1, made permanent.
+
+    The result is also written to a FILE, because the release exe is built
+    `--noconsole`: the first real run of this gate failed the build correctly
+    and printed nothing, so nobody could tell whether it was a missing module,
+    a dead activation, or simply no voices on the runner. A gate that fails
+    without saying why is half a gate.
+    """
+    import os
     import sys
 
     ok, message = winrt_selftest()
     print(message)
+    out = os.environ.get("PV_SELFTEST_OUT")
+    if out:
+        try:
+            with open(out, "w", encoding="utf-8") as f:
+                f.write(message + "\n")
+        except Exception as exc:      # never let reporting change the verdict
+            print(f"(could not write {out}: {exc})")
     sys.exit(0 if ok else 1)


### PR DESCRIPTION
The gate worked on its first real run — v2.45.0's build went red and Read Aloud never reached beta, which is exactly the point. But it **printed nothing**: the release exe is built `--noconsole`, so its stdout never reaches the CI log.

So "why" was unknown. A missing module, a dead WinRT activation, and simply no speech voices on a GitHub Actions runner are three different problems with three different fixes.

`--winrt-selftest` now also writes its verdict to `PV_SELFTEST_OUT`, and CI prints that file on pass or fail. Writing the file can never change the verdict — tested.

Suite 433 passed, same 15 pre-existing failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)