### PR TITLE
feat(read-aloud): an ElevenLabs key field that exists, per-engine rows, and voice preview

### DIFF
--- a/GATES.md
+++ b/GATES.md
@@ -1,140 +1,102 @@
-# Gates — Read Aloud (`vault/Plans/pipevoice-read-aloud.md`)
+# Gates — ElevenLabs key + voice preview (`vault/Plans/pipevoice-voice-keys-and-preview.md`)
 
 Bound to the code tree (`wisprlite/`, `tests/`), not to a commit id.
 
-1. Spike 1 passes on a clean Windows Sandbox — a frozen exe activating both
-   WinRT namespaces.
-   NOT VERIFIABLE ON THIS VPS: no Windows, no display, no Windows Sandbox.
-   Per the plan's DECISION 2026-09-04, this is relocated to CI instead of a
-   one-off spike run: `--winrt-selftest` (wisprlite/readaloud.py:113,
-   wired in `wisprlite/__main__.py`) activates both `Windows.Media.Ocr` and
-   `Windows.Media.SpeechSynthesis` from the code that will actually ship, and
-   `.github/workflows/build.yml`'s new "Self-test WinRT" step runs it against
-   the BUILT exe and fails the build on a non-zero exit. This step itself has
-   not run yet — it runs on the next push to `main`/CI trigger, on a real
-   Windows runner. Cannot be claimed PASS from here.
-
-2. Spike 2's CER table, >25% kill criterion.
-   NOT VERIFIABLE ON THIS VPS: needs real screenshots and a human transcribing
-   ground truth. Per the plan's DECISION, this moved to James testing the real
-   build, not a script's number. Not attempted here.
-
-3. The hotkey does not collide with the six existing chords.
-   CHECK: `python3 -m pytest -q tests/test_readaloud.py -k hotkey`
+1. `save_api_key` is called with `ELEVENLABS_API_KEY` when the field is filled;
+   the single-reader test still passes.
+   CHECK: `python3 -m pytest -q tests/test_tts_cloud.py::test_the_elevenlabs_key_has_exactly_one_reader`
+          `xvfb-run -a python3 -m pytest -q tests/test_read_aloud_voice_keys.py::test_elevenlabs_key_is_saved_through_save_api_key`
    EXPECT: pass.
-   RESULT: PASS. `read_aloud_hotkey` defaults to `""` (off), same convention as
-   meeting/screenrec/bookmark/voice-picker hotkeys. All three capture modes
-   (window/screen/region) live on ONE hotkey field — the modifier held at
-   trigger time picks the mode (`readaloud.capture_mode_for`,
-   `app.py:_read_aloud_run`) — so there is nothing else to collide.
-   `test_read_aloud_default_hotkey_does_not_collide_with_the_six_existing_chords`
-   and its sabotage twin
-   `test_a_user_configured_read_aloud_hotkey_does_not_shadow_the_others` (which
-   deliberately collides one first, to prove the check can fail) both pass.
+   RESULT: PASS. `wisprlite/settings.py:1951` calls
+   `config.save_api_key("ELEVENLABS_API_KEY", eleven_key_var.get())` when the
+   field is non-blank — the same pattern every other engine key already uses,
+   and the only new occurrence of the string in the codebase (config.py's
+   getter is the other one the single-reader test allows).
 
-4. Capture never touches disk.
-   CHECK: `python3 -m pytest -q tests/test_readaloud.py -k grab_png`
+2. Switching the engine picker shows the matching rows and hides the others -
+   drive the trace callback directly and assert `winfo_ismapped()`.
+   CHECK: `xvfb-run -a python3 -m pytest -q tests/test_read_aloud_voice_keys.py::test_engine_picker_shows_only_the_matching_rows`
    EXPECT: pass.
-   RESULT: PASS. `readaloud.grab_png` builds the PNG with `mss.tools.to_png`
-   in memory and returns bytes; never opens a file.
-   `test_grab_png_never_writes_a_temp_file` runs it in an empty `tmp_path` cwd
-   (with `mss` stubbed in `sys.modules`, since it isn't installed on this
-   Linux box) and asserts the directory is still empty afterward.
+   RESULT: PASS. `read_aloud_tts_var.trace_add("write", _on_read_aloud_tts)`
+   (`wisprlite/settings.py:1243`) pack_forgets all three engine-specific
+   groups and packs only the chosen one. Windows/Deepgram/ElevenLabs rows are
+   hidden entirely (not greyed) when not selected.
 
-5. Speaking is interruptible: Esc during a long read stops within ~200ms.
-   CHECK: `python3 -m pytest -q tests/test_readaloud.py -k stop`
+3. Preview uses the FORM values, not the saved config.
+   CHECK: `xvfb-run -a python3 -m pytest -q tests/test_read_aloud_voice_keys.py::test_preview_uses_the_unsaved_form_value_not_the_saved_config`
    EXPECT: pass.
-   RESULT: PASS. `readaloud.Speaker.stop()` calls the WinRT `MediaPlayer`'s own
-   `pause()` SYNCHRONOUSLY on the calling thread — not after the current
-   sentence, not via a flag checked later — so the interrupt latency is bounded
-   by how fast `MediaPlayer.pause()` returns, not by text length or poll rate.
-   `test_stop_pauses_the_player_synchronously_not_after_the_text_finishes`
-   injects a fake player whose `play()` calls `stop()` mid-call and asserts
-   `pause` was already recorded by the time `speak()` returns. The actual
-   keyboard polling loop (`app.py:_read_aloud_watch_interrupt`) runs at ~50Hz
-   (20ms), well under the 200ms budget, and calls this same `stop()`.
-   NOT MEASURED end-to-end with real audio: no Windows, no speakers, no WinRT
-   here. The synchronous-call guarantee is what the real ~200ms bound rests on;
-   an actual stopwatch measurement needs James's machine.
+   RESULT: PASS. `_run_preview` builds the snapshot from the live Tk vars
+   (`wisprlite/settings.py:1248` `_preview_snapshot`) at click time, before
+   the worker thread starts — changing the voice field without saving and
+   clicking Preview builds the speaker with the unsaved value.
 
-6. Full suite, baselined on `main` first (15 pre-existing failures; must not
-   add a sixteenth).
+4. Preview failure shows the reason and does NOT fall back to Windows
+   silently.
+   CHECK: `xvfb-run -a python3 -m pytest -q tests/test_read_aloud_voice_keys.py::test_preview_failure_shows_the_reason_and_does_not_fall_back_silently`
+   EXPECT: pass.
+   RESULT: PASS. When `readaloud.build_speaker` returns a non-empty degrade
+   reason, `_run_preview` shows it in the card and returns WITHOUT calling
+   `speaker.speak()` — the one path (a real read) that intentionally falls
+   back to the Windows voice is not taken here.
+
+5. The preview button is disabled while running and re-enabled after a
+   failure.
+   CHECK: `xvfb-run -a python3 -m pytest -q tests/test_read_aloud_voice_keys.py::test_preview_button_disabled_while_running_and_reenabled_after_failure`
+   EXPECT: pass.
+   RESULT: PASS. Disabled synchronously before the worker thread starts;
+   re-enabled in a `finally` regardless of success/failure/early-return.
+   NOTE ON TEST METHOD: the worker thread's `root.after(...)` call requires
+   the interpreter to be genuinely inside `mainloop()` to be delivered from a
+   different thread — a bare `root.update()` polling loop makes this
+   deterministically raise "main thread is not in main loop" in this harness
+   (unrelated to this change; the pre-existing `_cache_size` background
+   thread in Settings hits the identical error under the same polling style,
+   visible as a warning in every settings test run). The new test runs a real
+   `root.mainloop()` with an `after`-scheduled quit instead, which is also
+   the closer match to how the shipped app actually runs (blocked in
+   `mainloop()` the whole time a preview plays).
+
+6. Full suite under xvfb, baseline `main` first: 15 pre-existing failures, do
+   not add a sixteenth.
    CHECK: `python3 -m pytest -q --ignore=tests/test_transcribe_deepgram_e2e.py`
+          `xvfb-run -a python3 -m pytest -q --ignore=tests/test_transcribe_deepgram_e2e.py --ignore=tests/test_screenrec.py`
    EXPECT: same 15 pre-existing failures (test_env_precedence.py x8,
    test_transcribe_window.py x7), 0 new failures.
-   RESULT: PASS. Baseline (before any edit, this worktree): 15 failed, 402
-   passed, 25 skipped. After changes: 15 failed (identical set), 423 passed
-   (402 + 21 new in tests/test_readaloud.py), 25 skipped.
-   Settings UI also verified under `xvfb-run` (real Tk, real display):
-   `tests/test_ui_smoke.py` builds every settings tab including the new "Read
-   Aloud" card — 39 passed, no new widget errors.
-   NOT CLEAN: running the FULL suite (not just ui_smoke) under `xvfb-run`
-   aborts with a native `Fatal Python error: Aborted` inside PyAV's H.264
-   encoder, in `tests/test_screenrec.py::test_a_long_recording_does_not_hold_
-   every_frame_in_memory` (`wisprlite/screenrec.py:207 _encode_frame`) — a
-   file this PR does not touch. Reproduced twice, always at the same test.
-   Excluding `tests/test_readaloud.py` from the same xvfb run, the full suite
-   passes cleanly (427 passed, same 15 failures, no crash) — so the crash only
-   appears once the suite is large enough, under xvfb, on this VPS's
-   run-limited 4GB memory cap; nothing in the crash's own stack trace touches
-   `readaloud.py`, `app.py`'s read-aloud code, or the settings/overlay edits.
-   Read as a resource-pressure artifact of this shared, capped VPS, not a
-   defect in this diff — but flagging it plainly rather than omitting it,
-   since I could not get a fully clean xvfb run with the new test file
-   present. The gate as WRITTEN in the plan (non-xvfb `pytest -q`) is clean.
+   RESULT: PASS. Non-xvfb: 15 failed (identical set), 480 passed, 32 skipped.
+   Xvfb (excluding `test_screenrec.py`, same PyAV/xvfb crash on this VPS
+   documented in the prior Read Aloud PR's gates, unrelated to this diff):
+   15 failed (identical set), 461 passed, 0 new failures. Did not re-attempt
+   including `test_screenrec.py` in the same xvfb run — already known
+   resource-pressure crash on this box, not reproduced by anything touched
+   here.
 
 ## What was built
 
-- `wisprlite/readaloud.py` — capture (focused-window rect via ctypes, `mss`
-  grab to PNG bytes in memory), OCR via `Windows.Media.Ocr`, speech via
-  `Windows.Media.SpeechSynthesis` + `MediaPlayer` (interruptible), screen-reader
-  detection (informational only, never gates speaking), `--winrt-selftest`.
-- `wisprlite/config.py`: `read_aloud_hotkey` (`""` = off, matches the
-  meeting/screenrec/bookmark convention), `read_aloud_voice`, `read_aloud_rate`,
-  `read_aloud_ocr_language`, `read_aloud_clipboard` (default True),
-  `read_aloud_quiet_with_screenreader` (default **False** — speaks always,
-  per the panel's decision).
-- `wisprlite/app.py`: one `HotkeyManager` (`read_aloud_hotkeys`), started in
-  `run()`; `_read_aloud_trigger` / `_read_aloud_run` /
-  `_read_aloud_watch_interrupt` — capture mode picked by which modifier is ALSO
-  held (Shift = whole screen, Ctrl = drag a region via the existing
-  `screenrec.select_region()`, neither = focused window); clipboard copy
-  (never silent about it); everything wrapped so a `ReadAloudError` shows on
-  the overlay instead of raising into the hotkey loop.
-- `wisprlite/overlay.py`: a `"reading"` accent color, reusing the existing
-  generic `show`/`set_state` status-pill mechanism — no new custom-drawn phase,
-  since the pill already renders arbitrary state+text (`_draw_status`).
-- `wisprlite/settings.py`: a "Read Aloud" card (hotkey + Capture button, voice,
-  speed, OCR language, clipboard toggle, "stay quiet" toggle — default off,
-  with copy explaining why).
-- `wisprlite/__main__.py`: routes `--winrt-selftest` to `readaloud.main`.
-- `.github/workflows/build.yml`: `--collect-all winrt` added to the PyInstaller
-  build, and a new "Self-test WinRT" step runs `Pipevoice.exe --winrt-selftest`
-  against the built exe and fails the build on it (spike 1, made permanent).
-- `requirements.txt`: `winrt-*` at `3.2.1` (not `winsdk`, which is a beta),
-  each `; sys_platform == "win32"` so this Linux test suite still installs.
-- `tests/test_readaloud.py`: 21 tests — mode selection, hotkey-collision
-  (with a sabotage twin), no-disk-write capture (with a sabotage twin),
-  degrade-without-WinRT (import failure, no OCR engine, no voices — each
-  distinct), interrupt latency mechanism, speak-always-by-default with the
-  screen-reader opt-out. WinRT and `mss` are stubbed in `sys.modules` the same
-  way `tests/test_deepgram_bias.py` stubs the Deepgram SDK, per the plan's
-  "Tests must import on Linux" instruction.
+- `wisprlite/settings.py`: an "ElevenLabs API key" field in the Read Aloud
+  card, saved through the existing `save_api_key`. The card now shows only
+  the rows for the chosen voice engine (Windows voice picker + "get better
+  voices" link / Deepgram voice list + "already configured" note / ElevenLabs
+  key + voice ID + a link to find it), toggled by a `trace_add("write", ...)`
+  on the engine picker — the same pattern `_on_cleanup_provider` already used
+  for reacting to a picker change, extended to actually hide/show rows. A
+  "Preview" button next to the engine picker speaks one fixed sentence
+  through `readaloud.build_speaker` built from the unsaved form values, off
+  the Tk thread, disabled while running and re-enabled in a `finally`; a
+  degrade reason from `build_speaker` is shown in the card and does not
+  trigger the Windows fallback playback.
+- `tests/test_read_aloud_voice_keys.py`: 5 new tests, one per gate above.
 
 ## Explicitly not built (per the plan)
 
-- **Piper, ElevenLabs.** Not touched.
-- **"Re-OCR the last region."** Cut by the panel; not built.
-- **Custom UI Automation provider for the overlay.** Cut by the panel; the
-  overlay stays ordinary Tk.
-- **NVDA/JAWS-based auto-silencing.** The opposite was built on purpose: speak
-  always, opt-out setting only, default off.
+- Fetching the ElevenLabs voice catalogue over the API to build a picklist.
+  Per-account and needs a valid key to enumerate — the ID field plus a link
+  is what the plan asked for.
 
 ## Not verifiable on this VPS
 
-- Gate 1 (Windows Sandbox activation) and Gate 2 (OCR CER table) — no Windows.
-- The real end-to-end ~200ms interrupt latency with actual audio — no
-  speakers, no WinRT, no Windows.
-- Whether the CI `--winrt-selftest` step actually passes on a GitHub Actions
-  Windows runner (language pack / voice availability there is untested from
-  here) — it will report PASS/FAIL for real the next time CI runs.
+- The real ElevenLabs/Deepgram network round-trip during a preview (no
+  network keys configured here; `build_speaker` is exercised directly by the
+  readaloud/tts_cloud unit tests, and the settings-side wiring is exercised
+  with a faked `build_speaker`).
+- Real Windows voice enumeration/playback — no Windows, no WinRT, no
+  speakers on this box, same limitation as the prior Read Aloud PR.

--- a/tests/test_read_aloud_voice_keys.py
+++ b/tests/test_read_aloud_voice_keys.py
@@ -287,3 +287,93 @@ def test_preview_button_disabled_while_running_and_reenabled_after_failure():
             root.destroy()
     finally:
         readaloud.build_speaker = orig_build
+
+
+def test_preview_uses_a_key_that_is_typed_but_not_yet_saved():
+    """Paste a key, press Preview. That is the obvious order, and without this
+    it failed with "no ElevenLabs API key configured" while the key sat right
+    there in the box - because build_speaker read the SAVED key."""
+    import types
+    from unittest import mock
+    from wisprlite import readaloud, tts_cloud
+    from wisprlite import config as _config
+
+    cfg = types.SimpleNamespace(
+        read_aloud_tts="elevenlabs", read_aloud_rate=1.0, read_aloud_voice="",
+        read_aloud_elevenlabs_voice_id="abc123",
+        read_aloud_elevenlabs_key="typed-not-saved",
+    )
+    seen = {}
+
+    def fake(text, voice_id, api_key, **kw):
+        seen["key"] = api_key
+        return b"audio"
+
+    with mock.patch.object(tts_cloud, "elevenlabs_speak", side_effect=fake), \
+         mock.patch.object(_config, "elevenlabs_key", return_value=""), \
+         mock.patch.object(readaloud, "_winrt_player_from_bytes", return_value=object()):
+        _speaker, reason = readaloud.build_speaker("hello", cfg)
+
+    assert seen.get("key") == "typed-not-saved", \
+        f"preview used the saved key, not the typed one: {seen!r}"
+    assert reason == "", f"it fell back despite a usable key: {reason!r}"
+
+
+def test_a_saved_key_is_still_used_when_nothing_is_typed():
+    """The override must not break the normal path, where the field is blank
+    because the key is already saved."""
+    import types
+    from unittest import mock
+    from wisprlite import readaloud, tts_cloud
+    from wisprlite import config as _config
+
+    cfg = types.SimpleNamespace(
+        read_aloud_tts="deepgram", read_aloud_rate=1.0,
+        read_aloud_voice="aura-2-draco-en", read_aloud_deepgram_key="",
+    )
+    seen = {}
+
+    def fake(text, voice, api_key, **kw):
+        seen["key"] = api_key
+        return b"audio"
+
+    with mock.patch.object(tts_cloud, "deepgram_speak", side_effect=fake), \
+         mock.patch.object(_config, "deepgram_key", return_value="saved-key"), \
+         mock.patch.object(readaloud, "_winrt_player_from_bytes", return_value=object()):
+        readaloud.build_speaker("hello", cfg)
+
+    assert seen.get("key") == "saved-key", f"the saved key was ignored: {seen!r}"
+
+
+def test_the_preview_snapshot_carries_the_typed_keys():
+    """It was a closure inside main(), so dropping a field from it broke no
+    test while breaking the one flow Preview exists for."""
+    from wisprlite.settings import preview_snapshot
+
+    snap = preview_snapshot(
+        tier="elevenlabs", voice=" aura-2-draco-en ", elevenlabs_voice_id=" abc ",
+        rate_text="1.5", elevenlabs_key="  el-key  ", deepgram_key=" dg-key ")
+
+    assert snap.read_aloud_elevenlabs_key == "el-key"
+    assert snap.read_aloud_deepgram_key == "dg-key"
+    assert snap.read_aloud_voice == "aura-2-draco-en"
+    assert snap.read_aloud_elevenlabs_voice_id == "abc"
+    assert snap.read_aloud_rate == 1.5
+
+
+def test_a_nonsense_rate_does_not_break_preview():
+    from wisprlite.settings import preview_snapshot
+
+    for text in ("", "  ", "fast", None):
+        snap = preview_snapshot(tier="windows", voice="", elevenlabs_voice_id="",
+                                rate_text=text, elevenlabs_key="", deepgram_key="")
+        assert snap.read_aloud_rate == 1.0, f"{text!r} produced {snap.read_aloud_rate}"
+
+
+def test_the_rate_is_clamped_to_the_supported_range():
+    from wisprlite.settings import preview_snapshot
+
+    assert preview_snapshot(tier="windows", voice="", elevenlabs_voice_id="",
+                            rate_text="9", elevenlabs_key="", deepgram_key="").read_aloud_rate == 2.0
+    assert preview_snapshot(tier="windows", voice="", elevenlabs_voice_id="",
+                            rate_text="0.1", elevenlabs_key="", deepgram_key="").read_aloud_rate == 0.5

--- a/tests/test_read_aloud_voice_keys.py
+++ b/tests/test_read_aloud_voice_keys.py
@@ -1,0 +1,289 @@
+"""Read Aloud: ElevenLabs key field, per-engine rows, and voice preview.
+
+Run headless with:  xvfb-run -a python -m pytest tests/test_read_aloud_voice_keys.py
+Skips cleanly when there is no display.
+"""
+
+import pathlib
+import sys
+import threading
+import time
+import tkinter as tk
+import types
+
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent))
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+
+from uistub import have_display, install_platform_stubs
+
+install_platform_stubs()
+
+DISPLAY = have_display()
+SKIP = "no X display; run under xvfb-run"
+
+
+def _skip_if_headless():
+    if not DISPLAY:
+        pytest.skip(SKIP)
+
+
+def _find(widget, predicate):
+    for child in widget.winfo_children():
+        try:
+            if predicate(child):
+                return child
+        except Exception:
+            pass
+        found = _find(child, predicate)
+        if found is not None:
+            return found
+    return None
+
+
+def _find_by_text(widget, prefix):
+    return _find(widget, lambda w: str(w.cget("text")).startswith(prefix))
+
+
+def _build(monkeypatch=None):
+    """Build the real Settings window on the Read Aloud tab and return the root."""
+    import os
+    import tkinter as tk
+    from wisprlite import settings
+
+    os.environ["PV_TAB"] = "Settings"
+    captured: dict = {}
+    real_mainloop = tk.Misc.mainloop
+
+    def stub_mainloop(self, _n=0):
+        self.update_idletasks()
+        self.update()
+        captured["root"] = self
+
+    tk.Misc.mainloop = stub_mainloop
+    try:
+        settings.main()
+    finally:
+        tk.Misc.mainloop = real_mainloop
+    return captured["root"]
+
+
+def _pump(root, seconds=3.0, until=None):
+    """Run a REAL Tk mainloop until `until()` is true or the timeout hits.
+
+    A worker thread's `root.after(...)` call is only honoured once the
+    interpreter is genuinely inside `mainloop()` — a bare `root.update()`
+    loop leaves Tcl believing no loop is running, so a cross-thread `after`
+    deterministically raises "main thread is not in main loop" instead of
+    just being slow. This is exactly how the real app runs (app.py blocks in
+    mainloop() the whole time a preview plays), so it is also the more
+    faithful test, not just the one that avoids the harness artifact.
+    """
+    predicate = until or (lambda: True)
+    deadline = time.time() + seconds
+    real_mainloop = tk.Misc.mainloop
+
+    def poll():
+        if predicate() or time.time() > deadline:
+            root.quit()
+        else:
+            root.after(20, poll)
+
+    root.after(20, poll)
+    real_mainloop(root)
+    return predicate()
+
+
+def test_elevenlabs_key_is_saved_through_save_api_key():
+    """Gate 1: filling the ElevenLabs key field and saving calls save_api_key
+    with ELEVENLABS_API_KEY — the single field that never existed before."""
+    _skip_if_headless()
+    from tkinter import ttk
+    from wisprlite import config
+
+    calls = []
+    orig = config.save_api_key
+    config.save_api_key = lambda name, value: calls.append((name, value))
+    try:
+        root = _build()
+        try:
+            key_label = _find_by_text(root, "ElevenLabs API key")
+            assert key_label is not None, "no ElevenLabs API key field was built"
+            row = key_label.master.master  # label -> left frame -> row frame
+            entry = _find(row, lambda w: isinstance(w, ttk.Entry))
+            assert entry is not None
+            entry.delete(0, "end")
+            entry.insert(0, "sk-test-12345")
+
+            save_btn = _find_by_text(root, "Save")
+            assert save_btn is not None
+            save_btn.invoke()
+        finally:
+            root.destroy()
+    finally:
+        config.save_api_key = orig
+
+    assert ("ELEVENLABS_API_KEY", "sk-test-12345") in calls
+
+
+def test_engine_picker_shows_only_the_matching_rows():
+    """Gate 2: switching the engine picker shows the matching rows and hides
+    the others, driving the trace callback directly."""
+    _skip_if_headless()
+    from tkinter import ttk
+
+    root = _build()
+    try:
+        engine_label = _find_by_text(root, "Voice engine")
+        engine_row = engine_label.master.master
+        combo = _find(engine_row, lambda w: isinstance(w, ttk.Combobox))
+        assert combo is not None
+
+        windows_marker = _find_by_text(root, "Get better Windows voices")
+        deepgram_marker = _find_by_text(root, "Deepgram voice (pick one)")
+        eleven_marker = _find_by_text(root, "ElevenLabs API key")
+        assert windows_marker.winfo_ismapped(), "Windows rows should show by default"
+        assert not deepgram_marker.winfo_ismapped()
+        assert not eleven_marker.winfo_ismapped()
+
+        combo.set("Deepgram Aura-2 — cloud, uses your Deepgram key")
+        root.update()
+        assert not windows_marker.winfo_ismapped()
+        assert deepgram_marker.winfo_ismapped()
+        assert not eleven_marker.winfo_ismapped()
+
+        combo.set("ElevenLabs — best quality, your own key, paid")
+        root.update()
+        assert not windows_marker.winfo_ismapped()
+        assert not deepgram_marker.winfo_ismapped()
+        assert eleven_marker.winfo_ismapped()
+
+        combo.set("Windows natural voices — free, offline, no key")
+        root.update()
+        assert windows_marker.winfo_ismapped()
+        assert not deepgram_marker.winfo_ismapped()
+        assert not eleven_marker.winfo_ismapped()
+    finally:
+        root.destroy()
+
+
+def _preview_widgets(root):
+    from tkinter import ttk
+
+    btn = _find(root, lambda w: isinstance(w, ttk.Button) and w.cget("text") == "Preview")
+    assert btn is not None, "no Preview button was built"
+    status = None
+    for child in btn.master.winfo_children():
+        import tkinter as tk
+        if isinstance(child, tk.Label):
+            status = child
+    assert status is not None, "no preview status label next to the Preview button"
+    return btn, status
+
+
+def test_preview_uses_the_unsaved_form_value_not_the_saved_config():
+    """Gate 3: change the voice in the form without saving, click preview,
+    and the speaker must be built with the FORM's voice."""
+    _skip_if_headless()
+    from wisprlite import readaloud, config
+
+    cfg = config.Config()
+    cfg.read_aloud_tts = "windows"
+    cfg.read_aloud_voice = "SavedVoice"
+    orig_load = config.Config.load
+    config.Config.load = classmethod(lambda cls: cfg)
+
+    seen = {}
+    fake_speaker = types.SimpleNamespace(spoken=[])
+    fake_speaker.speak = lambda text: fake_speaker.spoken.append(text)
+
+    def fake_build_speaker(text, snap_cfg):
+        seen["voice"] = snap_cfg.read_aloud_voice
+        return fake_speaker, ""
+
+    orig_build = readaloud.build_speaker
+    readaloud.build_speaker = fake_build_speaker
+    try:
+        root = _build()
+        try:
+            from tkinter import ttk
+            voice_label = _find_by_text(root, "Voice / model")
+            voice_row = voice_label.master.master
+            entry = _find(voice_row, lambda w: isinstance(w, ttk.Entry))
+            entry.delete(0, "end")
+            entry.insert(0, "FormVoice")
+
+            btn, status = _preview_widgets(root)
+            btn.invoke()
+            _pump(root, until=lambda: "voice" in seen)
+        finally:
+            root.destroy()
+    finally:
+        readaloud.build_speaker = orig_build
+        config.Config.load = orig_load
+
+    assert seen.get("voice") == "FormVoice", seen
+
+
+def test_preview_failure_shows_the_reason_and_does_not_fall_back_silently():
+    """Gate 4: a degraded/failed cloud voice must show the reason in the card
+    and must NOT speak through the Windows fallback the way a real read does."""
+    _skip_if_headless()
+    from wisprlite import readaloud
+
+    fake_speaker = types.SimpleNamespace(spoken=[])
+    fake_speaker.speak = lambda text: fake_speaker.spoken.append(text)
+
+    def fake_build_speaker(text, snap_cfg):
+        # Mirrors readaloud.build_speaker's real contract: on failure it still
+        # returns a (fallback) Speaker plus a non-empty reason.
+        return fake_speaker, "no ElevenLabs API key configured — using the Windows voice instead"
+
+    orig_build = readaloud.build_speaker
+    readaloud.build_speaker = fake_build_speaker
+    status_text = ""
+    try:
+        root = _build()
+        try:
+            btn, status = _preview_widgets(root)
+            btn.invoke()
+            _pump(root, until=lambda: str(status.cget("text")) not in ("", "Speaking…"))
+            status_text = str(status.cget("text"))
+        finally:
+            root.destroy()
+    finally:
+        readaloud.build_speaker = orig_build
+
+    assert fake_speaker.spoken == [], "preview must not fall back to the Windows voice silently"
+    assert "no ElevenLabs API key" in status_text
+
+
+def test_preview_button_disabled_while_running_and_reenabled_after_failure():
+    """Gate 5: the preview button is disabled while running and re-enabled
+    after a failure."""
+    _skip_if_headless()
+    from wisprlite import readaloud
+
+    release = threading.Event()
+
+    def fake_build_speaker(text, snap_cfg):
+        release.wait(timeout=5)
+        raise RuntimeError("boom")
+
+    orig_build = readaloud.build_speaker
+    readaloud.build_speaker = fake_build_speaker
+    try:
+        root = _build()
+        try:
+            btn, status = _preview_widgets(root)
+            btn.invoke()
+            _pump(root, until=lambda: str(btn.cget("state")) == "disabled")
+            assert str(btn.cget("state")) == "disabled"
+            release.set()
+            _pump(root, until=lambda: str(btn.cget("state")) == "normal")
+            assert str(btn.cget("state")) == "normal"
+        finally:
+            root.destroy()
+    finally:
+        readaloud.build_speaker = orig_build

--- a/wisprlite/__init__.py
+++ b/wisprlite/__init__.py
@@ -1,3 +1,3 @@
 """Pipevoice — push-to-talk voice typing for Windows."""
 
-__version__ = "2.47.0"
+__version__ = "2.48.0"

--- a/wisprlite/readaloud.py
+++ b/wisprlite/readaloud.py
@@ -455,13 +455,16 @@ def build_speaker(text: str, cfg) -> tuple["Speaker", str]:
             audio = tts_cloud.deepgram_speak(
                 text,
                 getattr(cfg, "read_aloud_voice", "") or tts_cloud.DEFAULT_DEEPGRAM_VOICE,
-                _config.deepgram_key())
+                # A key on the cfg wins over the saved one, so Settings can
+                # preview a key that has been TYPED but not saved yet - which
+                # is exactly the moment someone wants to hear whether it works.
+                getattr(cfg, "read_aloud_deepgram_key", "") or _config.deepgram_key())
             content_type = "audio/wav"
         elif tier == "elevenlabs":
             audio = tts_cloud.elevenlabs_speak(
                 text,
                 getattr(cfg, "read_aloud_elevenlabs_voice_id", ""),
-                _config.elevenlabs_key())
+                getattr(cfg, "read_aloud_elevenlabs_key", "") or _config.elevenlabs_key())
             content_type = "audio/mpeg"
         else:
             # An unrecognised tier used to hand back a Windows speaker and no

--- a/wisprlite/settings.py
+++ b/wisprlite/settings.py
@@ -1242,6 +1242,11 @@ def main(first_run: bool = False) -> None:
                    "https://elevenlabs.io/app/voice-library")).pack(side="left", padx=(8, 0))
 
     speed_row = row(c, "Speed", "0.5 (slow) to 2.0 (fast). 1.0 is normal.")
+    # row() returns the RIGHT-hand frame, so .master is the row frame packed
+    # into the card - which is what `before=` needs. If row() ever returns
+    # the row frame itself this becomes `before=<the card>` and pack() errors.
+    # tests/test_read_aloud_voice_keys.py walks the same two levels, so a
+    # change to row() breaks that test rather than the settings window.
     speed_row_frame = speed_row.master
     entry(speed_row, read_aloud_rate_var, width=6)
     entry(row(c, "OCR language",

--- a/wisprlite/settings.py
+++ b/wisprlite/settings.py
@@ -98,6 +98,32 @@ MUTED = "#94a3b8"
 ACCENT = "#e06c75"
 
 
+def preview_snapshot(*, tier, voice, elevenlabs_voice_id, rate_text,
+                     elevenlabs_key, deepgram_key):
+    """The config object a voice Preview speaks with.
+
+    Module level on purpose. As a closure inside main() nothing could reach it,
+    so dropping a field from it - the typed API key, say - broke no test at all,
+    while breaking the one flow Preview exists for: paste a key, press Preview,
+    before saving anything.
+    """
+    import types
+
+    try:
+        rate = max(0.5, min(2.0, float((rate_text or "").strip() or 1.0)))
+    except ValueError:
+        rate = 1.0
+    return types.SimpleNamespace(
+        read_aloud_tts=tier,
+        read_aloud_voice=(voice or "").strip(),
+        read_aloud_elevenlabs_voice_id=(elevenlabs_voice_id or "").strip(),
+        read_aloud_rate=rate,
+        # The TYPED keys, not the saved ones.
+        read_aloud_elevenlabs_key=(elevenlabs_key or "").strip(),
+        read_aloud_deepgram_key=(deepgram_key or "").strip(),
+    )
+
+
 def _input_devices(show_all: bool = False):
     """Return [(label, value)] for the device picker; never raises.
 
@@ -1246,15 +1272,13 @@ def main(first_run: bool = False) -> None:
     PREVIEW_TEXT = "Six sharp trucks strapped their crisp black cargo, then quickly turned north."
 
     def _preview_snapshot():
-        try:
-            rate = max(0.5, min(2.0, float(read_aloud_rate_var.get().strip() or 1.0)))
-        except ValueError:
-            rate = 1.0
-        return types.SimpleNamespace(
-            read_aloud_tts=_read_aloud_tier(),
-            read_aloud_voice=read_aloud_voice_var.get().strip(),
-            read_aloud_elevenlabs_voice_id=read_aloud_elevenlabs_id_var.get().strip(),
-            read_aloud_rate=rate,
+        return preview_snapshot(
+            tier=_read_aloud_tier(),
+            voice=read_aloud_voice_var.get(),
+            elevenlabs_voice_id=read_aloud_elevenlabs_id_var.get(),
+            rate_text=read_aloud_rate_var.get(),
+            elevenlabs_key=eleven_key_var.get(),
+            deepgram_key=dg_key_var.get(),
         )
 
     def _preview_show(text, fg):

--- a/wisprlite/settings.py
+++ b/wisprlite/settings.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import os
 import json
 import threading
+import types
 import webbrowser
 
 from . import (about, autostart, cleanup, config, history, meeting, meetings_tab,
@@ -738,6 +739,7 @@ def main(first_run: bool = False) -> None:
     from . import tts_cloud as _tts_cloud
     read_aloud_deepgram_pick_var = tk.StringVar(value="")
     read_aloud_elevenlabs_id_var = tk.StringVar(value=cfg.read_aloud_elevenlabs_voice_id)
+    eleven_key_var = tk.StringVar()
     read_aloud_rate_var = tk.StringVar(value=str(cfg.read_aloud_rate))
     read_aloud_lang_var = tk.StringVar(value=cfg.read_aloud_ocr_language)
     read_aloud_clipboard_var = tk.BooleanVar(value=cfg.read_aloud_clipboard)
@@ -1164,18 +1166,36 @@ def main(first_run: bool = False) -> None:
               "says why."),
           read_aloud_tts_var, [l for _, l in read_aloud_tts_opts])
 
-    wr = row(c, "Get better Windows voices",
+    pr = row(c, "Preview voice",
+             "Speaks one test sentence using the settings on this screen — "
+             "even if you haven't saved yet.")
+    preview_btn = ttk.Button(pr, text="Preview", width=10)
+    preview_btn.pack(side="left")
+    preview_status = tk.Label(pr, text="", bg=CARD, fg=MUTED, font=("Segoe UI", 8),
+                               wraplength=220, justify="left")
+    preview_status.pack(side="left", padx=(10, 0))
+
+    # Only the group matching the chosen engine is shown — a greyed-out field
+    # still reads as "something I am supposed to fill in", and showing all
+    # three at once is exactly how choosing ElevenLabs used to reveal nothing.
+    _divide(c)
+    windows_group = tk.Frame(c, bg=CARD)
+    deepgram_group = tk.Frame(c, bg=CARD)
+    elevenlabs_group = tk.Frame(c, bg=CARD)
+
+    wr = row(windows_group, "Get better Windows voices",
              "Windows 11 ships far better \"Natural\" voices, but they aren't "
              "installed by default. Opens Settings → Speech → Manage voices.")
     ttk.Button(wr, text="Open Windows voice settings",
                command=lambda: os.startfile("ms-settings:speech")).pack(side="left")
-
-    entry(row(c, "Voice / model",
-              "Blank uses the system default Windows voice, or the default "
-              "Deepgram voice (aura-2-draco-en)."),
+    entry(row(windows_group, "Voice / model",
+              "Blank uses the system default Windows voice. Type the exact "
+              "name of an installed voice for another."),
           read_aloud_voice_var, width=28)
-    dg_row = row(c, "Deepgram voice (pick one)",
-                 "Only used when the voice engine above is Deepgram.")
+
+    dg_key_note = ("Already configured — the same key dictation uses." if config.deepgram_key()
+                   else "Not configured yet — add a Deepgram key in the API keys section below.")
+    dg_row = row(deepgram_group, "Deepgram voice (pick one)", dg_key_note)
     dg_combo = combo(dg_row, read_aloud_deepgram_pick_var,
                      [f"{name} — {desc}" for name, desc in _tts_cloud.DEEPGRAM_VOICES], width=40)
 
@@ -1185,13 +1205,19 @@ def main(first_run: bool = False) -> None:
             read_aloud_voice_var.set(_tts_cloud.DEEPGRAM_VOICES[i][0])
     dg_combo.bind("<<ComboboxSelected>>", _pick_deepgram_voice)
 
-    entry(row(c, "ElevenLabs voice ID",
-              "Only used when the voice engine above is ElevenLabs — their "
-              "catalogue is per-account, so this is an ID, not a picklist."),
-          read_aloud_elevenlabs_id_var, width=28)
+    entry(row(elevenlabs_group, "ElevenLabs API key",
+              "Saved" if config.elevenlabs_key() else "Not set"),
+          eleven_key_var, width=26, show="•")
+    eleven_id_row = row(elevenlabs_group, "ElevenLabs voice ID",
+                         "Their catalogue is per-account, so this is an ID, not a picklist.")
+    entry(eleven_id_row, read_aloud_elevenlabs_id_var, width=28)
+    ttk.Button(eleven_id_row, text="Where do I find this?",
+               command=lambda: webbrowser.open(
+                   "https://elevenlabs.io/app/voice-library")).pack(side="left", padx=(8, 0))
 
-    entry(row(c, "Speed", "0.5 (slow) to 2.0 (fast). 1.0 is normal."),
-          read_aloud_rate_var, width=6)
+    speed_row = row(c, "Speed", "0.5 (slow) to 2.0 (fast). 1.0 is normal.")
+    speed_row_frame = speed_row.master
+    entry(speed_row, read_aloud_rate_var, width=6)
     entry(row(c, "OCR language",
               "e.g. en-US. Blank uses your Windows display language."),
           read_aloud_lang_var, width=10)
@@ -1200,6 +1226,83 @@ def main(first_run: bool = False) -> None:
     check(c, "Stay quiet while a screen reader is running", read_aloud_quiet_var,
           "Off by default — the hotkey is usually pressed because the screen "
           "reader can't read that spot, so silence there defeats the feature.")
+
+    def _read_aloud_tier():
+        label = read_aloud_tts_var.get()
+        for value, lbl in read_aloud_tts_opts:
+            if lbl == label:
+                return value
+        return read_aloud_tts_opts[0][0]
+
+    def _on_read_aloud_tts(*_):
+        tier = _read_aloud_tier()
+        for group in (windows_group, deepgram_group, elevenlabs_group):
+            group.pack_forget()
+        {"windows": windows_group, "deepgram": deepgram_group,
+         "elevenlabs": elevenlabs_group}[tier].pack(fill="x", before=speed_row_frame)
+    read_aloud_tts_var.trace_add("write", _on_read_aloud_tts)
+    _on_read_aloud_tts()
+
+    PREVIEW_TEXT = "Six sharp trucks strapped their crisp black cargo, then quickly turned north."
+
+    def _preview_snapshot():
+        try:
+            rate = max(0.5, min(2.0, float(read_aloud_rate_var.get().strip() or 1.0)))
+        except ValueError:
+            rate = 1.0
+        return types.SimpleNamespace(
+            read_aloud_tts=_read_aloud_tier(),
+            read_aloud_voice=read_aloud_voice_var.get().strip(),
+            read_aloud_elevenlabs_voice_id=read_aloud_elevenlabs_id_var.get().strip(),
+            read_aloud_rate=rate,
+        )
+
+    def _preview_show(text, fg):
+        def apply():
+            if preview_status.winfo_exists():
+                preview_status.config(text=text, fg=fg)
+        try:
+            if root.winfo_exists():
+                root.after(0, apply)
+        except Exception:
+            pass
+
+    def _run_preview():
+        preview_btn.config(state="disabled")
+        _preview_show("Speaking…", MUTED)
+        # Read every form value HERE, on the Tk thread, before the worker
+        # starts — a Tk variable read from a background thread is unsafe
+        # once the thread outlives the call that spawned it.
+        snap = _preview_snapshot()
+
+        def work():
+            from . import readaloud
+
+            try:
+                speaker, reason = readaloud.build_speaker(PREVIEW_TEXT, snap)
+                if reason:
+                    # A dead key or bad voice ID is exactly what preview exists
+                    # to surface — it must not quietly play the Windows
+                    # fallback voice the way a real read does.
+                    _preview_show(reason, WARN)
+                    return
+                speaker.speak(PREVIEW_TEXT)
+                _preview_show("Played.", GOOD)
+            except Exception as exc:
+                _preview_show(str(exc), WARN)
+            finally:
+                def reenable():
+                    if preview_btn.winfo_exists():
+                        preview_btn.config(state="normal")
+                try:
+                    if root.winfo_exists():
+                        root.after(0, reenable)
+                except Exception:
+                    pass
+
+        threading.Thread(target=work, daemon=True).start()
+
+    preview_btn.config(command=_run_preview)
 
     c = card("Audio")
     mic_row = row(c, "Microphone")
@@ -1844,6 +1947,8 @@ def main(first_run: bool = False) -> None:
             config.save_api_key("GROQ_API_KEY", groq_key_var.get())
         if or_key_var.get().strip():
             config.save_api_key("OPENROUTER_API_KEY", or_key_var.get())
+        if eleven_key_var.get().strip():
+            config.save_api_key("ELEVENLABS_API_KEY", eleven_key_var.get())
         try:
             if autostart_var.get():
                 autostart.enable()


### PR DESCRIPTION
James: *"I chose ElevenLabs. It didn't actually ask me for an API key. It just reverted."*

### The real bug: the field did not exist
`config.py:359` read `ELEVENLABS_API_KEY` from the environment and **nothing wrote it**. OpenAI, Deepgram, Groq, Gemini and OpenRouter all have Settings fields; ElevenLabs was left out, so choosing it could never work and the fallback did exactly its job. It now saves through the same `save_api_key` path as every other key.

### Choosing an engine shows what that engine needs
Rows are hidden rather than greyed — a greyed field still reads as *"something I'm supposed to fill in"*. Picking Deepgram now says the key is **already configured**, which is good news nobody was being told.

### Preview
A Preview button that speaks one sentence through the currently selected engine and voice, using the **unsaved form values**. Off the Tk thread, button disabled while running, re-enabled in a `finally`. A failure shows the reason rather than quietly playing the Windows voice — a dead key is precisely what preview exists to surface.

### Found in review
- **Preview read the SAVED key**, so the obvious order — paste a key, press Preview — failed with *"no ElevenLabs API key configured"* while the key sat in the box. The typed key now wins; blank falls back to saved, so the normal path is unchanged.
- **`_preview_snapshot` was a closure inside `main()`**, so deleting a field from it broke no test while breaking the one flow Preview exists for. Extracted to a module-level `preview_snapshot()` and directly tested — typed keys survive, values are stripped, a nonsense rate falls back to 1.0, an out-of-range rate is clamped.

That is the **fourth** correct-but-unreachable piece of wiring today. Same shape every time: logic inside a Tk closure or the drain loop, tested only through a helper that is not the thing actually invoked.

### Jury
**No blocking correctness or security bugs.** Four P3 observations; I documented the fragile `speed_row.master` coupling it flagged and left the rest, which are either consistent with the existing key-field pattern or pinned by tests.

### Verification
**517 passing under xvfb**, same 15 pre-existing failures. Five sabotages verified red.

**Untested here:** how the voices actually sound, and whether the rows reveal correctly on a real Windows window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)