### PR TITLE
fix: the shipped exe could never run its own WinRT self-test

### DIFF
--- a/launch.py
+++ b/launch.py
@@ -1,6 +1,12 @@
 """Entry point for `python launch.py` and for PyInstaller builds.
 
 Pass --settings to open the settings window instead of the app.
+
+THIS is what PyInstaller freezes - not wisprlite/__main__.py, which exists for
+`python -m wisprlite`. The two dispatch tables must list the same flags: a flag
+added only to __main__.py works when run from source and silently falls through
+to the tray app in the shipped exe, which then never exits. That cost five red
+builds misread as a WinRT failure. tests/test_entrypoints.py pins them together.
 """
 
 import sys
@@ -23,6 +29,8 @@ elif "--mcp" in sys.argv:
     from wisprlite.mcp_shim import main
 elif "--feedback" in sys.argv:
     from wisprlite.feedback import main
+elif "--winrt-selftest" in sys.argv:
+    from wisprlite.readaloud import main
 else:
     from wisprlite.app import main
 

--- a/tests/test_entrypoints.py
+++ b/tests/test_entrypoints.py
@@ -1,0 +1,48 @@
+"""launch.py and wisprlite/__main__.py must dispatch the same flags.
+
+PyInstaller freezes launch.py. `python -m wisprlite` runs __main__.py. A flag
+added to only one of them works in development and silently does the WRONG thing
+in the shipped exe - it falls through to `else`, launching the tray app, which
+never exits.
+
+That is exactly what happened with --winrt-selftest: five CI builds failed and
+were read as "WinRT does not bundle" when the exe had simply never run the
+self-test at all.
+"""
+
+import pathlib
+import re
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+LAUNCH = ROOT / "launch.py"
+DUNDER = ROOT / "wisprlite" / "__main__.py"
+
+FLAG = re.compile(r'"(--[a-z0-9-]+)" in sys\.argv')
+
+
+def _flags(path: pathlib.Path) -> set:
+    return set(FLAG.findall(path.read_text(encoding="utf-8")))
+
+
+def test_both_entry_points_handle_the_same_flags():
+    launch, dunder = _flags(LAUNCH), _flags(DUNDER)
+    assert launch == dunder, (
+        "the two entry points disagree.\n"
+        f"  only in launch.py:     {sorted(launch - dunder)}\n"
+        f"  only in __main__.py:   {sorted(dunder - launch)}\n"
+        "A flag missing from launch.py silently launches the tray app in the "
+        "shipped exe instead of doing what was asked."
+    )
+
+
+def test_the_frozen_entry_point_is_the_one_ci_builds():
+    """If the workflow ever switches entry script, this test's premise dies."""
+    workflow = (ROOT / ".github" / "workflows" / "build.yml").read_text(encoding="utf-8")
+    assert "launch.py" in workflow, \
+        "CI no longer builds launch.py - update this test's assumption"
+
+
+def test_winrt_selftest_is_reachable_from_the_frozen_entry_point():
+    """The specific regression: the gate could never have run."""
+    assert "--winrt-selftest" in _flags(LAUNCH), \
+        "the shipped exe cannot run its own WinRT self-test"

--- a/wisprlite/__init__.py
+++ b/wisprlite/__init__.py
@@ -1,3 +1,3 @@
 """Pipevoice — push-to-talk voice typing for Windows."""
 
-__version__ = "2.45.4"
+__version__ = "2.45.5"


### PR DESCRIPTION
**Root cause of five red builds, and it was never WinRT.**

PyInstaller freezes `launch.py`. `--winrt-selftest` was added only to `wisprlite/__main__.py`, which exists for `python -m wisprlite`. So `Pipevoice.exe --winrt-selftest` fell through to `else:` and **launched the tray app** — which never exits. Hence a 90s timeout with no stdout, no stderr and no progress markers.

Every diagnosis built on that was wrong. The gate never tested WinRT once.

Two dispatch tables that must stay in sync is the duplicated-guard shape this project keeps hitting, so it is pinned now: `tests/test_entrypoints.py` fails if the two ever disagree, and separately if `--winrt-selftest` is unreachable from the frozen entry point. Verified red by removing the flag again.

The four earlier fixes were all real defects (silent output, no wait, unbounded hang, no progress trail) and the gate correctly kept Read Aloud off beta throughout — but the thing it was reporting on was itself the whole time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)