### PR TITLE
fix(ci): the WinRT gate never waited for the exe

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,18 +96,24 @@ jobs:
         shell: pwsh
         run: |
           $exe = "dist/Pipevoice/Pipevoice.exe"
-          # The exe is built --noconsole, so its stdout does not reach this log.
-          # Have it write the verdict to a file and print that, or a failure here
-          # is a red build with no reason attached.
+          # Start-Process -Wait -PassThru, exactly like the MCP smoke test above.
+          # `& $exe` does NOT work here: the exe is a GUI-subsystem binary
+          # (--noconsole), so PowerShell launches it and moves on without
+          # waiting, leaving $LASTEXITCODE EMPTY. The first two runs of this
+          # gate failed for that reason and were misread as a WinRT failure.
           $env:PV_SELFTEST_OUT = "$PWD\winrt-selftest.txt"
-          & $exe --winrt-selftest
-          $code = $LASTEXITCODE
-          if (Test-Path $env:PV_SELFTEST_OUT) {
-            Write-Host "winrt self-test: $(Get-Content $env:PV_SELFTEST_OUT -Raw)"
-          } else {
-            Write-Host "winrt self-test wrote no result file (exit $code)"
-          }
-          if ($code -ne 0) {
+          $p = Start-Process $exe -ArgumentList '--winrt-selftest' `
+                 -RedirectStandardOutput winrt_out.txt `
+                 -RedirectStandardError winrt_err.txt `
+                 -Wait -PassThru -WindowStyle Hidden
+          $verdict = Get-Content $env:PV_SELFTEST_OUT -Raw -ErrorAction SilentlyContinue
+          $out = Get-Content winrt_out.txt -Raw -ErrorAction SilentlyContinue
+          $err = Get-Content winrt_err.txt -Raw -ErrorAction SilentlyContinue
+          Write-Host "winrt self-test exit: $($p.ExitCode)"
+          if ($verdict) { Write-Host "verdict: $verdict" }
+          if ($out) { Write-Host "stdout:`n$out" }
+          if ($err) { Write-Host "stderr:`n$err" }
+          if ($p.ExitCode -ne 0) {
             Write-Host "Read Aloud would silently do nothing in this build."
             exit 1
           }

--- a/tests/test_installer_version.py
+++ b/tests/test_installer_version.py
@@ -86,3 +86,20 @@ def test_the_winget_manifest_hash_and_url_name_the_same_release():
     assert sha, "InstallerSha256 is missing or not a 64-char hex digest"
     assert sha.group(1).isupper() or not sha.group(1).isalpha(), \
         "winget expects the SHA-256 uppercase"
+
+
+def test_the_winrt_gate_waits_for_the_gui_exe():
+    """`& $exe` does not wait for a --noconsole binary, so $LASTEXITCODE is
+    EMPTY and the gate fails for a PowerShell reason rather than a WinRT one.
+    The MCP smoke test in the same file already used Start-Process -PassThru;
+    this one has to as well."""
+    text = WORKFLOW.read_text(encoding="utf-8")
+    step = text[text.index("Self-test WinRT"):]
+    step = step[:step.index("- name:", 10)] if "- name:" in step[10:] else step
+    # Comments explain WHY $LASTEXITCODE is wrong here, so assert on the code.
+    code = "\n".join(l for l in step.splitlines() if not l.strip().startswith("#"))
+
+    assert "Start-Process" in code and "-Wait" in code and "-PassThru" in code, \
+        "the WinRT gate does not wait for the exe, so its exit code is meaningless"
+    assert "$LASTEXITCODE" not in code, \
+        "$LASTEXITCODE is empty for a GUI-subsystem exe launched with &"

--- a/wisprlite/__init__.py
+++ b/wisprlite/__init__.py
@@ -1,3 +1,3 @@
 """Pipevoice — push-to-talk voice typing for Windows."""
 
-__version__ = "2.45.1"
+__version__ = "2.45.2"


### PR DESCRIPTION
Two red builds blamed on WinRT were a PowerShell problem.

`& $exe` does not wait for a GUI-subsystem binary, and the release exe is built `--noconsole`. PowerShell launched it, moved on 0.4s later, and left `$LASTEXITCODE` **empty** — which is `-ne 0`, so the gate failed every time regardless of what WinRT actually did. The second run made this visible: `winrt self-test wrote no result file (exit )`.

The MCP smoke test in the same file already solved this with `Start-Process -PassThru` and redirected output. I wrote a weaker version instead of reusing the pattern eight lines above it.

Now uses `Start-Process -Wait -PassThru`, prints the exit code, the verdict file, stdout and stderr. A test asserts the step waits and does not use `$LASTEXITCODE` — checking the code, not the comments that explain why.

**This does not yet tell us whether WinRT bundles.** It means the next build finally asks the question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)