### PR TITLE
fix(read-aloud): it opened the selector and never spoke

### DIFF
--- a/tests/test_readaloud.py
+++ b/tests/test_readaloud.py
@@ -461,3 +461,93 @@ def test_instrumentation_cannot_change_the_verdict():
         ok, _ = readaloud.winrt_selftest(progress=boom)
 
     assert ok is True, "a failing progress callback flipped the verdict"
+
+
+# ---- James, 2026-09-05: "blue thing came up but did nothing" / "cant hear it"
+
+def test_a_ctrl_hotkey_does_not_always_mean_region_mode():
+    """asking is_pressed("ctrl") the instant a ctrl-chord hotkey fires is
+    trivially true, so EVERY press picked region mode and opened the selector -
+    which is the blue thing that appeared when it should have read the window."""
+    from wisprlite import readaloud
+
+    shift, ctrl = readaloud.extra_modifiers(
+        "ctrl+shift+r", shift_down=True, ctrl_down=True)
+    assert (shift, ctrl) == (False, False), \
+        "the hotkey's own modifiers were counted as a mode choice"
+    assert readaloud.capture_mode_for(shift=shift, ctrl=ctrl) == "window"
+
+
+def test_a_genuinely_extra_modifier_still_picks_its_mode():
+    """The fix must not make the modes unreachable."""
+    from wisprlite import readaloud
+
+    # hotkey is alt+r, so a held ctrl IS extra
+    shift, ctrl = readaloud.extra_modifiers("alt+r", shift_down=False, ctrl_down=True)
+    assert readaloud.capture_mode_for(shift=shift, ctrl=ctrl) == "region"
+
+    shift, ctrl = readaloud.extra_modifiers("alt+r", shift_down=True, ctrl_down=False)
+    assert readaloud.capture_mode_for(shift=shift, ctrl=ctrl) == "screen"
+
+
+def test_modifier_names_are_normalised():
+    from wisprlite import readaloud
+    for chord in ("control+r", "CTRL+R", "left ctrl+r", "Ctrl + R"):
+        _s, c = readaloud.extra_modifiers(chord, shift_down=False, ctrl_down=True)
+        assert c is False, f"{chord!r} was not recognised as holding ctrl"
+
+
+def test_speak_waits_for_playback_instead_of_returning_immediately():
+    """play() is ASYNC. Returning straight after it let the caller's finally drop
+    the last reference, so the MediaPlayer was collected mid-sentence and nothing
+    was ever audible."""
+    import threading as _t
+    from unittest import mock
+    from wisprlite import readaloud
+
+    ended = None
+
+    class FakePlayer:
+        def __init__(self):
+            self.played = False
+        def add_media_ended(self, handler):
+            nonlocal ended
+            ended = handler
+        def play(self):
+            self.played = True
+        def pause(self):
+            pass
+        def close(self):
+            pass
+
+    player = FakePlayer()
+    speaker = readaloud.Speaker(player_factory=lambda: player)
+
+    returned = _t.Event()
+    _t.Thread(target=lambda: (speaker.speak("hello there"), returned.set()),
+              daemon=True).start()
+
+    assert not returned.wait(0.4), "speak() returned before playback ended"
+    assert player.played
+    ended()                                   # WinRT fires MediaEnded
+    assert returned.wait(2), "speak() never returned after playback ended"
+
+
+def test_stopping_breaks_the_wait_promptly():
+    """Esc must not have to wait out the whole passage."""
+    import threading as _t
+    from wisprlite import readaloud
+
+    class FakePlayer:
+        def add_media_ended(self, handler): pass
+        def play(self): pass
+        def pause(self): pass
+        def close(self): pass
+
+    speaker = readaloud.Speaker(player_factory=FakePlayer)
+    returned = _t.Event()
+    _t.Thread(target=lambda: (speaker.speak("a" * 2000), returned.set()),
+              daemon=True).start()
+    assert not returned.wait(0.3)
+    speaker.stop()
+    assert returned.wait(2), "stop() did not break the playback wait"

--- a/wisprlite/__init__.py
+++ b/wisprlite/__init__.py
@@ -1,3 +1,3 @@
 """Pipevoice — push-to-talk voice typing for Windows."""
 
-__version__ = "2.45.6"
+__version__ = "2.45.7"

--- a/wisprlite/app.py
+++ b/wisprlite/app.py
@@ -366,7 +366,13 @@ class App:
 
         try:
             import keyboard
-            shift, ctrl = keyboard.is_pressed("shift"), keyboard.is_pressed("ctrl")
+            # Subtract the modifiers the hotkey chord itself holds. Without that,
+            # a hotkey containing ctrl reads as "ctrl is down" on every press and
+            # always opened the region selector.
+            shift, ctrl = readaloud.extra_modifiers(
+                self.cfg.read_aloud_hotkey,
+                shift_down=keyboard.is_pressed("shift"),
+                ctrl_down=keyboard.is_pressed("ctrl"))
         except Exception:
             shift = ctrl = False
         mode = readaloud.capture_mode_for(shift=shift, ctrl=ctrl)

--- a/wisprlite/readaloud.py
+++ b/wisprlite/readaloud.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import ctypes
 import logging
 import threading
+import time
 from typing import Callable, Optional
 
 log = logging.getLogger("wisprlite")
@@ -67,6 +68,24 @@ def capture_mode_for(*, shift: bool, ctrl: bool) -> str:
     if shift:
         return "screen"
     return "window"
+
+
+def extra_modifiers(hotkey: str, *, shift_down: bool, ctrl_down: bool) -> tuple[bool, bool]:
+    """The modifiers held BEYOND the ones the hotkey itself requires.
+
+    Asking `keyboard.is_pressed("ctrl")` the instant a hotkey fires is useless
+    when the hotkey IS a chord containing ctrl: it is trivially true, so every
+    press picked region mode and opened the selector. Subtract what the chord
+    already holds, and only genuinely extra modifiers choose a mode.
+    """
+    # Substring, not exact match: the keyboard library yields "ctrl",
+    # "left ctrl", "right ctrl", "control" and people type "Ctrl". An alias
+    # table has to be complete to be correct; a substring test does not.
+    chord = (hotkey or "").lower()
+    holds_ctrl = "ctrl" in chord or "control" in chord
+    holds_shift = "shift" in chord
+    return (shift_down and not holds_shift,
+            ctrl_down and not holds_ctrl)
 
 
 def grab_png(region: Optional[tuple[int, int, int, int]]) -> bytes:
@@ -244,6 +263,7 @@ class Speaker:
             self._player = player
         try:
             self._play(player)
+            self._await_end(player, text)
         except Exception:
             # Do not leave a dead player as the live one - stop() would then
             # think something is speaking and pause a player that never played.
@@ -274,6 +294,8 @@ class Speaker:
                 log.info("read-aloud: resume failed: %s", exc)
 
     def stop(self) -> None:
+        # _stopped is set INSIDE the lock, which is what _await_end polls, so a
+        # stop breaks the wait within one 100ms tick.
         with self._lock:
             self._stopped = True
             player, self._player = self._player, None
@@ -334,6 +356,41 @@ class Speaker:
             player.play()
         except Exception as exc:
             raise ReadAloudError(f"playback failed: {exc}") from exc
+
+    def _await_end(self, player, text: str) -> None:
+        """Block until playback ends, is stopped, or a generous cap passes.
+
+        play() is ASYNCHRONOUS. Returning straight after it meant the caller's
+        finally dropped the last reference to the Speaker and its MediaPlayer,
+        the player was garbage-collected mid-sentence, and nothing was ever
+        audible. It also killed the Esc/Space watcher, which loops on that same
+        reference.
+
+        The cap is generous and derived from the text: it exists so a WinRT
+        event that never arrives cannot wedge the hotkey for ever, not as the
+        normal path.
+        """
+        done = threading.Event()
+        for attach in ("add_media_ended", "add_MediaEnded"):
+            adder = getattr(player, attach, None)
+            if adder is None:
+                continue
+            try:
+                adder(lambda *_a: done.set())
+                break
+            except Exception as exc:
+                log.info("read-aloud: could not attach the end handler: %s", exc)
+
+        # ~14 chars/second is slow speech; +5s of slack, capped at 10 minutes.
+        budget = min(600.0, 5.0 + len(text) / 14.0)
+        deadline = time.monotonic() + budget
+        while not done.wait(0.1):
+            if time.monotonic() > deadline:
+                log.info("read-aloud: playback cap reached after %.0fs", budget)
+                return
+            with self._lock:
+                if self._stopped or self._player is not player:
+                    return
 
 
 # ---- screen reader detection (informational only — never gates speaking) -----


### PR DESCRIPTION
See the commit message for the full analysis. Both fixes verified red by sabotage; suite green at the 15 pre-existing failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)