### PR TITLE
feat(read-aloud): Pause, Restart and Stop on the pill

### DIFF
--- a/tests/test_overlay.py
+++ b/tests/test_overlay.py
@@ -335,3 +335,34 @@ def test_every_done_button_is_reachable_by_a_click():
         x1, y1, x2, y2 = ov._done_button_box(index)
         hit = ov._screenrec_hit((x1 + x2) // 2, (y1 + y2) // 2, "done")
         assert hit == action, f"clicking the {action!r} button returned {hit!r}"
+
+
+def test_reading_buttons_fit_inside_the_pill():
+    """Same shared geometry as the done row - must not regress just because a
+    second button set now uses it."""
+    from wisprlite.overlay import Overlay, WIN_W
+
+    ov = Overlay.__new__(Overlay)
+    boxes = [ov._done_button_box(i, Overlay.READING_BUTTONS)
+             for i in range(len(Overlay.READING_BUTTONS))]
+    assert boxes[0][0] >= 0, f"the first reading button starts off the left edge: {boxes[0]}"
+    assert boxes[-1][2] <= WIN_W, f"the last reading button runs off the right edge: {boxes[-1]}"
+    for left, right in zip(boxes, boxes[1:]):
+        assert left[2] <= right[0], "the reading buttons overlap"
+
+
+def test_every_reading_button_is_reachable_by_a_click():
+    from wisprlite.overlay import Overlay
+
+    ov = Overlay.__new__(Overlay)
+    for index, (action, _label) in enumerate(Overlay.READING_BUTTONS):
+        x1, y1, x2, y2 = ov._done_button_box(index, Overlay.READING_BUTTONS)
+        hit = ov._reading_hit((x1 + x2) // 2, (y1 + y2) // 2)
+        assert hit == action, f"clicking the {action!r} button returned {hit!r}"
+
+
+def test_a_click_outside_the_reading_buttons_hits_nothing():
+    from wisprlite.overlay import Overlay
+
+    ov = Overlay.__new__(Overlay)
+    assert ov._reading_hit(0, 0) == ""

--- a/tests/test_readaloud.py
+++ b/tests/test_readaloud.py
@@ -337,6 +337,8 @@ def test_a_second_press_during_the_ocr_pass_does_not_start_a_second_read():
 
     from uistub import install_platform_stubs
     install_platform_stubs()          # app.py imports sounddevice/keyboard at module scope
+    from uistub import install_platform_stubs
+    install_platform_stubs()
     from wisprlite.app import App
 
     app = App.__new__(App)
@@ -410,14 +412,22 @@ def _make_app():
     install_platform_stubs()
     from wisprlite.app import App
 
+    from unittest import mock
+
     app = App.__new__(App)
     app._read_aloud_speaker = None
     app._read_aloud_last_text = None
     app._read_aloud_busy = threading.Lock()
+    # Every read-aloud action reports the resulting state back to the pill, so
+    # an App built for a test needs an overlay even when the test does not
+    # assert on it.
+    app.overlay = mock.Mock()
     return app
 
 
 def test_ra_pause_pauses_a_playing_speaker():
+    from uistub import install_platform_stubs
+    install_platform_stubs()
     from wisprlite.app import App
 
     app = _make_app()
@@ -429,6 +439,8 @@ def test_ra_pause_pauses_a_playing_speaker():
 
 
 def test_ra_pause_toggles_to_resume_on_a_paused_speaker():
+    from uistub import install_platform_stubs
+    install_platform_stubs()
     from wisprlite.app import App
 
     app = _make_app()
@@ -440,25 +452,69 @@ def test_ra_pause_toggles_to_resume_on_a_paused_speaker():
     assert speaker.pause_calls == 0
 
 
-def test_ra_pause_label_reads_resume_after_one_click_and_pause_after_two():
-    """Gate 5, driven through the PRODUCTION toggle.
+def test_the_pause_label_follows_the_SPEAKER_not_the_click():
+    """Two sources of truth is the bug. The overlay used to flip the label
+    itself on a click, so pressing SPACE paused the speaker without the pill
+    knowing: the button read "Pause" while clicking it called resume().
 
-    The first version of this test flipped st["reading_paused"] itself and then
-    asserted the value it had just set - a self-fulfilling test that stayed
-    green when the real toggle was deleted.
+    The app owns the speaker, so the app pushes the label state.
     """
+    from unittest import mock
+
+    from uistub import install_platform_stubs
+    install_platform_stubs()
+    from wisprlite.app import App
+
+    app = App.__new__(App)
+    app.overlay = mock.Mock()
+    speaker = mock.Mock(paused=False)
+    app._read_aloud_speaker = speaker
+
+    def pause():
+        speaker.paused = True
+    def resume():
+        speaker.paused = False
+    speaker.pause.side_effect = pause
+    speaker.resume.side_effect = resume
+
+    App._screenrec_action(app, "ra_pause")
+    speaker.pause.assert_called_once()
+    app.overlay.set_reading_paused.assert_called_with(True)
+
+    App._screenrec_action(app, "ra_pause")
+    speaker.resume.assert_called_once()
+    app.overlay.set_reading_paused.assert_called_with(False)
+
+
+def test_a_pause_click_with_no_speaker_does_not_flip_the_label():
+    """Clicking Pause in the window before a speaker exists used to flip the
+    label to Resume with nothing to resume."""
+    from unittest import mock
+
+    from uistub import install_platform_stubs
+    install_platform_stubs()
+    from wisprlite.app import App
+
+    app = App.__new__(App)
+    app.overlay = mock.Mock()
+    app._read_aloud_speaker = None
+
+    App._screenrec_action(app, "ra_pause")
+
+    app.overlay.set_reading_paused.assert_not_called()
+
+
+def test_the_click_resolver_does_not_touch_the_label():
+    """It resolves. It must not also decide what the label says, or the two
+    disagree the moment a keypress pauses instead of a click."""
     from wisprlite.overlay import Overlay
 
     ov = Overlay.__new__(Overlay)
     st = {"name": "reading"}
-    x1, y1, x2, y2 = ov._done_button_box(0, Overlay.READING_BUTTONS)  # ra_pause
-    cx, cy = (x1 + x2) // 2, (y1 + y2) // 2
-
-    assert ov._pill_click(st, cx, cy) == "ra_pause"
-    assert st["reading_paused"] is True, "the label should now read Resume"
-
-    assert ov._pill_click(st, cx, cy) == "ra_pause"
-    assert st["reading_paused"] is False, "the label should read Pause again"
+    x1, y1, x2, y2 = ov._done_button_box(0, Overlay.READING_BUTTONS)
+    assert ov._pill_click(st, (x1 + x2) // 2, (y1 + y2) // 2) == "ra_pause"
+    assert "reading_paused" not in st, \
+        "the resolver is still guessing at the label state"
 
 
 def test_a_click_on_the_reading_pill_is_actually_routed():
@@ -492,6 +548,8 @@ def test_a_click_in_a_state_with_no_buttons_resolves_to_nothing():
 
 
 def test_ra_stop_stops_a_playing_speaker():
+    from uistub import install_platform_stubs
+    install_platform_stubs()
     from wisprlite.app import App
 
     app = _make_app()
@@ -502,6 +560,8 @@ def test_ra_stop_stops_a_playing_speaker():
 
 
 def test_ra_stop_with_no_active_speaker_does_nothing():
+    from uistub import install_platform_stubs
+    install_platform_stubs()
     from wisprlite.app import App
 
     app = _make_app()
@@ -509,6 +569,8 @@ def test_ra_stop_with_no_active_speaker_does_nothing():
 
 
 def test_ra_restart_with_no_prior_read_does_nothing():
+    from uistub import install_platform_stubs
+    install_platform_stubs()
     from wisprlite.app import App
 
     app = _make_app()
@@ -521,6 +583,8 @@ def test_ra_restart_speaks_again_without_re_running_ocr():
     Assert that directly against the source, and that speaking happens again."""
     from unittest import mock
 
+    from uistub import install_platform_stubs
+    install_platform_stubs()
     from wisprlite.app import App
 
     app = _make_app()

--- a/tests/test_readaloud.py
+++ b/tests/test_readaloud.py
@@ -382,6 +382,161 @@ def test_a_speaker_is_one_shot_and_says_so():
         "the one-shot contract is not documented on speak()"
 
 
+# ---- overlay controls (gates 1, 4, 5) --------------------------------------
+
+class _FakeSpeaker:
+    def __init__(self):
+        self.paused = False
+        self.pause_calls = 0
+        self.resume_calls = 0
+        self.stop_calls = 0
+
+    def pause(self):
+        self.pause_calls += 1
+        self.paused = True
+
+    def resume(self):
+        self.resume_calls += 1
+        self.paused = False
+
+    def stop(self):
+        self.stop_calls += 1
+
+
+def _make_app():
+    import threading
+
+    from uistub import install_platform_stubs
+    install_platform_stubs()
+    from wisprlite.app import App
+
+    app = App.__new__(App)
+    app._read_aloud_speaker = None
+    app._read_aloud_last_text = None
+    app._read_aloud_busy = threading.Lock()
+    return app
+
+
+def test_ra_pause_pauses_a_playing_speaker():
+    from wisprlite.app import App
+
+    app = _make_app()
+    speaker = _FakeSpeaker()
+    app._read_aloud_speaker = speaker
+    App._screenrec_action(app, "ra_pause")
+    assert speaker.pause_calls == 1
+    assert speaker.resume_calls == 0
+
+
+def test_ra_pause_toggles_to_resume_on_a_paused_speaker():
+    from wisprlite.app import App
+
+    app = _make_app()
+    speaker = _FakeSpeaker()
+    speaker.paused = True
+    app._read_aloud_speaker = speaker
+    App._screenrec_action(app, "ra_pause")
+    assert speaker.resume_calls == 1
+    assert speaker.pause_calls == 0
+
+
+def test_ra_pause_label_reads_resume_after_one_click_and_pause_after_two():
+    """Gate 5, driven through the PRODUCTION toggle.
+
+    The first version of this test flipped st["reading_paused"] itself and then
+    asserted the value it had just set - a self-fulfilling test that stayed
+    green when the real toggle was deleted.
+    """
+    from wisprlite.overlay import Overlay
+
+    ov = Overlay.__new__(Overlay)
+    st = {"name": "reading"}
+    x1, y1, x2, y2 = ov._done_button_box(0, Overlay.READING_BUTTONS)  # ra_pause
+    cx, cy = (x1 + x2) // 2, (y1 + y2) // 2
+
+    assert ov._pill_click(st, cx, cy) == "ra_pause"
+    assert st["reading_paused"] is True, "the label should now read Resume"
+
+    assert ov._pill_click(st, cx, cy) == "ra_pause"
+    assert st["reading_paused"] is False, "the label should read Pause again"
+
+
+def test_a_click_on_the_reading_pill_is_actually_routed():
+    """The reading branch lived inline in the Tk drain loop, where no test
+    could reach it - deleting the whole branch left every test green."""
+    from wisprlite.overlay import Overlay
+
+    ov = Overlay.__new__(Overlay)
+    for index, (action, _label) in enumerate(Overlay.READING_BUTTONS):
+        x1, y1, x2, y2 = ov._done_button_box(index, Overlay.READING_BUTTONS)
+        got = ov._pill_click({"name": "reading"}, (x1 + x2) // 2, (y1 + y2) // 2)
+        assert got == action, f"a click on {action!r} resolved to {got!r}"
+
+
+def test_the_same_click_resolver_still_serves_the_recording_pill():
+    """One function now serves both, so it must not have lost the other."""
+    from wisprlite.overlay import Overlay
+
+    ov = Overlay.__new__(Overlay)
+    x1, y1, x2, y2 = ov._done_button_box(0, Overlay.SCREENREC_DONE)
+    got = ov._pill_click({"name": "screenrec", "screenrec_phase": "done"},
+                         (x1 + x2) // 2, (y1 + y2) // 2)
+    assert got == Overlay.SCREENREC_DONE[0][0], f"the recording pill lost its clicks: {got!r}"
+
+
+def test_a_click_in_a_state_with_no_buttons_resolves_to_nothing():
+    from wisprlite.overlay import Overlay
+
+    ov = Overlay.__new__(Overlay)
+    assert ov._pill_click({"name": "listening"}, 100, 70) == ""
+
+
+def test_ra_stop_stops_a_playing_speaker():
+    from wisprlite.app import App
+
+    app = _make_app()
+    speaker = _FakeSpeaker()
+    app._read_aloud_speaker = speaker
+    App._screenrec_action(app, "ra_stop")
+    assert speaker.stop_calls == 1
+
+
+def test_ra_stop_with_no_active_speaker_does_nothing():
+    from wisprlite.app import App
+
+    app = _make_app()
+    App._screenrec_action(app, "ra_stop")   # must not raise
+
+
+def test_ra_restart_with_no_prior_read_does_nothing():
+    from wisprlite.app import App
+
+    app = _make_app()
+    App._screenrec_action(app, "ra_restart")   # must not raise, nothing to restart
+
+
+def test_ra_restart_speaks_again_without_re_running_ocr():
+    """Gate 4. `_read_aloud_speak` is the only thing ra_restart calls - it never
+    touches `readaloud.ocr_png`, so restarting cannot re-OCR by construction.
+    Assert that directly against the source, and that speaking happens again."""
+    from unittest import mock
+
+    from wisprlite.app import App
+
+    app = _make_app()
+    old_speaker = _FakeSpeaker()
+    app._read_aloud_speaker = old_speaker
+    app._read_aloud_last_text = "hello world"
+
+    with mock.patch.object(App, "_read_aloud_speak") as speak, \
+         mock.patch("wisprlite.readaloud.ocr_png") as ocr:
+        App._screenrec_action(app, "ra_restart")
+
+    assert old_speaker.stop_calls == 1, "restart must stop whatever was already playing"
+    speak.assert_called_once_with("hello world")
+    ocr.assert_not_called()
+
+
 def test_the_selftest_writes_its_verdict_to_a_file():
     """The release exe is built --noconsole, so stdout does not reach the CI log.
     The first real run of this gate failed the build correctly and printed

--- a/wisprlite/__init__.py
+++ b/wisprlite/__init__.py
@@ -1,3 +1,3 @@
 """Pipevoice — push-to-talk voice typing for Windows."""
 
-__version__ = "2.46.0"
+__version__ = "2.47.0"

--- a/wisprlite/app.py
+++ b/wisprlite/app.py
@@ -154,6 +154,7 @@ class App:
         )
         self._read_aloud_speaker = None   # the live readaloud.Speaker, None when idle
         self._read_aloud_busy = threading.Lock()   # one read at a time
+        self._read_aloud_last_text = None   # so Restart can re-speak without re-OCR
 
         self._screenrec = None        # the live ScreenRecording, None when idle
         self._screenrec_selecting = False   # the region selector is open
@@ -402,6 +403,16 @@ class App:
             self.overlay.set_state("done", "No text found")
             return
 
+        self._read_aloud_last_text = text
+        self._read_aloud_speak(text)
+
+    def _read_aloud_speak(self, text: str) -> None:
+        """Copy + speak already-captured text. Shared by the initial read and
+        `ra_restart`, so restarting never re-runs OCR - re-OCRing would be
+        slower and could return different text, which is not what "again"
+        means."""
+        from . import readaloud
+
         copied = bool(self.cfg.read_aloud_clipboard)
         if copied:
             copy_clipboard(text)
@@ -428,6 +439,29 @@ class App:
             # it - a failed read looked exactly like a successful one.
             if not failed:
                 self.overlay.set_state("done", fallback_reason[:80])
+
+    def _read_aloud_restart(self) -> None:
+        """Stop whatever is speaking and read the last-captured text again,
+        from the start - the achievable form of "rewind"."""
+        text = self._read_aloud_last_text
+        if not text:
+            return
+        speaker = self._read_aloud_speaker
+        if speaker is not None:
+            speaker.stop()
+        # Blocks until the interrupted read's own thread has actually released
+        # this lock (it does so right after speaker.speak() returns, which
+        # stop() forces within ~200ms) - so that thread's finally cannot clear
+        # the NEW speaker this call is about to set.
+        if not self._read_aloud_busy.acquire(timeout=5):
+            return
+        try:
+            self._read_aloud_speak(text)
+        finally:
+            try:
+                self._read_aloud_busy.release()
+            except RuntimeError:
+                pass
 
     def _read_aloud_watch_interrupt(self, speaker) -> None:
         """Esc stops, Space pauses/resumes, the hotkey again stops. Polled at
@@ -752,6 +786,17 @@ class App:
 
     def _screenrec_action(self, action: str, value: str = "") -> None:
         """A control on the pill. Runs on the overlay's worker thread."""
+        if action in ("ra_pause", "ra_stop", "ra_restart"):
+            speaker = self._read_aloud_speaker
+            if action == "ra_pause":
+                if speaker is not None:
+                    (speaker.resume if speaker.paused else speaker.pause)()
+            elif action == "ra_stop":
+                if speaker is not None:
+                    speaker.stop()
+            else:
+                self._read_aloud_restart()
+            return
         if action in ("save", "skip"):
             self._screenrec_ui.answer_name(value if action == "save" else "")
             return

--- a/wisprlite/app.py
+++ b/wisprlite/app.py
@@ -483,6 +483,9 @@ class App:
                 space = keyboard.is_pressed("space")
                 if space and not prev_space:
                     (speaker.resume if speaker.paused else speaker.pause)()
+                    # The pill has to hear about a KEYBOARD pause too, or the
+                    # button says "Pause" while clicking it resumes.
+                    self.overlay.set_reading_paused(speaker.paused)
                 prev_space = space
                 hotkey_down = _all_pressed(self.cfg.read_aloud_hotkey)
                 if hotkey_down and not prev_hotkey:
@@ -791,6 +794,10 @@ class App:
             if action == "ra_pause":
                 if speaker is not None:
                     (speaker.resume if speaker.paused else speaker.pause)()
+                    # Push the REAL state back, so the label cannot drift from
+                    # the speaker - and so a click with no live speaker does
+                    # not flip the label onto nothing.
+                    self.overlay.set_reading_paused(speaker.paused)
             elif action == "ra_stop":
                 if speaker is not None:
                     speaker.stop()

--- a/wisprlite/overlay.py
+++ b/wisprlite/overlay.py
@@ -143,6 +143,16 @@ class Overlay:
     def set_state(self, state: str, text: Optional[str] = None) -> None:
         self._q.put(("state", state, text))
 
+    def set_reading_paused(self, paused: bool) -> None:
+        """Tell the pill whether the voice is paused, so the button can say
+        Pause or Resume truthfully.
+
+        The overlay used to flip this itself on a click, which made it a SECOND
+        source of truth: pressing Space paused the speaker without the pill
+        knowing, so the button read "Pause" while clicking it called resume().
+        The app owns the speaker, so the app owns the label."""
+        self._q.put(("reading_paused", "1" if paused else "", None))
+
     def set_text(self, text: str) -> None:
         self._q.put(("text", None, text))
 
@@ -318,6 +328,8 @@ class Overlay:
                         st["hide_at"] = 0.0
                         resize(WIN_H)
                         reveal()
+                    elif kind == "reading_paused":
+                        st["reading_paused"] = bool(state)
                     elif kind == "state":
                         if state:
                             # A fresh "reading" message always means a new
@@ -656,10 +668,10 @@ class Overlay:
         if name == "screenrec":
             return self._screenrec_hit(x, y, st.get("screenrec_phase", "recording"))
         if name == "reading":
-            action = self._reading_hit(x, y)
-            if action == "ra_pause":
-                st["reading_paused"] = not st.get("reading_paused", False)
-            return action
+            # Resolve only. The label is NOT flipped here: the app owns the
+            # speaker and pushes the real state back via set_reading_paused,
+            # so a Space keypress and a button click cannot disagree.
+            return self._reading_hit(x, y)
         return ""
 
     def _reading_hit(self, x, y) -> str:

--- a/wisprlite/overlay.py
+++ b/wisprlite/overlay.py
@@ -272,9 +272,12 @@ class Overlay:
                         if st["name"] == "meeting" and self.on_meeting_click:
                             callback = self.on_meeting_click
                             threading.Thread(target=callback, daemon=True).start()
-                        elif st["name"] == "screenrec" and self.on_screenrec_action:
-                            action = self._screenrec_hit(
-                                state, text, st.get("screenrec_phase", "recording"))
+                        elif self.on_screenrec_action:
+                            # ONE call, not a branch per state. The reading
+                            # branch and its label toggle used to live inline
+                            # here, where nothing could reach them: deleting
+                            # either left every test green.
+                            action = self._pill_click(st, state, text)
                             if action:
                                 fire(action)
                     elif kind == "hover":
@@ -317,6 +320,11 @@ class Overlay:
                         reveal()
                     elif kind == "state":
                         if state:
+                            # A fresh "reading" message always means a new
+                            # read - the initial one, or ra_restart - so the
+                            # Pause label must not carry over a stale pause.
+                            if state == "reading":
+                                st["reading_paused"] = False
                             st["name"] = state
                         if text is not None:
                             st["text"] = text
@@ -356,6 +364,8 @@ class Overlay:
                 except Exception:
                     phase = "recording"
                 resize(self.SCREENREC_H.get(phase, WIN_H))
+            elif st["name"] == "reading":
+                resize(self.SCREENREC_H["done"])   # same taller pill, same button row
             if st["visible"]:
                 self._draw(canvas, st)
             root.after(FRAME_MS, tick)
@@ -384,6 +394,9 @@ class Overlay:
             return
         if st["name"] == "screenrec":
             self._draw_screenrec(c, st, H, accent)
+            return
+        if st["name"] == "reading":
+            self._draw_reading(c, st, H, accent)
             return
         self._draw_status(c, st, H, accent)
 
@@ -603,25 +616,59 @@ class Overlay:
     # not say "open PipeVoice".
     SCREENREC_DONE = (("play", "Play"), ("send", "Send"),
                       ("copy", "Copy path"), ("open", "Open"))
+    # Reading-pill controls. Prefixed ra_ so they cannot collide with the
+    # screenrec actions they share a callback with. Stop is rightmost and
+    # drawn as the primary action - it's the one you reach for in a hurry.
+    READING_BUTTONS = (("ra_pause", "Pause"), ("ra_restart", "Restart"),
+                        ("ra_stop", "Stop"))
     DONE_BTN_H, DONE_BTN_Y = 30, 62
     DONE_GAP, DONE_EDGE = 8, 8
     SCREENREC_H = {"recording": WIN_H, "naming": 88, "working": WIN_H, "done": 100}
 
-    def _done_button_w(self):
+    def _done_button_w(self, buttons=None):
         # Derived from the count, never a constant. A fourth button at the old
         # fixed 108px measured 456px inside a 380px pill, so two of them would
         # have been drawn off the edge - and the hit test would still have
         # claimed they were there.
-        count = len(self.SCREENREC_DONE)
+        buttons = self.SCREENREC_DONE if buttons is None else buttons
+        count = len(buttons)
         gaps = (count - 1) * self.DONE_GAP
         return max(48, (WIN_W - 2 * self.DONE_EDGE - gaps) // count)
 
-    def _done_button_box(self, index: int):
-        width = self._done_button_w()
-        count = len(self.SCREENREC_DONE)
+    def _done_button_box(self, index: int, buttons=None):
+        buttons = self.SCREENREC_DONE if buttons is None else buttons
+        width = self._done_button_w(buttons)
+        count = len(buttons)
         total = count * width + (count - 1) * self.DONE_GAP
         x1 = (WIN_W - total) // 2 + index * (width + self.DONE_GAP)
         return x1, self.DONE_BTN_Y, x1 + width, self.DONE_BTN_Y + self.DONE_BTN_H
+
+    def _pill_click(self, st, x, y) -> str:
+        """Resolve a click on the pill for whichever state it is in, and apply
+        any state change the click implies.
+
+        This exists as one function so the WIRING is testable. The hit tests
+        and the Pause-label toggle were each covered, but only ever invoked
+        from inside the Tk drain loop - so removing the invocation, or the
+        toggle, broke nothing any test could see.
+        """
+        name = st.get("name")
+        if name == "screenrec":
+            return self._screenrec_hit(x, y, st.get("screenrec_phase", "recording"))
+        if name == "reading":
+            action = self._reading_hit(x, y)
+            if action == "ra_pause":
+                st["reading_paused"] = not st.get("reading_paused", False)
+            return action
+        return ""
+
+    def _reading_hit(self, x, y) -> str:
+        """Which reading-pill button a click at (x, y) landed on, or ""."""
+        for index, (action, _label) in enumerate(self.READING_BUTTONS):
+            x1, y1, x2, y2 = self._done_button_box(index, self.READING_BUTTONS)
+            if x1 <= x <= x2 and y1 <= y <= y2:
+                return action
+        return ""
 
     def _screenrec_hit(self, x, y, phase: str = "recording") -> str:
         """Which control a click at (x, y) landed on, or "" for the pill body."""
@@ -805,6 +852,32 @@ class Overlay:
         entry.bind("<Return>", lambda _e: self._q.put(("screenrec_submit", "save", "")))
         entry.bind("<Escape>", lambda _e: self._q.put(("screenrec_submit", "skip", "")))
         return entry
+
+    def _draw_reading(self, c, st, H: int, accent: str) -> None:
+        """The reading pill: preview text, the shortcuts nobody knew existed,
+        and Pause/Restart/Stop so the voice is never one you cannot see how to
+        interrupt."""
+        items = self._base_scene(c, st, "reading", H, accent)
+        if "reading_text" not in items:
+            items["reading_text"] = c.create_text(
+                24, 26, anchor="w", fill=PALETTE["fg"], font=("Segoe UI Semibold", 11))
+            items["reading_hint"] = c.create_text(
+                24, 44, anchor="w", fill=PALETTE["muted"], font=("Segoe UI", 8),
+                text="Esc stop · Space pause")
+            for index, (action, label) in enumerate(self.READING_BUTTONS):
+                x1, y1, x2, y2 = self._done_button_box(index, self.READING_BUTTONS)
+                items[f"reading_{action}_bg"] = self._round_rect(
+                    c, x1, y1, x2, y2, 8, fill=PALETTE["card"], outline="")
+                items[f"reading_{action}_text"] = c.create_text(
+                    (x1 + x2) // 2, (y1 + y2) // 2, text=label,
+                    fill=PALETTE["fg"], font=("Segoe UI", 9))
+        c.itemconfigure(items["reading_text"], text=self._fit(st["text"], WIN_W - 48))
+        # A "Pause" label on an already-paused read is a lie - the overlay
+        # tracks its own paused flag so the label always matches reality.
+        c.itemconfigure(items["reading_ra_pause_text"],
+                        text="Resume" if st.get("reading_paused") else "Pause")
+        c.itemconfigure(items["reading_ra_stop_bg"], fill=accent)
+        c.itemconfigure(items["reading_ra_stop_text"], fill="#1a0c0d")
 
     def _draw_status(self, c, st, H: int, accent: str) -> None:
         items = self._base_scene(c, st, "status", H, accent)


### PR DESCRIPTION
James: *"there is no stop feature. So it just carries on talking. Doesn't allow you to pause or stop it, or rewind."*

Esc, Space and the hotkey already worked, but nothing said so — and an undiscoverable shortcut is the same as no shortcut. The `reading` state was only a **colour**: it fell through to plain text rendering, and the pill's click routing only handled the meeting and recording states, so clicking it did literally nothing.

**Now:** Pause / Restart / Stop, with Stop rightmost and primary, plus a muted `Esc stop · Space pause` line. **Restart re-speaks the captured text without re-running OCR** — re-OCR would be slower and could come back different, which isn't what "again" means.

### Two guarantees had tests named after them and neither was real
- The Pause-label test flipped `st["reading_paused"]` **itself**, then asserted the value it had just set. Deleting the production toggle left it green.
- The click routing had **no test at all** — removing the whole reading branch broke nothing.

Both lived inline in the Tk drain loop where no test can reach. Click resolution is now one `_pill_click()` that both pills go through, so losing a branch takes tests with it.

### Jury findings
- **Two sources of truth for "paused"** (real): the overlay flipped the label on a click, so pressing **Space** paused the speaker without the pill knowing — the button read "Pause" while clicking it called `resume()`. The app owns the speaker, so the app now pushes the label state via `set_reading_paused()`, from both the click and the keyboard path. The P3 (clicking Pause with no speaker flipped the label onto nothing) falls out of the same fix.
- **Refuted:** the claim that `_read_aloud_restart`'s lock protects nothing. The lock is acquired in `_read_aloud_trigger` and released in `_read_aloud_run`'s `finally` — it *is* held for the whole read. The finding looked at `_read_aloud_speak`, which isn't where the acquire lives.

### Verification
**507 passing under xvfb**, same 15 pre-existing failures. Six sabotages verified red, including the two that previously slipped through. Also made every App-importing test install its own platform stubs — two were passing only because another test had stubbed globally first.

**Not verifiable here:** how the buttons actually render and feel on Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)