### PR TITLE
fix(ci): bound the WinRT gate's wait — a bare -Wait hung the build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,18 +102,30 @@ jobs:
           # waiting, leaving $LASTEXITCODE EMPTY. The first two runs of this
           # gate failed for that reason and were misread as a WinRT failure.
           $env:PV_SELFTEST_OUT = "$PWD\winrt-selftest.txt"
+          # -PassThru + Wait-Process -Timeout, never a bare -Wait. A GUI exe
+          # that never exits hangs -Wait for ever: this step sat in_progress for
+          # 30+ minutes on its first run and had to be cancelled by hand. A gate
+          # that can block the build indefinitely is worse than no gate.
           $p = Start-Process $exe -ArgumentList '--winrt-selftest' `
                  -RedirectStandardOutput winrt_out.txt `
                  -RedirectStandardError winrt_err.txt `
-                 -Wait -PassThru -WindowStyle Hidden
+                 -PassThru -WindowStyle Hidden
+          $timedOut = $false
+          try {
+            Wait-Process -Id $p.Id -Timeout 90 -ErrorAction Stop
+          } catch {
+            $timedOut = $true
+            try { $p.Kill() } catch { }
+          }
           $verdict = Get-Content $env:PV_SELFTEST_OUT -Raw -ErrorAction SilentlyContinue
           $out = Get-Content winrt_out.txt -Raw -ErrorAction SilentlyContinue
           $err = Get-Content winrt_err.txt -Raw -ErrorAction SilentlyContinue
-          Write-Host "winrt self-test exit: $($p.ExitCode)"
+          if ($timedOut) { Write-Host "winrt self-test: TIMED OUT after 90s" }
+          else { Write-Host "winrt self-test exit: $($p.ExitCode)" }
           if ($verdict) { Write-Host "verdict: $verdict" }
           if ($out) { Write-Host "stdout:`n$out" }
           if ($err) { Write-Host "stderr:`n$err" }
-          if ($p.ExitCode -ne 0) {
+          if ($timedOut -or $p.ExitCode -ne 0) {
             Write-Host "Read Aloud would silently do nothing in this build."
             exit 1
           }

--- a/tests/test_installer_version.py
+++ b/tests/test_installer_version.py
@@ -99,7 +99,13 @@ def test_the_winrt_gate_waits_for_the_gui_exe():
     # Comments explain WHY $LASTEXITCODE is wrong here, so assert on the code.
     code = "\n".join(l for l in step.splitlines() if not l.strip().startswith("#"))
 
-    assert "Start-Process" in code and "-Wait" in code and "-PassThru" in code, \
-        "the WinRT gate does not wait for the exe, so its exit code is meaningless"
+    assert "Start-Process" in code and "-PassThru" in code, \
+        "the WinRT gate does not capture the process, so its exit code is meaningless"
     assert "$LASTEXITCODE" not in code, \
         "$LASTEXITCODE is empty for a GUI-subsystem exe launched with &"
+    # A bare -Wait hangs for ever on a GUI exe that never exits; the first run
+    # of this gate sat in_progress for 30+ minutes and had to be cancelled.
+    assert "Wait-Process" in code and "-Timeout" in code, \
+        "the gate can hang the build for ever - it needs a bounded wait"
+    assert "-Wait " not in code and not code.rstrip().endswith("-Wait"), \
+        "a bare -Wait on a GUI exe is an unbounded hang"

--- a/wisprlite/__init__.py
+++ b/wisprlite/__init__.py
@@ -1,3 +1,3 @@
 """Pipevoice — push-to-talk voice typing for Windows."""
 
-__version__ = "2.45.2"
+__version__ = "2.45.3"


### PR DESCRIPTION
The v2.45.2 build sat `in_progress` on the self-test step for **30+ minutes** and had to be cancelled by hand. `Start-Process -Wait` on a GUI exe that never exits waits for ever.

A gate that can hang the build indefinitely is worse than no gate — it blocks every release, not just a broken one.

Now `-PassThru` plus `Wait-Process -Timeout 90`, killing the process and failing the step on timeout with `TIMED OUT after 90s` in the log. A test asserts the step uses a bounded wait and rejects a bare `-Wait`; verified red by putting the bare `-Wait` back.

Third fix to this gate. In order: it printed nothing (`--noconsole`), then it never waited (`$LASTEXITCODE` empty), now it waited for ever. **It still has not told us whether WinRT bundles** — that is the point of the next build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)