### PR TITLE
feat: full-width tabs, select-what-to-read, and better voices

### DIFF
--- a/tests/test_readaloud.py
+++ b/tests/test_readaloud.py
@@ -20,20 +20,20 @@ from wisprlite import readaloud
 
 # ---- mode selection (pure logic) -------------------------------------------
 
-def test_plain_press_captures_the_focused_window():
-    assert readaloud.capture_mode_for(shift=False, ctrl=False) == "window"
+def test_plain_press_drags_a_region():
+    assert readaloud.capture_mode_for(shift=False, ctrl=False) == "region"
 
 
 def test_shift_captures_the_whole_screen():
     assert readaloud.capture_mode_for(shift=True, ctrl=False) == "screen"
 
 
-def test_ctrl_drags_a_region():
-    assert readaloud.capture_mode_for(shift=False, ctrl=True) == "region"
+def test_ctrl_captures_the_focused_window():
+    assert readaloud.capture_mode_for(shift=False, ctrl=True) == "window"
 
 
 def test_ctrl_wins_over_shift_if_somehow_both_are_held():
-    assert readaloud.capture_mode_for(shift=True, ctrl=True) == "region"
+    assert readaloud.capture_mode_for(shift=True, ctrl=True) == "window"
 
 
 # ---- hotkey collision (gate 3: testable headlessly) ------------------------
@@ -465,17 +465,17 @@ def test_instrumentation_cannot_change_the_verdict():
 
 # ---- James, 2026-09-05: "blue thing came up but did nothing" / "cant hear it"
 
-def test_a_ctrl_hotkey_does_not_always_mean_region_mode():
+def test_a_ctrl_hotkey_does_not_always_mean_a_non_default_mode():
     """asking is_pressed("ctrl") the instant a ctrl-chord hotkey fires is
-    trivially true, so EVERY press picked region mode and opened the selector -
-    which is the blue thing that appeared when it should have read the window."""
+    trivially true, so EVERY press picked a non-default mode - which is the
+    blue thing that appeared when it should have dragged a region."""
     from wisprlite import readaloud
 
     shift, ctrl = readaloud.extra_modifiers(
         "ctrl+shift+r", shift_down=True, ctrl_down=True)
     assert (shift, ctrl) == (False, False), \
         "the hotkey's own modifiers were counted as a mode choice"
-    assert readaloud.capture_mode_for(shift=shift, ctrl=ctrl) == "window"
+    assert readaloud.capture_mode_for(shift=shift, ctrl=ctrl) == "region"
 
 
 def test_a_genuinely_extra_modifier_still_picks_its_mode():
@@ -484,7 +484,7 @@ def test_a_genuinely_extra_modifier_still_picks_its_mode():
 
     # hotkey is alt+r, so a held ctrl IS extra
     shift, ctrl = readaloud.extra_modifiers("alt+r", shift_down=False, ctrl_down=True)
-    assert readaloud.capture_mode_for(shift=shift, ctrl=ctrl) == "region"
+    assert readaloud.capture_mode_for(shift=shift, ctrl=ctrl) == "window"
 
     shift, ctrl = readaloud.extra_modifiers("alt+r", shift_down=True, ctrl_down=False)
     assert readaloud.capture_mode_for(shift=shift, ctrl=ctrl) == "screen"

--- a/tests/test_tts_cloud.py
+++ b/tests/test_tts_cloud.py
@@ -223,3 +223,65 @@ def test_a_dead_key_falls_back_and_says_why():
 
     assert speaker is not None
     assert "401" in note and "Windows voice" in note
+
+
+def test_a_voice_name_cannot_rewrite_the_deepgram_request():
+    """Raw interpolation let a voice string containing & or ? change the
+    container or the model - a 400 nobody could explain from the UI."""
+    from unittest import mock
+    from wisprlite import tts_cloud
+
+    seen = {}
+
+    def fake(url, headers, payload, *, timeout, label):
+        seen["url"] = url
+        return b"audio"
+
+    with mock.patch.object(tts_cloud, "_post_for_audio", side_effect=fake):
+        tts_cloud.deepgram_speak("hi", "aura-2-draco-en&container=mp3", "key")
+
+    assert "container=mp3" not in seen["url"], f"the voice rewrote the request: {seen['url']}"
+    assert "container=wav" in seen["url"]
+
+
+def test_an_elevenlabs_voice_id_cannot_change_the_endpoint():
+    """The voice ID is free text the user pastes. A stray slash would route the
+    request to a different endpoint entirely."""
+    from unittest import mock
+    from wisprlite import tts_cloud
+
+    seen = {}
+
+    def fake(url, headers, payload, *, timeout, label):
+        seen["url"] = url
+        return b"audio"
+
+    with mock.patch.object(tts_cloud, "_post_for_audio", side_effect=fake):
+        tts_cloud.elevenlabs_speak("hi", "  abc/../v1/history  ", "key")
+
+    assert seen["url"].endswith("/v1/text-to-speech/abc%2F..%2Fv1%2Fhistory"), \
+        f"the voice ID escaped its path segment: {seen['url']}"
+
+
+def test_an_unknown_voice_engine_says_so_instead_of_going_quiet():
+    import types
+    from wisprlite import readaloud
+
+    cfg = types.SimpleNamespace(read_aloud_tts="jarvis", read_aloud_rate=1.0,
+                                read_aloud_voice="")
+    _speaker, note = readaloud.build_speaker("hello", cfg)
+    assert "jarvis" in note and "Windows voice" in note, \
+        f"an unrecognised engine was silently ignored: {note!r}"
+
+
+def test_the_elevenlabs_key_has_exactly_one_reader():
+    """Same single-reader rule the Deepgram key already has."""
+    import pathlib as _p
+    import re
+    root = _p.Path(__file__).resolve().parent.parent
+    hits = []
+    for path in (root / "wisprlite").rglob("*.py"):
+        for num, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+            if re.search(r'ELEVENLABS_API_KEY', line):
+                hits.append(f"{path.name}:{num}")
+    assert len(hits) <= 2, f"more than one place reads the ElevenLabs key: {hits}"

--- a/tests/test_tts_cloud.py
+++ b/tests/test_tts_cloud.py
@@ -184,3 +184,42 @@ def test_build_speaker_uses_the_cloud_audio_on_success():
     builder.assert_called_once_with(b"wav-bytes", "audio/wav")
     # the factory hands back the pre-built player rather than re-synthesizing
     assert speaker._build_player("hello") is fake_player
+
+
+def test_a_cloud_call_that_succeeds_but_cannot_play_still_falls_back():
+    """The player was built OUTSIDE the try, so a cloud response that arrived
+    and then failed to become a player raised out of build_speaker - no
+    fallback, and silence, which is the one thing this path must never do."""
+    import types
+    from unittest import mock
+    from wisprlite import readaloud, tts_cloud
+    from wisprlite import config as _config
+
+    cfg = types.SimpleNamespace(read_aloud_tts="deepgram", read_aloud_rate=1.0,
+                                read_aloud_voice="aura-2-draco-en")
+
+    with mock.patch.object(tts_cloud, "deepgram_speak", return_value=b"RIFFfake"), \
+         mock.patch.object(_config, "deepgram_key", return_value="k"), \
+         mock.patch.object(readaloud, "_winrt_player_from_bytes",
+                           side_effect=RuntimeError("no MediaPlayer here")):
+        speaker, note = readaloud.build_speaker("hello", cfg)
+
+    assert speaker is not None, "it raised instead of falling back"
+    assert "Windows voice" in note, f"the fallback was silent about why: {note!r}"
+
+
+def test_a_dead_key_falls_back_and_says_why():
+    import types
+    from unittest import mock
+    from wisprlite import readaloud, tts_cloud
+    from wisprlite import config as _config
+
+    cfg = types.SimpleNamespace(read_aloud_tts="deepgram", read_aloud_rate=1.0,
+                                read_aloud_voice="aura-2-draco-en")
+    with mock.patch.object(tts_cloud, "deepgram_speak",
+                           side_effect=tts_cloud.CloudTTSError("HTTP 401")), \
+         mock.patch.object(_config, "deepgram_key", return_value="bad"):
+        speaker, note = readaloud.build_speaker("hello", cfg)
+
+    assert speaker is not None
+    assert "401" in note and "Windows voice" in note

--- a/tests/test_tts_cloud.py
+++ b/tests/test_tts_cloud.py
@@ -1,0 +1,186 @@
+"""Deepgram/ElevenLabs TTS for Read Aloud: bring-your-own-key, and every
+failure (bad key, network, quota) degrades to the Windows voice instead of
+going silent. Runs on Linux with the HTTP layer mocked — never hits a real API.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+import urllib.error
+from unittest import mock
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent))
+
+from wisprlite import tts_cloud
+
+
+class _Resp:
+    def __init__(self, payload: bytes):
+        self.payload = payload
+
+    def read(self):
+        return self.payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_exc):
+        return False
+
+
+# ---- gate 3: a mocked 200 returns audio bytes ------------------------------
+
+def test_deepgram_speak_returns_audio_bytes_on_a_200():
+    with mock.patch.object(tts_cloud.urllib.request, "urlopen",
+                            return_value=_Resp(b"RIFF....WAVEfmt ")) as urlopen:
+        audio = tts_cloud.deepgram_speak("hello world", "aura-2-draco-en", "fake-key")
+    assert audio == b"RIFF....WAVEfmt "
+    req = urlopen.call_args[0][0]
+    assert "aura-2-draco-en" in req.full_url
+    assert req.headers.get("Authorization") == "Token fake-key"
+
+
+def test_elevenlabs_speak_returns_audio_bytes_on_a_200():
+    with mock.patch.object(tts_cloud.urllib.request, "urlopen",
+                            return_value=_Resp(b"ID3-mp3-bytes")) as urlopen:
+        audio = tts_cloud.elevenlabs_speak("hello world", "voice123", "fake-key")
+    assert audio == b"ID3-mp3-bytes"
+    req = urlopen.call_args[0][0]
+    assert "voice123" in req.full_url
+    assert req.headers.get("Xi-api-key") == "fake-key"
+
+
+# ---- gate 3: a 401 and a network error each raise CloudTTSError -----------
+
+def test_deepgram_speak_raises_on_401():
+    err = urllib.error.HTTPError("url", 401, "Unauthorized", {}, None)
+    with mock.patch.object(tts_cloud.urllib.request, "urlopen", side_effect=err):
+        try:
+            tts_cloud.deepgram_speak("hi", "aura-2-draco-en", "bad-key")
+        except tts_cloud.CloudTTSError as exc:
+            assert "401" in str(exc)
+        else:
+            raise AssertionError("expected CloudTTSError")
+
+
+def test_deepgram_speak_raises_on_a_network_error():
+    err = urllib.error.URLError("no route to host")
+    with mock.patch.object(tts_cloud.urllib.request, "urlopen", side_effect=err):
+        try:
+            tts_cloud.deepgram_speak("hi", "aura-2-draco-en", "a-key")
+        except tts_cloud.CloudTTSError as exc:
+            assert "no route to host" in str(exc)
+        else:
+            raise AssertionError("expected CloudTTSError")
+
+
+def test_elevenlabs_speak_raises_on_401():
+    err = urllib.error.HTTPError("url", 401, "Unauthorized", {}, None)
+    with mock.patch.object(tts_cloud.urllib.request, "urlopen", side_effect=err):
+        try:
+            tts_cloud.elevenlabs_speak("hi", "voice123", "bad-key")
+        except tts_cloud.CloudTTSError as exc:
+            assert "401" in str(exc)
+        else:
+            raise AssertionError("expected CloudTTSError")
+
+
+def test_deepgram_speak_without_a_key_raises_before_any_http_call():
+    with mock.patch.object(tts_cloud.urllib.request, "urlopen") as urlopen:
+        try:
+            tts_cloud.deepgram_speak("hi", "aura-2-draco-en", "")
+        except tts_cloud.CloudTTSError as exc:
+            assert "key" in str(exc)
+        else:
+            raise AssertionError("expected CloudTTSError")
+    assert not urlopen.called
+
+
+def test_elevenlabs_speak_without_a_voice_id_raises_before_any_http_call():
+    with mock.patch.object(tts_cloud.urllib.request, "urlopen") as urlopen:
+        try:
+            tts_cloud.elevenlabs_speak("hi", "", "a-key")
+        except tts_cloud.CloudTTSError as exc:
+            assert "voice ID" in str(exc)
+        else:
+            raise AssertionError("expected CloudTTSError")
+    assert not urlopen.called
+
+
+# ---- gate 4: config.deepgram_key() is the only reader of the env var ------
+
+def test_deepgram_env_var_has_exactly_one_reader():
+    """A second os.getenv("DEEPGRAM_API_KEY") anywhere would be a second place
+    to store/read the key, which the plan explicitly forbids."""
+    import re
+
+    wisprlite_dir = pathlib.Path(__file__).resolve().parent.parent / "wisprlite"
+    readers = []
+    for path in wisprlite_dir.glob("*.py"):
+        text = path.read_text(encoding="utf-8")
+        for m in re.finditer(r'os\.getenv\(\s*["\']DEEPGRAM_API_KEY["\']', text):
+            readers.append(f"{path.name}:{text.count(chr(10), 0, m.start()) + 1}")
+    assert readers, "sabotage check: os.getenv(\"DEEPGRAM_API_KEY\") was not found anywhere"
+    assert all(r.startswith("config.py:") for r in readers), (
+        f"DEEPGRAM_API_KEY is read outside config.py: {readers}"
+    )
+    # tts_cloud itself must not read the env var directly.
+    tts_cloud_src = (wisprlite_dir / "tts_cloud.py").read_text(encoding="utf-8")
+    assert "os.getenv" not in tts_cloud_src, \
+        "tts_cloud.py must go through config.deepgram_key(), not read the env directly"
+
+
+# ---- readaloud.build_speaker: tier dispatch + fallback ---------------------
+
+def test_build_speaker_windows_tier_never_touches_the_network():
+    from wisprlite import config, readaloud
+
+    cfg = config.Config(read_aloud_tts="windows", read_aloud_voice="")
+    with mock.patch.object(tts_cloud.urllib.request, "urlopen") as urlopen:
+        speaker, reason = readaloud.build_speaker("hello", cfg)
+    assert not urlopen.called
+    assert reason == ""
+    assert isinstance(speaker, readaloud.Speaker)
+
+
+def test_build_speaker_falls_back_to_windows_on_a_deepgram_failure():
+    from wisprlite import config, readaloud
+
+    cfg = config.Config(read_aloud_tts="deepgram", read_aloud_voice="aura-2-draco-en")
+    with mock.patch.object(config, "deepgram_key", return_value="a-key"), \
+         mock.patch.object(tts_cloud, "deepgram_speak",
+                            side_effect=tts_cloud.CloudTTSError("Deepgram speak failed: HTTP 401")):
+        speaker, reason = readaloud.build_speaker("hello", cfg)
+    assert isinstance(speaker, readaloud.Speaker)
+    assert speaker.voice == ""
+    assert "HTTP 401" in reason
+    assert "Windows" in reason
+
+
+def test_build_speaker_falls_back_to_windows_on_a_network_error():
+    from wisprlite import config, readaloud
+
+    cfg = config.Config(read_aloud_tts="deepgram", read_aloud_voice="aura-2-draco-en")
+    with mock.patch.object(config, "deepgram_key", return_value="a-key"), \
+         mock.patch.object(tts_cloud, "deepgram_speak",
+                            side_effect=tts_cloud.CloudTTSError("Deepgram speak failed: timed out")):
+        speaker, reason = readaloud.build_speaker("hello", cfg)
+    assert isinstance(speaker, readaloud.Speaker)
+    assert "timed out" in reason
+
+
+def test_build_speaker_uses_the_cloud_audio_on_success():
+    from wisprlite import config, readaloud
+
+    cfg = config.Config(read_aloud_tts="deepgram", read_aloud_voice="aura-2-draco-en")
+    fake_player = object()
+    with mock.patch.object(config, "deepgram_key", return_value="a-key"), \
+         mock.patch.object(tts_cloud, "deepgram_speak", return_value=b"wav-bytes"), \
+         mock.patch.object(readaloud, "_winrt_player_from_bytes", return_value=fake_player) as builder:
+        speaker, reason = readaloud.build_speaker("hello", cfg)
+    assert reason == ""
+    assert isinstance(speaker, readaloud.Speaker)
+    builder.assert_called_once_with(b"wav-bytes", "audio/wav")
+    # the factory hands back the pre-built player rather than re-synthesizing
+    assert speaker._build_player("hello") is fake_player

--- a/tests/test_ui_smoke.py
+++ b/tests/test_ui_smoke.py
@@ -1638,3 +1638,115 @@ def test_a_transcript_that_failed_to_upload_is_not_called_sent():
         f"the title claims it was sent while the transcript failed: {snap}"
     assert "disk full" in (snap.get("subtitle") or ""), \
         f"the reason must survive to the pill: {snap}"
+
+
+def test_voices_editor_scroll_content_tracks_the_canvas_width():
+    """Same trap, same fix, different window: the standalone --voices editor
+    has its own scrollable canvas and had the identical missing width-bind."""
+    _skip_if_headless()
+    import tkinter as tk
+
+    from wisprlite import voices_editor
+
+    def _find_canvases(widget):
+        found = []
+        for child in widget.winfo_children():
+            if isinstance(child, tk.Canvas):
+                found.append(child)
+            found.extend(_find_canvases(child))
+        return found
+
+    # build_window destroys root before returning, so rebuild manually here to
+    # keep the window alive long enough to resize it and inspect the item.
+    real_mainloop = tk.Misc.mainloop
+    captured = {}
+
+    def stub_mainloop(self, _n=0):
+        self.update_idletasks()
+        self.update()
+        captured["root"] = self
+
+    tk.Misc.mainloop = stub_mainloop
+    try:
+        voices_editor.main()
+    finally:
+        tk.Misc.mainloop = real_mainloop
+
+    root = captured["root"]
+    try:
+        canvases = _find_canvases(root)
+        assert canvases, "the voices editor did not build a scrolling canvas"
+        canvas = canvases[0]
+        items = canvas.find_all()
+        assert items, "the canvas has no scroll item"
+        item = items[0]
+
+        seen = []
+        for root_width in (520, 940):
+            root.geometry(f"{root_width}x400")
+            root.update_idletasks()
+            root.update()
+            actual = canvas.winfo_width()
+            tracked = int(canvas.itemcget(item, "width") or 0)
+            seen.append((actual, tracked))
+            assert tracked == actual, (
+                f"inner item width is {tracked}, but the canvas itself is "
+                f"{actual} wide — the content will hug the left edge"
+            )
+        assert seen[0][0] != seen[1][0], "the two geometries produced the same canvas width"
+    finally:
+        root.destroy()
+
+
+def test_about_tab_scroll_content_tracks_the_canvas_width():
+    """The classic Tk scrollable-frame trap: a canvas item created with
+    create_window keeps its NATURAL width forever unless something binds it to
+    the canvas's own width. Without that bind, the inner frame hugs the left
+    edge and a maximised window (the normal case now) leaves dead space on the
+    right instead of filling it. Prove it holds at two different widths."""
+    _skip_if_headless()
+    import tkinter as tk
+    from unittest import mock
+
+    from wisprlite import about, updater
+
+    root = tk.Tk()
+    try:
+        container = tk.Frame(root)
+        container.pack(fill="both", expand=True)
+        with mock.patch.object(updater, "recent_releases", return_value=[]), \
+             mock.patch.object(updater, "current_version", return_value="9.9.9"):
+            about.build(container, root, wheel=lambda _c: None)
+        root.update_idletasks()
+        root.update()
+
+        def _find_canvases(widget):
+            found = []
+            for child in widget.winfo_children():
+                if isinstance(child, tk.Canvas):
+                    found.append(child)
+                found.extend(_find_canvases(child))
+            return found
+
+        canvases = _find_canvases(container)
+        assert canvases, "About did not build a scrolling canvas"
+        canvas = canvases[0]
+        items = canvas.find_all()
+        assert items, "the canvas has no scroll item"
+        item = items[0]
+
+        seen = []
+        for root_width in (520, 940):
+            root.geometry(f"{root_width}x400")
+            root.update_idletasks()
+            root.update()
+            actual = canvas.winfo_width()
+            tracked = int(canvas.itemcget(item, "width") or 0)
+            seen.append((actual, tracked))
+            assert tracked == actual, (
+                f"inner item width is {tracked}, but the canvas itself is "
+                f"{actual} wide — the content will hug the left edge"
+            )
+        assert seen[0][0] != seen[1][0], "the two geometries produced the same canvas width"
+    finally:
+        root.destroy()

--- a/wisprlite/__init__.py
+++ b/wisprlite/__init__.py
@@ -1,3 +1,3 @@
 """Pipevoice — push-to-talk voice typing for Windows."""
 
-__version__ = "2.45.7"
+__version__ = "2.46.0"

--- a/wisprlite/about.py
+++ b/wisprlite/about.py
@@ -121,8 +121,12 @@ def build(container, root, wheel=None) -> None:
     vbar.pack(side="right", fill="y")
     canvas.pack(side="left", fill="both", expand=True)
     inner = tk.Frame(canvas, bg=BG)
-    canvas.create_window((0, 0), window=inner, anchor="nw")
+    inner_window = canvas.create_window((0, 0), window=inner, anchor="nw")
     inner.bind("<Configure>", lambda e: canvas.configure(scrollregion=canvas.bbox("all")))
+    # Without this the inner frame keeps its natural width and hugs the left
+    # edge once the canvas grows past it — the classic Tk scrollable-frame trap,
+    # and a maximised window is the normal case now, not an edge case.
+    canvas.bind("<Configure>", lambda e: canvas.itemconfigure(inner_window, width=e.width))
     wheel(canvas)
 
     def _exit_for_install():

--- a/wisprlite/about.py
+++ b/wisprlite/about.py
@@ -120,13 +120,15 @@ def build(container, root, wheel=None) -> None:
     canvas.configure(yscrollcommand=vbar.set)
     vbar.pack(side="right", fill="y")
     canvas.pack(side="left", fill="both", expand=True)
+    from . import winui
+
     inner = tk.Frame(canvas, bg=BG)
     inner_window = canvas.create_window((0, 0), window=inner, anchor="nw")
     inner.bind("<Configure>", lambda e: canvas.configure(scrollregion=canvas.bbox("all")))
     # Without this the inner frame keeps its natural width and hugs the left
     # edge once the canvas grows past it — the classic Tk scrollable-frame trap,
     # and a maximised window is the normal case now, not an edge case.
-    canvas.bind("<Configure>", lambda e: canvas.itemconfigure(inner_window, width=e.width))
+    winui.fit_scroll_body(canvas, inner_window)
     wheel(canvas)
 
     def _exit_for_install():

--- a/wisprlite/app.py
+++ b/wisprlite/app.py
@@ -415,13 +415,19 @@ class App:
         speaker, fallback_reason = readaloud.build_speaker(text, self.cfg)
         self._read_aloud_speaker = speaker
         threading.Thread(target=self._read_aloud_watch_interrupt, args=(speaker,), daemon=True).start()
+        failed = False
         try:
             speaker.speak(text)
         except readaloud.ReadAloudError as exc:
+            failed = True
             self.overlay.set_state("error", str(exc)[:80])
         finally:
             self._read_aloud_speaker = None
-            self.overlay.set_state("done", fallback_reason[:80])
+            # The finally used to overwrite unconditionally, so the error set
+            # two lines above was replaced by "done" before anyone could read
+            # it - a failed read looked exactly like a successful one.
+            if not failed:
+                self.overlay.set_state("done", fallback_reason[:80])
 
     def _read_aloud_watch_interrupt(self, speaker) -> None:
         """Esc stops, Space pauses/resumes, the hotkey again stops. Polled at

--- a/wisprlite/app.py
+++ b/wisprlite/app.py
@@ -412,7 +412,7 @@ class App:
             self.overlay.set_state("done", "Copied — staying quiet (screen reader running)")
             return
 
-        speaker = readaloud.Speaker(voice=self.cfg.read_aloud_voice, rate=self.cfg.read_aloud_rate)
+        speaker, fallback_reason = readaloud.build_speaker(text, self.cfg)
         self._read_aloud_speaker = speaker
         threading.Thread(target=self._read_aloud_watch_interrupt, args=(speaker,), daemon=True).start()
         try:
@@ -421,7 +421,7 @@ class App:
             self.overlay.set_state("error", str(exc)[:80])
         finally:
             self._read_aloud_speaker = None
-            self.overlay.set_state("done", "")
+            self.overlay.set_state("done", fallback_reason[:80])
 
     def _read_aloud_watch_interrupt(self, speaker) -> None:
         """Esc stops, Space pauses/resumes, the hotkey again stops. Polled at

--- a/wisprlite/config.py
+++ b/wisprlite/config.py
@@ -201,9 +201,11 @@ class Config:
     screenrec_dir: str = ""           # blank = %USERPROFILE%\\Videos\\PipeVoice
     screenrec_fps: int = 12           # pure-python capture; 10-15 is realistic at 1080p
     # Read Aloud — OCR + speech via WinRT. "" = off, like meeting/screenrec hotkeys.
-    # Base = focused window, +Shift = whole screen, +Ctrl = drag a region.
+    # Base = drag a region, +Shift = whole screen, +Ctrl = the focused window.
     read_aloud_hotkey: str = ""
-    read_aloud_voice: str = ""        # "" = the system default WinRT voice
+    read_aloud_tts: str = "windows"   # windows | deepgram | elevenlabs
+    read_aloud_voice: str = ""        # "" = the system default WinRT voice; tier-specific otherwise
+    read_aloud_elevenlabs_voice_id: str = ""  # bring-your-own voice ID, per-account catalogue
     read_aloud_rate: float = 1.0      # 0.5-2.0, passed straight to SpeechSynthesisStream
     read_aloud_ocr_language: str = "" # "" = user's profile languages
     read_aloud_clipboard: bool = True # also copy the recognized text; never silent about it
@@ -352,6 +354,10 @@ def groq_key() -> str:
 
 def openrouter_key() -> str:
     return os.getenv("OPENROUTER_API_KEY", "").strip()
+
+
+def elevenlabs_key() -> str:
+    return os.getenv("ELEVENLABS_API_KEY", "").strip()
 
 
 def device_arg(cfg: Config):

--- a/wisprlite/readaloud.py
+++ b/wisprlite/readaloud.py
@@ -62,12 +62,18 @@ def focused_window_rect() -> Optional[tuple[int, int, int, int]]:
 def capture_mode_for(*, shift: bool, ctrl: bool) -> str:
     """Which of the three modes a hotkey press means, by which modifiers were
     ALSO held. Pure function so the mode-selection logic is testable without a
-    keyboard: focused window is the default because it needs no mouse."""
+    keyboard.
+
+    Dragging a region is the default: James, the actual user, asked plainly to
+    "select what I want to be read aloud... where we just highlight what we
+    want", overriding an earlier design decision that defaulted to the focused
+    window on the theory that some hypothetical user has no mouse.
+    """
     if ctrl:
-        return "region"
+        return "window"
     if shift:
         return "screen"
-    return "window"
+    return "region"
 
 
 def extra_modifiers(hotkey: str, *, shift_down: bool, ctrl_down: bool) -> tuple[bool, bool]:
@@ -391,6 +397,80 @@ class Speaker:
             with self._lock:
                 if self._stopped or self._player is not player:
                     return
+
+
+# ---- tiered voice selection (Windows / Deepgram / ElevenLabs) ---------------
+
+def _winrt_player_from_bytes(audio_bytes: bytes, content_type: str):
+    """A winrt MediaPlayer sourced from already-synthesized bytes (a cloud TTS
+    response) instead of SpeechSynthesizer. Reuses the same interruptible
+    player Speaker already knows how to stop/pause/release, rather than a
+    second playback path for cloud voices."""
+    import asyncio
+
+    from winrt.windows.media.core import MediaSource
+    from winrt.windows.media.playback import MediaPlayer
+    from winrt.windows.storage.streams import DataWriter, InMemoryRandomAccessStream
+
+    async def build():
+        stream = InMemoryRandomAccessStream()
+        writer = DataWriter(stream.get_output_stream_at(0))
+        try:
+            writer.write_bytes(audio_bytes)
+        except TypeError:
+            writer.write_bytes(list(audio_bytes))
+        await writer.store_async()
+        await writer.flush_async()
+        try:
+            stream.seek(0)
+        except AttributeError:
+            stream.position = 0
+        player = MediaPlayer()
+        player.source = MediaSource.create_from_stream(stream, content_type)
+        return player
+
+    return asyncio.run(build())
+
+
+def build_speaker(text: str, cfg) -> tuple["Speaker", str]:
+    """Build the Speaker for one read, honouring `cfg.read_aloud_tts`.
+
+    Windows stays the default: offline, no key, no cost, and the privacy
+    promise is the product — a cloud voice must always be an explicit choice.
+    Every cloud path degrades to the Windows voice on ANY failure (a dead key,
+    no network, a 402): the second item in the returned tuple is empty on
+    success or a reason to surface when it degraded — Read Aloud must never go
+    silent about why it fell back.
+    """
+    tier = (getattr(cfg, "read_aloud_tts", "") or "windows").strip().lower()
+    rate = getattr(cfg, "read_aloud_rate", 1.0)
+    if tier == "windows":
+        return Speaker(voice=getattr(cfg, "read_aloud_voice", ""), rate=rate), ""
+
+    from . import config as _config
+    from . import tts_cloud
+
+    try:
+        if tier == "deepgram":
+            audio = tts_cloud.deepgram_speak(
+                text,
+                getattr(cfg, "read_aloud_voice", "") or tts_cloud.DEFAULT_DEEPGRAM_VOICE,
+                _config.deepgram_key())
+            content_type = "audio/wav"
+        elif tier == "elevenlabs":
+            audio = tts_cloud.elevenlabs_speak(
+                text,
+                getattr(cfg, "read_aloud_elevenlabs_voice_id", ""),
+                _config.elevenlabs_key())
+            content_type = "audio/mpeg"
+        else:
+            return Speaker(voice=getattr(cfg, "read_aloud_voice", ""), rate=rate), ""
+    except tts_cloud.CloudTTSError as exc:
+        return (Speaker(voice="", rate=rate),
+                f"{str(exc)} — using the Windows voice instead")
+
+    player = _winrt_player_from_bytes(audio, content_type)
+    return Speaker(rate=rate, player_factory=lambda: player), ""
 
 
 # ---- screen reader detection (informational only — never gates speaking) -----

--- a/wisprlite/readaloud.py
+++ b/wisprlite/readaloud.py
@@ -465,11 +465,19 @@ def build_speaker(text: str, cfg) -> tuple["Speaker", str]:
             content_type = "audio/mpeg"
         else:
             return Speaker(voice=getattr(cfg, "read_aloud_voice", ""), rate=rate), ""
+        # Building the player is INSIDE the try. It was outside, so a cloud
+        # call that succeeded and then failed to produce a player raised
+        # straight out of here - no fallback, and silence, which is the one
+        # thing this path must never do.
+        player = _winrt_player_from_bytes(audio, content_type)
     except tts_cloud.CloudTTSError as exc:
         return (Speaker(voice="", rate=rate),
                 f"{str(exc)} — using the Windows voice instead")
+    except Exception as exc:
+        log.exception("read-aloud: cloud voice failed, falling back")
+        return (Speaker(voice="", rate=rate),
+                f"{type(exc).__name__} — using the Windows voice instead")
 
-    player = _winrt_player_from_bytes(audio, content_type)
     return Speaker(rate=rate, player_factory=lambda: player), ""
 
 

--- a/wisprlite/readaloud.py
+++ b/wisprlite/readaloud.py
@@ -464,7 +464,11 @@ def build_speaker(text: str, cfg) -> tuple["Speaker", str]:
                 _config.elevenlabs_key())
             content_type = "audio/mpeg"
         else:
-            return Speaker(voice=getattr(cfg, "read_aloud_voice", ""), rate=rate), ""
+            # An unrecognised tier used to hand back a Windows speaker and no
+            # reason, so a setting that had silently drifted looked like normal
+            # operation. Say which value was not understood.
+            return (Speaker(voice="", rate=rate),
+                    f"unknown voice engine {tier!r} — using the Windows voice instead")
         # Building the player is INSIDE the try. It was outside, so a cloud
         # call that succeeded and then failed to produce a player raised
         # straight out of here - no fallback, and silence, which is the one

--- a/wisprlite/settings.py
+++ b/wisprlite/settings.py
@@ -727,7 +727,17 @@ def main(first_run: bool = False) -> None:
     bookmark_sensitivity_var = tk.DoubleVar(value=cfg.bookmark_sensitivity)
     bookmark_phrases_var = tk.StringVar(value=cfg.bookmark_phrases)
     read_aloud_hotkey_var = tk.StringVar(value=cfg.read_aloud_hotkey)
+    read_aloud_tts_opts = [
+        ("windows", "Windows natural voices — free, offline, no key"),
+        ("deepgram", "Deepgram Aura-2 — cloud, uses your Deepgram key"),
+        ("elevenlabs", "ElevenLabs — best quality, your own key, paid"),
+    ]
+    read_aloud_tts_var = tk.StringVar(
+        value=dict(read_aloud_tts_opts).get(cfg.read_aloud_tts, read_aloud_tts_opts[0][1]))
     read_aloud_voice_var = tk.StringVar(value=cfg.read_aloud_voice)
+    from . import tts_cloud as _tts_cloud
+    read_aloud_deepgram_pick_var = tk.StringVar(value="")
+    read_aloud_elevenlabs_id_var = tk.StringVar(value=cfg.read_aloud_elevenlabs_voice_id)
     read_aloud_rate_var = tk.StringVar(value=str(cfg.read_aloud_rate))
     read_aloud_lang_var = tk.StringVar(value=cfg.read_aloud_ocr_language)
     read_aloud_clipboard_var = tk.BooleanVar(value=cfg.read_aloud_clipboard)
@@ -1136,17 +1146,50 @@ def main(first_run: bool = False) -> None:
     c = card(
         "Read Aloud",
         "For text a screen reader can't reach — an image, a canvas, a scanned "
-        "PDF. Tap = the focused window, +Shift = the whole screen, +Ctrl = drag "
-        "a region. Speaks even with a screen reader running, unless you turn "
-        "that off below.",
+        "PDF. Tap = drag a region, +Shift = the whole screen, +Ctrl = the "
+        "focused window. Speaks even with a screen reader running, unless you "
+        "turn that off below.",
     )
     r = row(c, "Read Aloud hotkey", "Blank turns the feature off.")
     entry(r, read_aloud_hotkey_var, width=14)
     ra_cap_btn = ttk.Button(r, text="Capture", width=8)
     ra_cap_btn.pack(side="left", padx=(8, 0))
     ra_cap_btn.config(command=_mk_capture(ra_cap_btn, read_aloud_hotkey_var))
-    entry(row(c, "Voice", "Blank uses the system default voice."),
+
+    combo(row(c, "Voice engine",
+              "Windows is free, offline, no key — nothing ever leaves this "
+              "machine. Deepgram and ElevenLabs send the recognized text to "
+              "their servers to speak it; only pick those on purpose. Any "
+              "cloud failure (dead key, no network) falls back to Windows and "
+              "says why."),
+          read_aloud_tts_var, [l for _, l in read_aloud_tts_opts])
+
+    wr = row(c, "Get better Windows voices",
+             "Windows 11 ships far better \"Natural\" voices, but they aren't "
+             "installed by default. Opens Settings → Speech → Manage voices.")
+    ttk.Button(wr, text="Open Windows voice settings",
+               command=lambda: os.startfile("ms-settings:speech")).pack(side="left")
+
+    entry(row(c, "Voice / model",
+              "Blank uses the system default Windows voice, or the default "
+              "Deepgram voice (aura-2-draco-en)."),
           read_aloud_voice_var, width=28)
+    dg_row = row(c, "Deepgram voice (pick one)",
+                 "Only used when the voice engine above is Deepgram.")
+    dg_combo = combo(dg_row, read_aloud_deepgram_pick_var,
+                     [f"{name} — {desc}" for name, desc in _tts_cloud.DEEPGRAM_VOICES], width=40)
+
+    def _pick_deepgram_voice(_evt=None):
+        i = dg_combo.current()
+        if 0 <= i < len(_tts_cloud.DEEPGRAM_VOICES):
+            read_aloud_voice_var.set(_tts_cloud.DEEPGRAM_VOICES[i][0])
+    dg_combo.bind("<<ComboboxSelected>>", _pick_deepgram_voice)
+
+    entry(row(c, "ElevenLabs voice ID",
+              "Only used when the voice engine above is ElevenLabs — their "
+              "catalogue is per-account, so this is an ID, not a picklist."),
+          read_aloud_elevenlabs_id_var, width=28)
+
     entry(row(c, "Speed", "0.5 (slow) to 2.0 (fast). 1.0 is normal."),
           read_aloud_rate_var, width=6)
     entry(row(c, "OCR language",
@@ -1723,7 +1766,9 @@ def main(first_run: bool = False) -> None:
         except ValueError:
             cfg.screenrec_fps = 12
         cfg.read_aloud_hotkey = read_aloud_hotkey_var.get().strip()
+        cfg.read_aloud_tts = value_for(read_aloud_tts_var, read_aloud_tts_opts)
         cfg.read_aloud_voice = read_aloud_voice_var.get().strip()
+        cfg.read_aloud_elevenlabs_voice_id = read_aloud_elevenlabs_id_var.get().strip()
         try:
             cfg.read_aloud_rate = max(0.5, min(2.0, float(read_aloud_rate_var.get().strip() or 1.0)))
         except ValueError:

--- a/wisprlite/tts_cloud.py
+++ b/wisprlite/tts_cloud.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import json
 import urllib.error
+import urllib.parse
 import urllib.request
 
 
@@ -43,8 +44,11 @@ def _post_for_audio(url: str, headers: dict, payload: dict, *, timeout: float, l
         raise CloudTTSError(f"{label} failed: HTTP {exc.code}") from exc
     except urllib.error.URLError as exc:
         raise CloudTTSError(f"{label} failed: {exc.reason}") from exc
-    except Exception as exc:
-        raise CloudTTSError(f"{label} failed: {exc}") from exc
+    # Deliberately NOT a bare `except Exception` here. A TypeError from a
+    # malformed payload is our bug, not a cloud failure, and relabelling it as
+    # CloudTTSError hid it behind the friendly "using the Windows voice"
+    # message. build_speaker still catches it and still falls back - but it
+    # names the exception type, so the bug is visible in the log.
 
 
 def deepgram_speak(text: str, voice: str, api_key: str, *, timeout: float = 20.0) -> bytes:
@@ -53,7 +57,10 @@ def deepgram_speak(text: str, voice: str, api_key: str, *, timeout: float = 20.0
     if not (api_key or "").strip():
         raise CloudTTSError("no Deepgram API key configured")
     model = (voice or DEFAULT_DEEPGRAM_VOICE).strip()
-    url = f"https://api.deepgram.com/v1/speak?model={model}&encoding=linear16&container=wav"
+    # quoted: a voice string containing & or ? silently rewrites the request -
+    # a different container, a different model, or a 400 nobody can explain.
+    url = ("https://api.deepgram.com/v1/speak"
+           f"?model={urllib.parse.quote(model, safe='')}&encoding=linear16&container=wav")
     return _post_for_audio(
         url,
         {"Authorization": f"Token {api_key}", "Content-Type": "application/json"},
@@ -69,7 +76,11 @@ def elevenlabs_speak(text: str, voice_id: str, api_key: str, *, timeout: float =
         raise CloudTTSError("no ElevenLabs API key configured")
     if not (voice_id or "").strip():
         raise CloudTTSError("no ElevenLabs voice ID configured")
-    url = f"https://api.elevenlabs.io/v1/text-to-speech/{voice_id}"
+    # quoted: the voice ID is free text the user pastes in. A stray slash or
+    # trailing whitespace would otherwise route the request to a different
+    # endpoint entirely.
+    url = ("https://api.elevenlabs.io/v1/text-to-speech/"
+           + urllib.parse.quote(voice_id.strip(), safe=""))
     return _post_for_audio(
         url,
         {"xi-api-key": api_key, "Content-Type": "application/json"},

--- a/wisprlite/tts_cloud.py
+++ b/wisprlite/tts_cloud.py
@@ -1,0 +1,79 @@
+"""Cloud text-to-speech for Read Aloud: Deepgram Aura-2 and ElevenLabs.
+
+Both are bring-your-own-key. Deepgram reuses `config.deepgram_key()` — the same
+key already configured for dictation, no second place to store it. ElevenLabs
+is bring-your-own-key exactly like the transcription engines, via
+`config.elevenlabs_key()`.
+
+Every failure (missing key, bad key, no network, a quota wall) raises
+CloudTTSError — never a bare urllib exception — so the caller has one thing to
+catch and can degrade to the Windows voice. Read Aloud must never go silent.
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+
+
+class CloudTTSError(Exception):
+    """A degraded-but-handled cloud TTS failure: no key, network, quota, etc."""
+
+
+# Curated rather than the full ~40-voice catalogue. draco is the default: the
+# closest thing in it to the JARVIS register James asked for.
+DEEPGRAM_VOICES = [
+    ("aura-2-draco-en", "British baritone, warm, trustworthy"),
+    ("aura-2-zeus-en", "American, deep, trustworthy, smooth"),
+    ("aura-2-saturn-en", "American, knowledgeable, confident, baritone"),
+    ("aura-2-jupiter-en", "American, expressive, knowledgeable, baritone"),
+    ("aura-2-asteria-en", "American feminine, clear"),
+]
+DEFAULT_DEEPGRAM_VOICE = "aura-2-draco-en"
+
+
+def _post_for_audio(url: str, headers: dict, payload: dict, *, timeout: float, label: str) -> bytes:
+    data = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(url, data=data, method="POST", headers=headers)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return resp.read()
+    except urllib.error.HTTPError as exc:
+        raise CloudTTSError(f"{label} failed: HTTP {exc.code}") from exc
+    except urllib.error.URLError as exc:
+        raise CloudTTSError(f"{label} failed: {exc.reason}") from exc
+    except Exception as exc:
+        raise CloudTTSError(f"{label} failed: {exc}") from exc
+
+
+def deepgram_speak(text: str, voice: str, api_key: str, *, timeout: float = 20.0) -> bytes:
+    """POST to Deepgram's /v1/speak. Returns WAV bytes (container=wav is
+    requested explicitly so playback doesn't have to guess the encoding)."""
+    if not (api_key or "").strip():
+        raise CloudTTSError("no Deepgram API key configured")
+    model = (voice or DEFAULT_DEEPGRAM_VOICE).strip()
+    url = f"https://api.deepgram.com/v1/speak?model={model}&encoding=linear16&container=wav"
+    return _post_for_audio(
+        url,
+        {"Authorization": f"Token {api_key}", "Content-Type": "application/json"},
+        {"text": text},
+        timeout=timeout,
+        label="Deepgram speak",
+    )
+
+
+def elevenlabs_speak(text: str, voice_id: str, api_key: str, *, timeout: float = 20.0) -> bytes:
+    """POST to ElevenLabs' text-to-speech endpoint. Returns MP3 bytes."""
+    if not (api_key or "").strip():
+        raise CloudTTSError("no ElevenLabs API key configured")
+    if not (voice_id or "").strip():
+        raise CloudTTSError("no ElevenLabs voice ID configured")
+    url = f"https://api.elevenlabs.io/v1/text-to-speech/{voice_id}"
+    return _post_for_audio(
+        url,
+        {"xi-api-key": api_key, "Content-Type": "application/json"},
+        {"text": text},
+        timeout=timeout,
+        label="ElevenLabs speak",
+    )

--- a/wisprlite/voices_editor.py
+++ b/wisprlite/voices_editor.py
@@ -75,8 +75,9 @@ def main() -> None:
     vbar.pack(side="right", fill="y")
     canvas.pack(side="left", fill="both", expand=True)
     holder = tk.Frame(canvas, bg=BG)
-    canvas.create_window((0, 0), window=holder, anchor="nw")
+    _holder_window = canvas.create_window((0, 0), window=holder, anchor="nw")
     holder.bind("<Configure>", lambda e: canvas.configure(scrollregion=canvas.bbox("all")))
+    canvas.bind("<Configure>", lambda e: canvas.itemconfigure(_holder_window, width=e.width))
     canvas.bind("<Enter>", lambda e: canvas.bind_all(
         "<MouseWheel>", lambda ev: canvas.yview_scroll(int(-ev.delta / 120), "units")))
     canvas.bind("<Leave>", lambda e: canvas.unbind_all("<MouseWheel>"))

--- a/wisprlite/voices_editor.py
+++ b/wisprlite/voices_editor.py
@@ -77,7 +77,7 @@ def main() -> None:
     holder = tk.Frame(canvas, bg=BG)
     _holder_window = canvas.create_window((0, 0), window=holder, anchor="nw")
     holder.bind("<Configure>", lambda e: canvas.configure(scrollregion=canvas.bbox("all")))
-    canvas.bind("<Configure>", lambda e: canvas.itemconfigure(_holder_window, width=e.width))
+    winui.fit_scroll_body(canvas, _holder_window)
     canvas.bind("<Enter>", lambda e: canvas.bind_all(
         "<MouseWheel>", lambda ev: canvas.yview_scroll(int(-ev.delta / 120), "units")))
     canvas.bind("<Leave>", lambda e: canvas.unbind_all("<MouseWheel>"))


### PR DESCRIPTION
Three things James hit on v2.45.7.

### 1. About was pinned to the left in a maximised window
`create_window` keeps a canvas item at its natural width forever unless something binds it. Fixed once in `winui.fit_scroll_body()` and applied to **every** scrolling tab — About, History, Profiles, Settings, Voices — because they all had it. The helper also **caps and centres**, so a 2560px monitor doesn't put a control an inch from its label.

### 2. Read Aloud now selects what to read
James: *"select what I want to be read aloud... where we just highlight what we want"*. Base hotkey drags a region, +Shift is the whole screen, +Ctrl the focused window.

**This deliberately reverses the idea panel**, which argued for focused-window-by-default on the theory some user has no mouse. That was an inference about a hypothetical; James is the actual user and said plainly what he wants.

### 3. Voices: three tiers, and Settings finally says so
- **Windows** — default, offline, no key. Settings now explains that Windows 11's much better *Natural* voices aren't installed by default, with a button to `ms-settings:speech`.
- **Deepgram Aura-2** — reuses the `DEEPGRAM_API_KEY` already configured for dictation, no new account. Default `aura-2-draco-en`: British baritone, warm, trustworthy — the closest thing to the JARVIS register asked for.
- **ElevenLabs** — bring-your-own-key, like the transcription engines.

Windows stays default: screen contents can be anything, so a cloud voice is always an explicit choice. **Every cloud path degrades to the Windows voice with a reason** — never silence.

### Bugs found in review
- `build_speaker()` built the cloud player **outside** its try, so a call that succeeded then failed to play raised straight out — no fallback, silence.
- About and the Voices editor kept **inline copies** of the width fix instead of the new helper, and the inline ones had no cap.
- The `finally` overwrote the overlay unconditionally, so a read error was replaced by "done" before it could be read.
- Deepgram voice and ElevenLabs voice ID were interpolated **raw into URLs** — the latter is user-pasted free text, where a stray slash reaches a different endpoint.
- A bare `except Exception` relabelled our own `TypeError`s as cloud failures, hiding them behind the friendly fallback message.
- An unrecognised engine setting fell back silently with no reason.

### Verification
- **492 passing under a display**, same 15 pre-existing failures. The UI tests **skip headless** — two of my earlier sabotage readings were skips, not passes, and everything was re-run with xvfb.
- Every fix verified red by sabotage.
- Two jury findings refuted with the code: the screen-reader message isn't clobbered (that path returns early), and `asyncio.run` isn't at risk (called from a plain worker thread).

**Untested here:** how the Deepgram and ElevenLabs voices actually sound, and whether the tabs fill a real maximised window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)