### PR TITLE
fix(read-aloud): declare winrt Foundation.Collections — the gate's first real catch

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,6 +28,11 @@ winrt-Windows.Media.Core>=3.2.1; sys_platform == "win32"
 winrt-Windows.Graphics.Imaging>=3.2.1; sys_platform == "win32"
 winrt-Windows.Storage.Streams>=3.2.1; sys_platform == "win32"
 winrt-Windows.Foundation>=3.2.1; sys_platform == "win32"
+# SpeechSynthesizer.all_voices returns an IVectorView, which lives in the
+# Collections namespace. Declaring Foundation does NOT bring it in, and the
+# frozen exe failed with ModuleNotFoundError only at the point of enumerating
+# voices - imports and OCR activation both succeeded first.
+winrt-Windows.Foundation.Collections>=3.2.1; sys_platform == "win32"
 winrt-Windows.Globalization>=3.2.1; sys_platform == "win32"
 
 # --- UI niceties ---

--- a/tests/test_installer_version.py
+++ b/tests/test_installer_version.py
@@ -109,3 +109,25 @@ def test_the_winrt_gate_waits_for_the_gui_exe():
         "the gate can hang the build for ever - it needs a bounded wait"
     assert "-Wait " not in code and not code.rstrip().endswith("-Wait"), \
         "a bare -Wait on a GUI exe is an unbounded hang"
+
+
+def test_every_winrt_namespace_the_code_touches_is_declared():
+    """A WinRT namespace that is used but not declared installs fine from a
+    transitive dependency in development and is MISSING from the frozen exe.
+    SpeechSynthesizer.all_voices returns an IVectorView from the Collections
+    namespace; declaring Foundation does not bring it in, and the failure only
+    appeared when enumerating voices - after imports and OCR both succeeded."""
+    reqs = (ROOT / "requirements.txt").read_text(encoding="utf-8").lower()
+    for namespace in (
+        "winrt-runtime",
+        "winrt-windows.media.ocr",
+        "winrt-windows.media.speechsynthesis",
+        "winrt-windows.media.playback",
+        "winrt-windows.media.core",
+        "winrt-windows.graphics.imaging",
+        "winrt-windows.storage.streams",
+        "winrt-windows.globalization",
+        "winrt-windows.foundation",
+        "winrt-windows.foundation.collections",
+    ):
+        assert namespace in reqs, f"{namespace} is used but not declared"

--- a/wisprlite/__init__.py
+++ b/wisprlite/__init__.py
@@ -1,3 +1,3 @@
 """Pipevoice — push-to-talk voice typing for Windows."""
 
-__version__ = "2.45.5"
+__version__ = "2.45.6"


### PR DESCRIPTION
The gate finally asked the question and got a precise answer:

```
step: start -> import-ocr -> import-speech -> create-ocr-engine -> list-voices
FAIL: winrt activation: ModuleNotFoundError: No module named 'winrt.windows.foundation.collections'
```

Imports fine. OCR engine activates fine. Then `SpeechSynthesizer.all_voices` returns an `IVectorView`, which lives in the **Collections** namespace — declaring `Foundation` does not bring it in.

This is precisely the FastMCP shape: a dependency that resolves transitively in development and is simply absent from the frozen exe. **Caught in CI instead of on a user's machine**, which is the entire reason the gate exists.

A test now asserts every WinRT namespace the code touches is declared in `requirements.txt`; verified red by deleting the new line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)