### PR TITLE
fix(ci): make the WinRT hang diagnosable

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,7 +120,13 @@ jobs:
           $verdict = Get-Content $env:PV_SELFTEST_OUT -Raw -ErrorAction SilentlyContinue
           $out = Get-Content winrt_out.txt -Raw -ErrorAction SilentlyContinue
           $err = Get-Content winrt_err.txt -Raw -ErrorAction SilentlyContinue
-          if ($timedOut) { Write-Host "winrt self-test: TIMED OUT after 90s" }
+          if ($timedOut) {
+            Write-Host "winrt self-test: TIMED OUT after 90s"
+            # The progress markers are the ONLY evidence a hang leaves. The last
+            # one written names the step that blocked.
+            if ($verdict) { Write-Host "last step reached:`n$verdict" }
+            else { Write-Host "no progress markers - it hung before the first step" }
+          }
           else { Write-Host "winrt self-test exit: $($p.ExitCode)" }
           if ($verdict) { Write-Host "verdict: $verdict" }
           if ($out) { Write-Host "stdout:`n$out" }

--- a/tests/test_readaloud.py
+++ b/tests/test_readaloud.py
@@ -413,3 +413,51 @@ def test_a_failure_to_write_the_verdict_does_not_change_it():
         with pytest.raises(SystemExit) as exit_info:
             readaloud.main()
     assert exit_info.value.code == 0, "a write failure flipped the verdict"
+
+
+def test_the_selftest_reports_progress_before_each_step():
+    """The first real run of this gate HUNG - no stdout, no stderr, no verdict -
+    so there was no way to tell whether the import, the OCR activation or the
+    voice enumeration blocked. A hang has to leave a trail or it cannot be
+    diagnosed."""
+    from unittest import mock
+    from wisprlite import readaloud
+
+    seen = []
+    with mock.patch.dict(sys.modules, {
+        "winrt": mock.Mock(),
+        "winrt.windows": mock.Mock(),
+        "winrt.windows.media": mock.Mock(),
+        "winrt.windows.media.ocr": mock.Mock(OcrEngine=mock.Mock(
+            try_create_from_user_profile_languages=mock.Mock(return_value=object()))),
+        "winrt.windows.media.speechsynthesis": mock.Mock(SpeechSynthesizer=mock.Mock(
+            all_voices=[object()])),
+    }):
+        ok, _msg = readaloud.winrt_selftest(progress=seen.append)
+
+    assert ok is True
+    assert seen[0] == "start", f"no marker before the first import: {seen}"
+    for expected in ("import-ocr", "import-speech", "create-ocr-engine", "list-voices"):
+        assert expected in seen, f"no marker for {expected}: {seen}"
+
+
+def test_instrumentation_cannot_change_the_verdict():
+    """A progress callback that raises must not turn a PASS into a FAIL."""
+    from unittest import mock
+    from wisprlite import readaloud
+
+    def boom(_marker):
+        raise RuntimeError("logging blew up")
+
+    with mock.patch.dict(sys.modules, {
+        "winrt": mock.Mock(),
+        "winrt.windows": mock.Mock(),
+        "winrt.windows.media": mock.Mock(),
+        "winrt.windows.media.ocr": mock.Mock(OcrEngine=mock.Mock(
+            try_create_from_user_profile_languages=mock.Mock(return_value=object()))),
+        "winrt.windows.media.speechsynthesis": mock.Mock(SpeechSynthesizer=mock.Mock(
+            all_voices=[object()])),
+    }):
+        ok, _ = readaloud.winrt_selftest(progress=boom)
+
+    assert ok is True, "a failing progress callback flipped the verdict"

--- a/wisprlite/__init__.py
+++ b/wisprlite/__init__.py
@@ -1,3 +1,3 @@
 """Pipevoice — push-to-talk voice typing for Windows."""
 
-__version__ = "2.45.3"
+__version__ = "2.45.4"

--- a/wisprlite/readaloud.py
+++ b/wisprlite/readaloud.py
@@ -98,20 +98,42 @@ def winrt_available() -> bool:
         return False
 
 
-def winrt_selftest() -> tuple[bool, str]:
+def winrt_selftest(progress: Optional[Callable[[str], None]] = None) -> tuple[bool, str]:
     """Activate both WinRT namespaces used here from a FROZEN build and report
     PASS/FAIL. This is spike 1, made permanent as a CI gate (`--winrt-selftest`):
-    a broken PyInstaller bundle then fails the build instead of shipping."""
+    a broken PyInstaller bundle then fails the build instead of shipping.
+
+    `progress` is called with a marker before EACH step. The first real run of
+    this gate did not crash - it HUNG, with no stdout, no stderr and no verdict,
+    so there was no way to tell whether the import, the OCR activation or the
+    voice enumeration was the thing that blocked. A hang has to leave a trail or
+    it is unfalsifiable.
+    """
+    def step(name: str) -> None:
+        if progress is not None:
+            try:
+                progress(name)
+            except Exception:
+                pass    # instrumentation must never change the verdict
+
+    step("start")
     try:
+        step("import-ocr")
         from winrt.windows.media.ocr import OcrEngine
+        step("import-speech")
         from winrt.windows.media.speechsynthesis import SpeechSynthesizer
     except Exception as exc:
         return False, f"FAIL: winrt import: {type(exc).__name__}: {exc}"
+
     try:
+        step("create-ocr-engine")
         engine = OcrEngine.try_create_from_user_profile_languages()
+        step("list-voices")
         voices = list(SpeechSynthesizer.all_voices)
+        step("done")
     except Exception as exc:
         return False, f"FAIL: winrt activation: {type(exc).__name__}: {exc}"
+
     if engine is None:
         return False, "FAIL: no OCR engine for this profile's languages"
     if not voices:
@@ -357,13 +379,29 @@ def main() -> None:
     import os
     import sys
 
-    ok, message = winrt_selftest()
-    print(message)
     out = os.environ.get("PV_SELFTEST_OUT")
+    handle = None
     if out:
         try:
-            with open(out, "w", encoding="utf-8") as f:
-                f.write(message + "\n")
+            handle = open(out, "w", encoding="utf-8", buffering=1)
+        except Exception as exc:
+            print(f"(could not open {out}: {exc})")
+
+    def progress(marker: str) -> None:
+        # Flushed per line: on a HANG the file is the only evidence there is,
+        # and a buffered write would be lost when the process is killed.
+        if handle is not None:
+            handle.write(f"step: {marker}\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+
+    ok, message = winrt_selftest(progress=progress)
+    print(message)
+    if handle is not None:
+        try:
+            handle.write(message + "\n")
+            handle.flush()
+            handle.close()
         except Exception as exc:      # never let reporting change the verdict
             print(f"(could not write {out}: {exc})")
     sys.exit(0 if ok else 1)


### PR DESCRIPTION
First real signal from the gate: the exe **hangs**. It does not crash — no stdout, no stderr, no verdict file, killed at the 90s timeout.

So we still cannot tell whether the `winrt` import, the OCR engine activation, or the voice enumeration is what blocks. Those are three different problems.

`winrt_selftest()` now writes a progress marker before every step, flushed and `fsync`ed per line, because on a hang the file is the only evidence that survives the kill. On timeout CI prints the last marker reached — that names the blocking step directly instead of me guessing at it.

Instrumentation can never change the verdict; tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)