### PR TITLE
copy(read-aloud): say what to do at the ElevenLabs voice library

### DIFF
--- a/wisprlite/settings.py
+++ b/wisprlite/settings.py
@@ -1234,10 +1234,14 @@ def main(first_run: bool = False) -> None:
     entry(row(elevenlabs_group, "ElevenLabs API key",
               "Saved" if config.elevenlabs_key() else "Not set"),
           eleven_key_var, width=26, show="•")
-    eleven_id_row = row(elevenlabs_group, "ElevenLabs voice ID",
-                         "Their catalogue is per-account, so this is an ID, not a picklist.")
+    eleven_id_row = row(
+        elevenlabs_group, "ElevenLabs voice ID",
+        "Search the Voice Library for a character or accent, add it to your "
+        "collection, and copy its ID here. Nothing there? Voice Design builds "
+        "one from a description. The catalogue is per-account, which is why "
+        "this is an ID rather than a picklist.")
     entry(eleven_id_row, read_aloud_elevenlabs_id_var, width=28)
-    ttk.Button(eleven_id_row, text="Where do I find this?",
+    ttk.Button(eleven_id_row, text="Browse voices ↗",
                command=lambda: webbrowser.open(
                    "https://elevenlabs.io/app/voice-library")).pack(side="left", padx=(8, 0))
 


### PR DESCRIPTION
The button already existed in v2.48.0 — I offered James a feature he had. What was missing is that `"Where do I find this?"` doesn't tell you what to *do* once you're there.

Now **"Browse voices ↗"**, and the help text names both routes: search the Voice Library for a character or accent and copy its ID, or use Voice Design to build one from a description. That second one is the answer to "shame it's not JARVIS" — Deepgram's catalogue is fixed, ElevenLabs' isn't.

Copy only, no behaviour change. Suite 517 passing under xvfb.

🤖 Generated with [Claude Code](https://claude.com/claude-code)