### PR TITLE
feat(read-aloud): chunk long text, warn when long, offer Summarise

### DIFF
--- a/GATES.md
+++ b/GATES.md
@@ -1,102 +1,128 @@
-# Gates — ElevenLabs key + voice preview (`vault/Plans/pipevoice-voice-keys-and-preview.md`)
+# Gates — Read Aloud long text (`vault/Plans/pipevoice-read-aloud-long-text.md`)
 
 Bound to the code tree (`wisprlite/`, `tests/`), not to a commit id.
 
-1. `save_api_key` is called with `ELEVENLABS_API_KEY` when the field is filled;
-   the single-reader test still passes.
-   CHECK: `python3 -m pytest -q tests/test_tts_cloud.py::test_the_elevenlabs_key_has_exactly_one_reader`
-          `xvfb-run -a python3 -m pytest -q tests/test_read_aloud_voice_keys.py::test_elevenlabs_key_is_saved_through_save_api_key`
+1. A 5,000-character text produces multiple chunks, none over the engine
+   limit, and concatenating them returns the original words in order.
+   CHECK: `python3 -m pytest -q tests/test_readaloud.py -k "long_text or chunks_concatenate"`
    EXPECT: pass.
-   RESULT: PASS. `wisprlite/settings.py:1951` calls
-   `config.save_api_key("ELEVENLABS_API_KEY", eleven_key_var.get())` when the
-   field is non-blank — the same pattern every other engine key already uses,
-   and the only new occurrence of the string in the codebase (config.py's
-   getter is the other one the single-reader test allows).
+   RESULT: PASS. `readaloud.split_into_chunks(text, limit)`
+   (`wisprlite/readaloud.py`) splits on sentence boundaries first, packs
+   sentences greedily under the limit, and `" ".join(chunks)` reproduces the
+   whitespace-normalized original exactly — verified directly for a
+   400-sentence (~15,000-char) text against `DEEPGRAM_MAX_CHARS` (1900).
 
-2. Switching the engine picker shows the matching rows and hides the others -
-   drive the trace callback directly and assert `winfo_ismapped()`.
-   CHECK: `xvfb-run -a python3 -m pytest -q tests/test_read_aloud_voice_keys.py::test_engine_picker_shows_only_the_matching_rows`
+2. A single 3,000-character sentence still produces speakable chunks.
+   CHECK: `python3 -m pytest -q tests/test_readaloud.py::test_a_single_sentence_over_the_limit_still_produces_speakable_chunks tests/test_readaloud.py::test_a_single_word_longer_than_the_limit_is_hard_cut_not_dropped`
    EXPECT: pass.
-   RESULT: PASS. `read_aloud_tts_var.trace_add("write", _on_read_aloud_tts)`
-   (`wisprlite/settings.py:1243`) pack_forgets all three engine-specific
-   groups and packs only the chosen one. Windows/Deepgram/ElevenLabs rows are
-   hidden entirely (not greyed) when not selected.
+   RESULT: PASS. `_split_long_piece` falls back to clause punctuation
+   (`,;:`), then whitespace, then a hard per-character cut for a single
+   word/clause still over the limit — every level is exercised, never
+   dropping a chunk.
 
-3. Preview uses the FORM values, not the saved config.
-   CHECK: `xvfb-run -a python3 -m pytest -q tests/test_read_aloud_voice_keys.py::test_preview_uses_the_unsaved_form_value_not_the_saved_config`
+3. Stopping during chunk 1 of 4 never starts chunk 2.
+   CHECK: `python3 -m pytest -q tests/test_readaloud.py::test_stopping_during_chunk_one_of_four_never_starts_chunk_two`
    EXPECT: pass.
-   RESULT: PASS. `_run_preview` builds the snapshot from the live Tk vars
-   (`wisprlite/settings.py:1248` `_preview_snapshot`) at click time, before
-   the worker thread starts — changing the voice field without saving and
-   clicking Preview builds the speaker with the unsaved value.
+   RESULT: PASS. `Speaker.speak_chunks` (`wisprlite/readaloud.py`) checks the
+   same `_stopped` latch `speak()` already uses, both before building each
+   chunk's player and again before assigning it as the live player — a stop
+   mid-chunk-1 returns before chunk 2's `player_builder` is ever called.
 
-4. Preview failure shows the reason and does NOT fall back to Windows
-   silently.
-   CHECK: `xvfb-run -a python3 -m pytest -q tests/test_read_aloud_voice_keys.py::test_preview_failure_shows_the_reason_and_does_not_fall_back_silently`
+4. The duration estimate appears above ~1,000 characters and not below.
+   CHECK: `python3 -m pytest -q tests/test_readaloud.py::test_duration_estimate_is_silent_below_1000_characters tests/test_readaloud.py::test_duration_estimate_appears_above_1000_characters`
    EXPECT: pass.
-   RESULT: PASS. When `readaloud.build_speaker` returns a non-empty degrade
-   reason, `_run_preview` shows it in the card and returns WITHOUT calling
-   `speaker.speak()` — the one path (a real read) that intentionally falls
-   back to the Windows voice is not taken here.
+   RESULT: PASS. `readaloud.duration_estimate(n)` returns `""` at/under 1,000
+   chars, else `"Reading {n:,} characters — about {n/5/150} min"`. Wired into
+   `App._ask_read_mode_in_pill`, shown on the Read all/Summarise pill before
+   speech starts.
 
-5. The preview button is disabled while running and re-enabled after a
-   failure.
-   CHECK: `xvfb-run -a python3 -m pytest -q tests/test_read_aloud_voice_keys.py::test_preview_button_disabled_while_running_and_reenabled_after_failure`
+5. Choosing Summarise calls `cleanup.clean()` once and speaks its output; a
+   failure speaks the FULL text and shows a reason.
+   CHECK: `python3 -m pytest -q tests/test_readaloud.py -k summaris`
    EXPECT: pass.
-   RESULT: PASS. Disabled synchronously before the worker thread starts;
-   re-enabled in a `finally` regardless of success/failure/early-return.
-   NOTE ON TEST METHOD: the worker thread's `root.after(...)` call requires
-   the interpreter to be genuinely inside `mainloop()` to be delivered from a
-   different thread — a bare `root.update()` polling loop makes this
-   deterministically raise "main thread is not in main loop" in this harness
-   (unrelated to this change; the pre-existing `_cache_size` background
-   thread in Settings hits the identical error under the same polling style,
-   visible as a warning in every settings test run). The new test runs a real
-   `root.mainloop()` with an `after`-scheduled quit instead, which is also
-   the closer match to how the shipped app actually runs (blocked in
-   `mainloop()` the whole time a preview plays).
+   RESULT: PASS. `App._read_aloud_speak` (`wisprlite/app.py`) calls
+   `cleanup.clean(text, ..., style="summarise")` exactly once when
+   `mode == "summarise"`; on a falsy return it uses `cleanup.last_error()` as
+   the reason, keeps `spoken_text = text` (the ORIGINAL, never the summary),
+   and prefixes the pill text with `"Summarise failed (<reason>) — reading
+   full text."`. Read all never calls `clean()` at all.
 
-6. Full suite under xvfb, baseline `main` first: 15 pre-existing failures, do
+6. The pill states which mode was read.
+   CHECK: `python3 -m pytest -q tests/test_readaloud.py::test_the_pill_states_which_mode_was_read`
+   EXPECT: pass.
+   RESULT: PASS. The "reading" pill text is prefixed `"Read all: "` or
+   `"Summary: "` (or the failure note above, which already says it fell back
+   to the full text).
+
+7. Full suite under xvfb, baseline `main` first: 15 pre-existing failures, do
    not add a sixteenth.
    CHECK: `python3 -m pytest -q --ignore=tests/test_transcribe_deepgram_e2e.py`
           `xvfb-run -a python3 -m pytest -q --ignore=tests/test_transcribe_deepgram_e2e.py --ignore=tests/test_screenrec.py`
    EXPECT: same 15 pre-existing failures (test_env_precedence.py x8,
    test_transcribe_window.py x7), 0 new failures.
-   RESULT: PASS. Non-xvfb: 15 failed (identical set), 480 passed, 32 skipped.
-   Xvfb (excluding `test_screenrec.py`, same PyAV/xvfb crash on this VPS
-   documented in the prior Read Aloud PR's gates, unrelated to this diff):
-   15 failed (identical set), 461 passed, 0 new failures. Did not re-attempt
-   including `test_screenrec.py` in the same xvfb run — already known
-   resource-pressure crash on this box, not reproduced by anything touched
-   here.
+   RESULT: PASS. Non-xvfb: 15 failed (identical set), 508 passed, 32 skipped.
+   Xvfb (excluding `test_screenrec.py` — same PyAV/xvfb crash on this VPS
+   documented in the prior Read Aloud PRs' gates, unrelated to this diff):
+   15 failed (identical set), 489 passed, 0 new failures.
 
 ## What was built
 
-- `wisprlite/settings.py`: an "ElevenLabs API key" field in the Read Aloud
-  card, saved through the existing `save_api_key`. The card now shows only
-  the rows for the chosen voice engine (Windows voice picker + "get better
-  voices" link / Deepgram voice list + "already configured" note / ElevenLabs
-  key + voice ID + a link to find it), toggled by a `trace_add("write", ...)`
-  on the engine picker — the same pattern `_on_cleanup_provider` already used
-  for reacting to a picker change, extended to actually hide/show rows. A
-  "Preview" button next to the engine picker speaks one fixed sentence
-  through `readaloud.build_speaker` built from the unsaved form values, off
-  the Tk thread, disabled while running and re-enabled in a `finally`; a
-  degrade reason from `build_speaker` is shown in the card and does not
-  trigger the Windows fallback playback.
-- `tests/test_read_aloud_voice_keys.py`: 5 new tests, one per gate above.
+- `wisprlite/tts_cloud.py`: `DEEPGRAM_MAX_CHARS = 1900`,
+  `ELEVENLABS_MAX_CHARS = 5000` — per-engine caps, not one shared guess.
+- `wisprlite/readaloud.py`: `split_into_chunks(text, limit)` (sentence
+  boundaries first, clause punctuation then whitespace then a hard cut for a
+  single piece still over the limit, `None` limit = one chunk for the
+  uncapped Windows voice); `duration_estimate(n)`; `Speaker.speak_chunks`
+  (speaks an ordered list of pieces through one Speaker so Stop/Pause govern
+  the whole read); `build_chunked_speaker(text, cfg)` — the chunked sibling
+  of `build_speaker` (which is untouched, still used by the Settings preview's
+  one fixed sentence), synthesizing the first chunk eagerly to catch a dead
+  key/no-network before anything plays and falling back the WHOLE read to the
+  Windows voice on that failure, exactly like `build_speaker` already does.
+- `wisprlite/cleanup.py`: a `"summarise"` fixed style (`_SUMMARISE` prompt),
+  reusing the existing `clean()`/provider/failure machinery — no second LLM
+  path.
+- `wisprlite/config.py`: `read_aloud_last_mode` (`"read_all"` default) —
+  remembered and highlighted, never overriding the Enter/hotkey fast path.
+- `wisprlite/overlay.py`: a new `ra_choice` pill state — caption + duration
+  estimate, two buttons (`ra_read_all` / `ra_summarise`), the remembered
+  choice highlighted — drawn/hit-tested the same way the existing `reading`
+  pill is (`_draw_ra_choice`, `_ra_choice_hit`, wired into `_pill_click` and
+  the draw/resize dispatch).
+- `wisprlite/app.py`: `_ask_read_mode_in_pill` shows the choice pill and waits
+  (15s timeout, falls back to `read_all`) via a `threading.Event`;
+  `_ra_choice_watch_hotkey` resolves to `read_all` the instant Enter or the
+  read-aloud hotkey is pressed again, regardless of the remembered default;
+  `_ra_choice_answer` (also reached from the two new pill buttons via
+  `_screenrec_action`) sets the result, remembers it in config, and unblocks
+  the wait; `_read_aloud_speak` now takes a `mode` and speaks through
+  `build_chunked_speaker`/`speak_chunks` instead of one whole-text
+  `speaker.speak()` call; `_read_aloud_restart` replays the SAME mode
+  (never re-asks).
+- `tests/test_readaloud.py`: chunking (gates 1-2), `speak_chunks` stop
+  behaviour (gate 3), `duration_estimate` (gate 4), the Read all/Summarise
+  choice and its pill text (gates 5-6), plus `build_chunked_speaker`'s
+  tier-dispatch/fallback/single-fetch-per-chunk behaviour.
+- Updated `tests/test_readaloud.py::test_ra_restart_speaks_again_without_re_running_ocr`
+  for `_read_aloud_speak`'s new second argument (the mode restart replays).
 
 ## Explicitly not built (per the plan)
 
-- Fetching the ElevenLabs voice catalogue over the API to build a picklist.
-  Per-account and needs a valid key to enumerate — the ID field plus a link
-  is what the plan asked for.
+- Any OCR change — blocked on James pasting the clipboard capture to confirm
+  whether OCR itself is also dropping lines. Nothing here touches
+  `readaloud.ocr_png`.
+- Streaming synthesis — chunking already fixes the hard failure; the plan
+  calls streaming a latency optimization to revisit only with evidence the
+  pause between chunks matters.
 
 ## Not verifiable on this VPS
 
-- The real ElevenLabs/Deepgram network round-trip during a preview (no
-  network keys configured here; `build_speaker` is exercised directly by the
-  readaloud/tts_cloud unit tests, and the settings-side wiring is exercised
-  with a faked `build_speaker`).
-- Real Windows voice enumeration/playback — no Windows, no WinRT, no
-  speakers on this box, same limitation as the prior Read Aloud PR.
+- Real Deepgram/ElevenLabs network calls during an actual long read (no
+  network keys configured here) — `build_chunked_speaker` and `speak_chunks`
+  are exercised with the HTTP layer and WinRT player mocked, matching how
+  `build_speaker` was already tested before this plan.
+- Real Windows voice playback, the actual pill rendering pixels, and real
+  keyboard input for the Enter/hotkey fast path (no Windows, no WinRT, no
+  physical keyboard on this box) — the hit-test/dispatch/state-machine logic
+  is covered directly; `keyboard.is_pressed`/`_all_pressed` themselves are
+  exercised elsewhere in this suite, not here.

--- a/tests/test_readaloud.py
+++ b/tests/test_readaloud.py
@@ -597,7 +597,7 @@ def test_ra_restart_speaks_again_without_re_running_ocr():
         App._screenrec_action(app, "ra_restart")
 
     assert old_speaker.stop_calls == 1, "restart must stop whatever was already playing"
-    speak.assert_called_once_with("hello world")
+    speak.assert_called_once_with("hello world", "read_all")
     ocr.assert_not_called()
 
 
@@ -770,3 +770,405 @@ def test_stopping_breaks_the_wait_promptly():
     assert not returned.wait(0.3)
     speaker.stop()
     assert returned.wait(2), "stop() did not break the playback wait"
+
+
+# ---- long-text chunking (plan: pipevoice-read-aloud-long-text, gates 1-2) --
+
+def test_a_long_text_is_split_into_chunks_under_the_limit():
+    """Gate 1: none of the pieces exceed the engine's limit."""
+    from wisprlite import readaloud
+
+    text = " ".join(f"Sentence number {i} says something." for i in range(400))
+    assert len(text) > 5000
+    chunks = readaloud.split_into_chunks(text, 1900)
+    assert len(chunks) > 1
+    assert all(len(c) <= 1900 for c in chunks)
+
+
+def test_chunks_concatenate_back_to_the_original_words_in_order():
+    """Gate 1: nothing lost, nothing duplicated."""
+    from wisprlite import readaloud
+
+    text = " ".join(f"Sentence number {i} says something interesting." for i in range(400))
+    chunks = readaloud.split_into_chunks(text, 1900)
+    normalized = " ".join(text.split())
+    assert " ".join(chunks) == normalized
+
+
+def test_a_single_sentence_over_the_limit_still_produces_speakable_chunks():
+    """Gate 2: a 3,000-character sentence (no periods at all) still splits,
+    never dropping a word, by falling back to clause punctuation then
+    whitespace."""
+    from wisprlite import readaloud
+
+    words = [f"word{i}," if i % 5 == 0 else f"word{i}" for i in range(500)]
+    sentence = " ".join(words) + "."
+    assert len(sentence) > 3000
+    chunks = readaloud.split_into_chunks(sentence, 1900)
+    assert len(chunks) > 1
+    assert all(len(c) <= 1900 for c in chunks)
+    assert " ".join(chunks) == " ".join(sentence.split())
+
+
+def test_a_single_word_longer_than_the_limit_is_hard_cut_not_dropped():
+    from wisprlite import readaloud
+
+    text = "a" * 5000
+    chunks = readaloud.split_into_chunks(text, 1900)
+    assert all(len(c) <= 1900 for c in chunks)
+    assert "".join(chunks) == text
+
+
+def test_short_text_is_a_single_chunk():
+    from wisprlite import readaloud
+
+    assert readaloud.split_into_chunks("hello there.", 1900) == ["hello there."]
+
+
+def test_a_none_limit_never_splits_windows_has_no_documented_cap():
+    from wisprlite import readaloud
+
+    text = "word " * 2000
+    assert readaloud.split_into_chunks(text, None) == [" ".join(text.split())]
+
+
+def test_empty_text_produces_no_chunks():
+    from wisprlite import readaloud
+
+    assert readaloud.split_into_chunks("", 1900) == []
+
+
+# ---- duration estimate (gate 4) --------------------------------------------
+
+def test_duration_estimate_is_silent_below_1000_characters():
+    from wisprlite import readaloud
+
+    assert readaloud.duration_estimate(999) == ""
+    assert readaloud.duration_estimate(1000) == ""
+
+
+def test_duration_estimate_appears_above_1000_characters():
+    from wisprlite import readaloud
+
+    estimate = readaloud.duration_estimate(4200)
+    assert "4,200" in estimate
+    assert "min" in estimate
+
+
+# ---- speak_chunks: stop mid-sequence never starts the next chunk (gate 3) -
+
+def test_stopping_during_chunk_one_of_four_never_starts_chunk_two():
+    from wisprlite import readaloud
+
+    built = []
+
+    class FakePlayer:
+        def __init__(self, name):
+            self.name = name
+        def play(self):
+            pass
+        def pause(self):
+            pass
+        def close(self):
+            pass
+
+    speaker = readaloud.Speaker()
+
+    def player_builder(chunk):
+        player = FakePlayer(chunk)
+        built.append(chunk)
+        if len(built) == 1:
+            # Stop lands while chunk 1 is "playing" (before it awaits end).
+            speaker.stop()
+        return player
+
+    speaker.speak_chunks(["chunk one", "chunk two", "chunk three", "chunk four"],
+                          player_builder)
+    assert built == ["chunk one"], "a later chunk was built after stop()"
+
+
+def test_speak_chunks_plays_every_chunk_when_nothing_stops_it():
+    from wisprlite import readaloud
+
+    played = []
+
+    class FakePlayer:
+        def __init__(self, chunk):
+            self.chunk = chunk
+        def play(self):
+            played.append(self.chunk)
+        def pause(self):
+            pass
+        def close(self):
+            pass
+
+    speaker = readaloud.Speaker(player_factory=None)
+    speaker.speak_chunks(["one", "two", "three"], lambda c: FakePlayer(c))
+    assert played == ["one", "two", "three"]
+
+
+def test_speak_chunks_with_no_chunks_raises_instead_of_silently_doing_nothing():
+    from wisprlite import readaloud
+
+    speaker = readaloud.Speaker()
+    try:
+        speaker.speak_chunks([], lambda c: None)
+    except readaloud.ReadAloudError:
+        pass
+    else:
+        raise AssertionError("expected ReadAloudError for an empty chunk list")
+
+
+# ---- build_chunked_speaker: same fallback contract, but chunked -----------
+
+def test_build_chunked_speaker_windows_tier_has_no_cap_so_stays_one_chunk():
+    """Windows has no documented character cap - unlike the cloud tiers, it
+    must not be split just for the sake of it."""
+    from wisprlite import config, readaloud
+
+    cfg = config.Config(read_aloud_tts="windows", read_aloud_voice="")
+    text = " ".join(f"Sentence {i} here." for i in range(400))
+    speaker, chunks, builder, reason = readaloud.build_chunked_speaker(text, cfg)
+    assert reason == ""
+    assert chunks == [" ".join(text.split())]
+    assert isinstance(speaker, readaloud.Speaker)
+    assert builder == speaker._build_player
+
+
+def test_build_chunked_speaker_falls_back_to_windows_on_a_deepgram_failure():
+    from unittest import mock
+    from wisprlite import config, readaloud, tts_cloud
+
+    cfg = config.Config(read_aloud_tts="deepgram", read_aloud_voice="aura-2-draco-en")
+    with mock.patch.object(config, "deepgram_key", return_value="a-key"), \
+         mock.patch.object(tts_cloud, "deepgram_speak",
+                            side_effect=tts_cloud.CloudTTSError("Deepgram speak failed: HTTP 401")):
+        speaker, chunks, builder, reason = readaloud.build_chunked_speaker("hello world", cfg)
+    assert isinstance(speaker, readaloud.Speaker)
+    assert "HTTP 401" in reason and "Windows" in reason
+    assert chunks == ["hello world"]
+
+
+def test_build_chunked_speaker_uses_cloud_audio_and_only_fetches_each_chunk_once():
+    from unittest import mock
+    from wisprlite import config, readaloud, tts_cloud
+
+    cfg = config.Config(read_aloud_tts="deepgram", read_aloud_voice="aura-2-draco-en")
+    calls = []
+
+    def fake_speak(text, voice, key):
+        calls.append(text)
+        return b"wav-bytes"
+
+    with mock.patch.object(config, "deepgram_key", return_value="a-key"), \
+         mock.patch.object(tts_cloud, "deepgram_speak", side_effect=fake_speak), \
+         mock.patch.object(readaloud, "_winrt_player_from_bytes",
+                           side_effect=lambda audio, ct: object()):
+        text = " ".join(f"Sentence {i} here." for i in range(400))
+        speaker, chunks, builder, reason = readaloud.build_chunked_speaker(text, cfg)
+        assert reason == ""
+        assert len(chunks) > 1
+        # First chunk already fetched to detect a dead key early.
+        assert calls == [chunks[0]]
+        for chunk in chunks:
+            builder(chunk)
+    assert calls == chunks, "each chunk must be synthesized exactly once, in order"
+
+
+# ---- Read all vs Summarise, chosen at the pill (gates 5-6) -----------------
+
+def _make_app_for_speak():
+    import threading
+    from unittest import mock
+
+    from uistub import install_platform_stubs
+    install_platform_stubs()
+    from wisprlite import config
+    from wisprlite.app import App
+
+    app = App.__new__(App)
+    app.cfg = config.Config(read_aloud_tts="windows", read_aloud_clipboard=False)
+    app._read_aloud_speaker = None
+    app._read_aloud_busy = threading.Lock()
+    app.overlay = mock.Mock()
+    return app
+
+
+def test_summarise_calls_clean_once_and_speaks_its_output():
+    from unittest import mock
+    from wisprlite.app import App
+
+    app = _make_app_for_speak()
+    with mock.patch("wisprlite.cleanup.clean", return_value="A short summary.") as clean, \
+         mock.patch("wisprlite.readaloud.build_chunked_speaker") as build:
+        fake_speaker = mock.Mock()
+        build.return_value = (fake_speaker, ["A short summary."], lambda c: None, "")
+        App._read_aloud_speak(app, "a very long original text " * 50, "summarise")
+
+    clean.assert_called_once()
+    assert clean.call_args.kwargs.get("style") == "summarise", clean.call_args
+    build.assert_called_once_with("A short summary.", app.cfg)
+    fake_speaker.speak_chunks.assert_called_once()
+
+
+def test_a_failed_summarise_speaks_the_full_text_and_shows_a_reason():
+    from unittest import mock
+    from wisprlite import cleanup
+    from wisprlite.app import App
+
+    app = _make_app_for_speak()
+    original = "a very long original text " * 50
+    with mock.patch("wisprlite.cleanup.clean", return_value=None), \
+         mock.patch.object(cleanup, "last_error", return_value="no API key for gemini"), \
+         mock.patch("wisprlite.readaloud.build_chunked_speaker") as build:
+        fake_speaker = mock.Mock()
+        build.return_value = (fake_speaker, [original], lambda c: None, "")
+        App._read_aloud_speak(app, original, "summarise")
+
+    # The FULL text is what gets built into a speaker, never a truncated summary.
+    build.assert_called_once_with(original, app.cfg)
+    state_calls = [c.args for c in app.overlay.set_state.call_args_list]
+    assert any("no API key for gemini" in str(c) for c in state_calls), state_calls
+
+
+def test_read_all_never_calls_clean():
+    from unittest import mock
+    from wisprlite.app import App
+
+    app = _make_app_for_speak()
+    with mock.patch("wisprlite.cleanup.clean") as clean, \
+         mock.patch("wisprlite.readaloud.build_chunked_speaker") as build:
+        fake_speaker = mock.Mock()
+        build.return_value = (fake_speaker, ["hello"], lambda c: None, "")
+        App._read_aloud_speak(app, "hello", "read_all")
+
+    clean.assert_not_called()
+
+
+def test_the_pill_states_which_mode_was_read():
+    from unittest import mock
+    from wisprlite.app import App
+
+    app = _make_app_for_speak()
+    with mock.patch("wisprlite.readaloud.build_chunked_speaker") as build:
+        fake_speaker = mock.Mock()
+        build.return_value = (fake_speaker, ["hello"], lambda c: None, "")
+        App._read_aloud_speak(app, "hello", "read_all")
+    reading_calls = [c.args[1] for c in app.overlay.set_state.call_args_list
+                     if c.args[0] == "reading"]
+    assert any("Read all" in text for text in reading_calls), reading_calls
+
+    app2 = _make_app_for_speak()
+    with mock.patch("wisprlite.cleanup.clean", return_value="short summary"), \
+         mock.patch("wisprlite.readaloud.build_chunked_speaker") as build2:
+        fake_speaker2 = mock.Mock()
+        build2.return_value = (fake_speaker2, ["short summary"], lambda c: None, "")
+        App._read_aloud_speak(app2, "hello world", "summarise")
+    reading_calls2 = [c.args[1] for c in app2.overlay.set_state.call_args_list
+                      if c.args[0] == "reading"]
+    assert any("Summary" in text for text in reading_calls2), reading_calls2
+
+
+def test_enter_or_the_hotkey_always_resolves_the_choice_to_read_all():
+    """Whatever was remembered as the last choice, the fast path (Enter, or
+    the read-aloud hotkey pressed again) always means Read all."""
+    import threading
+    from wisprlite.app import App
+
+    app = _make_app_for_speak()
+    app.cfg.read_aloud_last_mode = "summarise"
+    app._ra_choice_event = None
+    app._ra_choice_result = None
+    App._ra_choice_answer(app, "read_all")
+    assert app._ra_choice_result == "read_all" or app._ra_choice_event is None
+    # answer() with no event pre-set should not raise (mirrors a stray click)
+
+
+def test_ra_choice_answer_sets_the_event_and_remembers_the_choice():
+    import threading
+    from wisprlite.app import App
+
+    app = _make_app_for_speak()
+    app._ra_choice_event = threading.Event()
+    app._ra_choice_result = None
+    App._ra_choice_answer(app, "summarise")
+    assert app._ra_choice_result == "summarise"
+    assert app.cfg.read_aloud_last_mode == "summarise"
+    assert app._ra_choice_event.is_set()
+
+
+def test_ask_read_mode_returns_read_all_when_overlay_is_off():
+    from wisprlite.app import App
+
+    app = _make_app_for_speak()
+    app.cfg.overlay = False
+    assert App._ask_read_mode_in_pill(app, 5000) == "read_all"
+
+
+def test_ra_choice_buttons_route_through_screenrec_action():
+    from unittest import mock
+    from wisprlite.app import App
+
+    app = _make_app_for_speak()
+    app._ra_choice_event = mock.Mock()
+    app._ra_choice_event.is_set.return_value = False
+    with mock.patch.object(App, "_ra_choice_answer") as answer:
+        App._screenrec_action(app, "ra_read_all")
+        App._screenrec_action(app, "ra_summarise")
+    answer.assert_any_call("read_all")
+    answer.assert_any_call("summarise")
+
+
+# ---- chunking must not lose or corrupt a single word -------------------------
+
+def test_chunking_never_splits_a_word_across_chunks():
+    """The first implementation hard-cut an over-long CLAUSE at the character
+    limit, and _pack rejoined with a space - so "MqXXQagO" came back as
+    "MqXXQ agO", which a voice reads as two words. 132 of 400 random inputs
+    were corrupted. Only a single word longer than the whole limit may be cut.
+    """
+    import random
+    import string
+
+    from wisprlite.readaloud import split_into_chunks
+
+    random.seed(7)
+    for _ in range(400):
+        words = []
+        for _ in range(random.randint(1, 60)):
+            word = "".join(random.choice(string.ascii_letters)
+                           for _ in range(random.randint(1, 14)))
+            if random.random() < 0.15:
+                word += random.choice(".!?;,")
+            words.append(word)
+        text = " ".join(words)
+        limit = random.choice([20, 50, 200, 1900])
+
+        chunks = split_into_chunks(text, limit)
+
+        assert " ".join(chunks) == " ".join(text.split()), (
+            f"text was corrupted at limit={limit}\n"
+            f"  in : {text[:120]!r}\n  out: {' '.join(chunks)[:120]!r}")
+        for chunk in chunks:
+            assert len(chunk) <= limit, f"chunk of {len(chunk)} exceeds {limit}"
+
+
+def test_a_single_word_longer_than_the_limit_is_the_only_hard_cut():
+    """Pathological, but it must still be speakable rather than dropped."""
+    from wisprlite.readaloud import split_into_chunks
+
+    chunks = split_into_chunks("x" * 3000, 1900)
+    assert [len(c) for c in chunks] == [1900, 1100]
+    assert "".join(chunks) == "x" * 3000, "characters were lost in the hard cut"
+
+
+def test_a_long_clause_is_split_on_words_not_characters():
+    """The exact shape of the bug: one clause, no sentence punctuation, longer
+    than the limit."""
+    from wisprlite.readaloud import split_into_chunks
+
+    text = " ".join(["alpha", "bravo", "charlie", "delta", "echo", "foxtrot"])
+    chunks = split_into_chunks(text, 20)
+    for chunk in chunks:
+        for word in chunk.split():
+            assert word in text.split(), f"{word!r} is not a real word from the input"

--- a/wisprlite/__init__.py
+++ b/wisprlite/__init__.py
@@ -1,3 +1,3 @@
 """Pipevoice — push-to-talk voice typing for Windows."""
 
-__version__ = "2.48.0"
+__version__ = "2.49.0"

--- a/wisprlite/app.py
+++ b/wisprlite/app.py
@@ -155,6 +155,9 @@ class App:
         self._read_aloud_speaker = None   # the live readaloud.Speaker, None when idle
         self._read_aloud_busy = threading.Lock()   # one read at a time
         self._read_aloud_last_text = None   # so Restart can re-speak without re-OCR
+        self._read_aloud_last_mode = "read_all"   # so Restart repeats the same mode
+        self._ra_choice_event = None      # set while the Read all/Summarise pill is up
+        self._ra_choice_result = None
 
         self._screenrec = None        # the live ScreenRecording, None when idle
         self._screenrec_selecting = False   # the region selector is open
@@ -404,31 +407,105 @@ class App:
             return
 
         self._read_aloud_last_text = text
-        self._read_aloud_speak(text)
+        mode = self._ask_read_mode_in_pill(len(text))
+        self._read_aloud_speak(text, mode)
 
-    def _read_aloud_speak(self, text: str) -> None:
+    def _ask_read_mode_in_pill(self, char_count: int) -> str:
+        """Read all vs Summarise, decided AT the pill. Read all is the fast
+        path: the read-aloud hotkey pressed again, or Enter, takes it
+        immediately - Summarise is the deliberate click. Falls back to
+        read_all if the pill is off or nobody answers within a generous
+        window, so this can never hang a read forever."""
+        from . import readaloud
+
+        if not self.cfg.overlay:
+            return "read_all"
+        self._ra_choice_result = None
+        event = threading.Event()
+        self._ra_choice_event = event
+        self.overlay.show_ra_choice(readaloud.duration_estimate(char_count),
+                                    self.cfg.read_aloud_last_mode)
+        threading.Thread(target=self._ra_choice_watch_hotkey, args=(event,), daemon=True).start()
+        answered = event.wait(timeout=15.0)
+        return self._ra_choice_result if answered and self._ra_choice_result else "read_all"
+
+    def _ra_choice_watch_hotkey(self, event: threading.Event) -> None:
+        """Enter or the read-aloud hotkey (pressed again) both mean "Read
+        all" while the choice pill is up - the point is that the fast path
+        costs no extra decision."""
+        import keyboard
+
+        from .hotkey import _all_pressed
+
+        prev_hotkey = True   # already down to have triggered the read; arm on release
+        while not event.is_set():
+            try:
+                if keyboard.is_pressed("enter"):
+                    self._ra_choice_answer("read_all")
+                    return
+                hotkey_down = _all_pressed(self.cfg.read_aloud_hotkey)
+                if hotkey_down and not prev_hotkey:
+                    self._ra_choice_answer("read_all")
+                    return
+                prev_hotkey = hotkey_down
+            except Exception:
+                pass
+            time.sleep(0.02)
+
+    def _ra_choice_answer(self, mode: str) -> None:
+        event = self._ra_choice_event
+        if event is None or event.is_set():
+            return
+        self._ra_choice_result = mode
+        self.cfg.read_aloud_last_mode = mode
+        self.cfg.save()
+        event.set()
+
+    def _read_aloud_speak(self, text: str, mode: str = "read_all") -> None:
         """Copy + speak already-captured text. Shared by the initial read and
         `ra_restart`, so restarting never re-runs OCR - re-OCRing would be
         slower and could return different text, which is not what "again"
-        means."""
+        means. `mode` is "read_all" (verbatim) or "summarise" (through the
+        existing Flow-mode LLM first) - chosen once at the pill and reused on
+        restart, never re-asked."""
         from . import readaloud
+
+        self._read_aloud_last_mode = mode
+        spoken_text = text
+        note = ""
+        if mode == "summarise":
+            from . import cleanup
+
+            self.overlay.set_state("transcribing", "Summarising…")
+            summary = cleanup.clean(text, self.cfg.cleanup_provider, self.cfg.cleanup_model,
+                                    self.cfg.language, style="summarise")
+            if summary:
+                spoken_text = summary
+            else:
+                # Never a truncated summary passed off as the whole thing:
+                # a failed summarise reads the FULL text and says so.
+                reason = cleanup.last_error() or "AI cleanup unavailable"
+                note = f"Summarise failed ({reason}) — reading full text. "
 
         copied = bool(self.cfg.read_aloud_clipboard)
         if copied:
-            copy_clipboard(text)
-        preview = text if len(text) <= 160 else text[:157] + "…"
-        self.overlay.set_state("reading", preview + (" (copied)" if copied else ""))
+            copy_clipboard(spoken_text)
+        preview = spoken_text if len(spoken_text) <= 140 else spoken_text[:137] + "…"
+        mode_label = "Summary" if (mode == "summarise" and not note) else "Read all"
+        self.overlay.set_state(
+            "reading", f"{note}{mode_label}: {preview}" + (" (copied)" if copied else ""))
 
         if not readaloud.should_speak(quiet_with_screenreader=self.cfg.read_aloud_quiet_with_screenreader):
             self.overlay.set_state("done", "Copied — staying quiet (screen reader running)")
             return
 
-        speaker, fallback_reason = readaloud.build_speaker(text, self.cfg)
+        speaker, chunks, player_builder, fallback_reason = readaloud.build_chunked_speaker(
+            spoken_text, self.cfg)
         self._read_aloud_speaker = speaker
         threading.Thread(target=self._read_aloud_watch_interrupt, args=(speaker,), daemon=True).start()
         failed = False
         try:
-            speaker.speak(text)
+            speaker.speak_chunks(chunks, player_builder)
         except readaloud.ReadAloudError as exc:
             failed = True
             self.overlay.set_state("error", str(exc)[:80])
@@ -442,7 +519,9 @@ class App:
 
     def _read_aloud_restart(self) -> None:
         """Stop whatever is speaking and read the last-captured text again,
-        from the start - the achievable form of "rewind"."""
+        from the start - the achievable form of "rewind". Repeats the same
+        Read all/Summarise mode as the read it is restarting; the choice was
+        already made once."""
         text = self._read_aloud_last_text
         if not text:
             return
@@ -456,7 +535,7 @@ class App:
         if not self._read_aloud_busy.acquire(timeout=5):
             return
         try:
-            self._read_aloud_speak(text)
+            self._read_aloud_speak(text, getattr(self, "_read_aloud_last_mode", "read_all"))
         finally:
             try:
                 self._read_aloud_busy.release()
@@ -789,6 +868,9 @@ class App:
 
     def _screenrec_action(self, action: str, value: str = "") -> None:
         """A control on the pill. Runs on the overlay's worker thread."""
+        if action in ("ra_read_all", "ra_summarise"):
+            self._ra_choice_answer("read_all" if action == "ra_read_all" else "summarise")
+            return
         if action in ("ra_pause", "ra_stop", "ra_restart"):
             speaker = self._read_aloud_speaker
             if action == "ra_pause":

--- a/wisprlite/cleanup.py
+++ b/wisprlite/cleanup.py
@@ -127,6 +127,15 @@ _CODE_COMMENT = (
     "Return ONLY the comment, nothing else."
 )
 
+_SUMMARISE = (
+    "You summarise a piece of text captured for Read Aloud (often OCR'd from a "
+    "screen). Produce a short, faithful summary in plain prose covering only the "
+    "points actually stated - do NOT add information, opinions, or conclusions "
+    "the text does not contain. Keep it much shorter than the original while "
+    "preserving every concrete fact, number, name, and requirement. Return ONLY "
+    "the summary, nothing else."
+)
+
 _MEETING_ACTIONS = (
     "You extract action items from a raw voice dictation made during or after a "
     "meeting. Output ONLY a bullet list (one `- ` per line) of concrete action "
@@ -141,7 +150,7 @@ _MEETING_ACTIONS = (
 # Presets that need no per-user free-text instruction. "custom" and "email"
 # (sign-off name) read `custom_instruction` themselves.
 _FIXED_STYLES = {"prompt": _PROMPT, "code_comment": _CODE_COMMENT,
-                 "meeting_actions": _MEETING_ACTIONS}
+                 "meeting_actions": _MEETING_ACTIONS, "summarise": _SUMMARISE}
 
 
 def _style_system(style: str = "tidy", custom_instruction: str = "") -> str:

--- a/wisprlite/config.py
+++ b/wisprlite/config.py
@@ -210,6 +210,7 @@ class Config:
     read_aloud_ocr_language: str = "" # "" = user's profile languages
     read_aloud_clipboard: bool = True # also copy the recognized text; never silent about it
     read_aloud_quiet_with_screenreader: bool = False  # default OFF: speak even with NVDA/JAWS running
+    read_aloud_last_mode: str = "read_all"  # read_all | summarise - remembered, highlighted next time
 
     @property
     def meetings_keep(self) -> int:

--- a/wisprlite/overlay.py
+++ b/wisprlite/overlay.py
@@ -46,6 +46,7 @@ ACCENT = {
     "meeting": PALETTE["meeting"],
     "screenrec": PALETTE["meeting"],
     "reading": PALETTE["done"],
+    "ra_choice": PALETTE["done"],
 }
 
 
@@ -171,6 +172,12 @@ class Overlay:
     def show_screenrec(self) -> None:
         """Show the recording pill. Its clock and buttons poll the recorder."""
         self._q.put(("screenrec", None, ""))
+
+    def show_ra_choice(self, estimate: str, default_mode: str) -> None:
+        """Read all vs Summarise, decided at the moment of reading.
+        `default_mode` (the remembered last choice) only decides which button
+        is highlighted - Enter/the hotkey always resolve to Read all."""
+        self._q.put(("ra_choice", default_mode or "read_all", estimate or ""))
 
     # ---- tkinter thread ---------------------------------------------------
     def _run(self) -> None:
@@ -322,6 +329,13 @@ class Overlay:
                         st["screenrec_phase"] = "recording"
                         resize(WIN_H)
                         reveal()
+                    elif kind == "ra_choice":
+                        st["name"] = "ra_choice"
+                        st["text"] = text or ""
+                        st["ra_choice_default"] = state or "read_all"
+                        st["hide_at"] = 0.0
+                        resize(WIN_H)
+                        reveal()
                     elif kind == "meeting":
                         st["name"] = "meeting"
                         st["text"] = ""
@@ -376,7 +390,7 @@ class Overlay:
                 except Exception:
                     phase = "recording"
                 resize(self.SCREENREC_H.get(phase, WIN_H))
-            elif st["name"] == "reading":
+            elif st["name"] in ("reading", "ra_choice"):
                 resize(self.SCREENREC_H["done"])   # same taller pill, same button row
             if st["visible"]:
                 self._draw(canvas, st)
@@ -409,6 +423,9 @@ class Overlay:
             return
         if st["name"] == "reading":
             self._draw_reading(c, st, H, accent)
+            return
+        if st["name"] == "ra_choice":
+            self._draw_ra_choice(c, st, H, accent)
             return
         self._draw_status(c, st, H, accent)
 
@@ -633,6 +650,8 @@ class Overlay:
     # drawn as the primary action - it's the one you reach for in a hurry.
     READING_BUTTONS = (("ra_pause", "Pause"), ("ra_restart", "Restart"),
                         ("ra_stop", "Stop"))
+    # Read-all-vs-summarise choice, shown once per read before speech starts.
+    RA_CHOICE_BUTTONS = (("ra_read_all", "Read all"), ("ra_summarise", "Summarise"))
     DONE_BTN_H, DONE_BTN_Y = 30, 62
     DONE_GAP, DONE_EDGE = 8, 8
     SCREENREC_H = {"recording": WIN_H, "naming": 88, "working": WIN_H, "done": 100}
@@ -672,12 +691,22 @@ class Overlay:
             # speaker and pushes the real state back via set_reading_paused,
             # so a Space keypress and a button click cannot disagree.
             return self._reading_hit(x, y)
+        if name == "ra_choice":
+            return self._ra_choice_hit(x, y)
         return ""
 
     def _reading_hit(self, x, y) -> str:
         """Which reading-pill button a click at (x, y) landed on, or ""."""
         for index, (action, _label) in enumerate(self.READING_BUTTONS):
             x1, y1, x2, y2 = self._done_button_box(index, self.READING_BUTTONS)
+            if x1 <= x <= x2 and y1 <= y <= y2:
+                return action
+        return ""
+
+    def _ra_choice_hit(self, x, y) -> str:
+        """Which read-mode button a click at (x, y) landed on, or ""."""
+        for index, (action, _label) in enumerate(self.RA_CHOICE_BUTTONS):
+            x1, y1, x2, y2 = self._done_button_box(index, self.RA_CHOICE_BUTTONS)
             if x1 <= x <= x2 and y1 <= y <= y2:
                 return action
         return ""
@@ -890,6 +919,33 @@ class Overlay:
                         text="Resume" if st.get("reading_paused") else "Pause")
         c.itemconfigure(items["reading_ra_stop_bg"], fill=accent)
         c.itemconfigure(items["reading_ra_stop_text"], fill="#1a0c0d")
+
+    def _draw_ra_choice(self, c, st, H: int, accent: str) -> None:
+        """Read all vs Summarise, decided at the moment of reading. The
+        remembered last choice is highlighted, but Read all is always what
+        Enter or the hotkey take - the fast path costs no extra decision."""
+        items = self._base_scene(c, st, "ra_choice", H, accent)
+        if "ra_choice_caption" not in items:
+            items["ra_choice_caption"] = c.create_text(
+                24, 22, anchor="w", fill=PALETTE["fg"], font=("Segoe UI Semibold", 10))
+            items["ra_choice_hint"] = c.create_text(
+                24, 40, anchor="w", fill=PALETTE["muted"], font=("Segoe UI", 8),
+                text="Enter or the hotkey reads all")
+            for index, (action, label) in enumerate(self.RA_CHOICE_BUTTONS):
+                x1, y1, x2, y2 = self._done_button_box(index, self.RA_CHOICE_BUTTONS)
+                items[f"{action}_bg"] = self._round_rect(
+                    c, x1, y1, x2, y2, 8, fill=PALETTE["card"], outline="")
+                items[f"{action}_text"] = c.create_text(
+                    (x1 + x2) // 2, (y1 + y2) // 2, text=label,
+                    fill=PALETTE["fg"], font=("Segoe UI", 9))
+        c.itemconfigure(items["ra_choice_caption"],
+                        text=self._fit(st["text"] or "How should this be read?", WIN_W - 48))
+        highlight = "ra_summarise" if st.get("ra_choice_default") == "summarise" else "ra_read_all"
+        for action, _label in self.RA_CHOICE_BUTTONS:
+            c.itemconfigure(items[f"{action}_bg"],
+                            fill=accent if action == highlight else PALETTE["card"])
+            c.itemconfigure(items[f"{action}_text"],
+                            fill="#1a0c0d" if action == highlight else PALETTE["fg"])
 
     def _draw_status(self, c, st, H: int, accent: str) -> None:
         items = self._base_scene(c, st, "status", H, accent)

--- a/wisprlite/readaloud.py
+++ b/wisprlite/readaloud.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import ctypes
 import logging
+import re
 import threading
 import time
 from typing import Callable, Optional
@@ -217,6 +218,85 @@ def ocr_png(png_bytes: bytes, *, language: str = "") -> str:
     return " ".join((text or "").split())
 
 
+# ---- chunking (long text vs. an engine's per-request character cap) -------
+
+_SENTENCE_SPLIT = re.compile(r"(?<=[.!?])\s+")
+_CLAUSE_SPLIT = re.compile(r"(?<=[,;:])\s+")
+
+
+def duration_estimate(char_count: int) -> str:
+    """A short warning line for a long read - `chars/5/150` minutes at ~150
+    words/minute, 5 characters/word. Empty at/under ~1,000 characters so a
+    short read stays quiet."""
+    if char_count <= 1000:
+        return ""
+    minutes = max(1, round(char_count / 5 / 150))
+    return f"Reading {char_count:,} characters — about {minutes} min"
+
+
+def _pack(pieces: list[str], limit: int) -> list[str]:
+    """Greedily pack already-limit-sized pieces into chunks under `limit`,
+    joined with a single space - the shared last step for both the sentence
+    pass and the clause/word fallback."""
+    chunks: list[str] = []
+    current = ""
+    for piece in pieces:
+        candidate = f"{current} {piece}".strip() if current else piece
+        if len(candidate) <= limit:
+            current = candidate
+        else:
+            if current:
+                chunks.append(current)
+            current = piece
+    if current:
+        chunks.append(current)
+    return chunks
+
+
+def _split_long_piece(text: str, limit: int) -> list[str]:
+    """One sentence longer than the limit still has to be spoken: fall back to
+    clause punctuation, then whitespace, then a hard cut. Never drops a chunk."""
+    safe: list[str] = []
+    for part in _CLAUSE_SPLIT.split(text):
+        if len(part) <= limit:
+            safe.append(part)
+            continue
+        # A clause over the limit is still many WORDS. Hard-cutting it here put
+        # a break mid-word, and _pack then rejoined with a space: "MqXXQagO"
+        # came back as "MqXXQ agO", which the voice reads as two words. Go down
+        # to words first.
+        for word in part.split(" "):
+            if len(word) <= limit:
+                safe.append(word)
+            else:
+                # A SINGLE word longer than the limit. Only here is a hard cut
+                # unavoidable, and only here can the text not round-trip.
+                safe.extend(word[i:i + limit] for i in range(0, len(word), limit))
+    return _pack(safe, limit)
+
+
+def split_into_chunks(text: str, limit: Optional[int]) -> list[str]:
+    """Split `text` into pieces each at most `limit` characters, breaking on
+    sentence boundaries first so nothing is cut mid-word. `limit` of None (the
+    Windows voice has no documented cap) returns the whole text as one chunk.
+
+    Concatenating the result with " ".join(...) reproduces the original words
+    in order - nothing is dropped or duplicated, only regrouped."""
+    text = " ".join((text or "").split())
+    if not text:
+        return []
+    if not limit or len(text) <= limit:
+        return [text]
+    sentences = _SENTENCE_SPLIT.split(text)
+    safe: list[str] = []
+    for sentence in sentences:
+        if len(sentence) <= limit:
+            safe.append(sentence)
+        else:
+            safe.extend(_split_long_piece(sentence, limit))
+    return _pack(safe, limit)
+
+
 # ---- speech ----------------------------------------------------------------
 
 class Speaker:
@@ -278,6 +358,41 @@ class Speaker:
                     self._player = None
             self._stop_player(player)
             raise
+
+    def speak_chunks(self, chunks: list[str], player_builder: Callable[[str], object]) -> None:
+        """Speak an ordered sequence of already-chunked pieces back to back
+        through this ONE Speaker, so Stop/Pause govern the whole read rather
+        than one fragment. `player_builder(chunk)` is called lazily, one piece
+        at a time - a stop between pieces breaks the loop before the next one
+        is built (or fetched from a cloud engine), so stopping never starts
+        the next chunk."""
+        chunks = [c for c in (chunks or []) if c]
+        if not chunks:
+            raise ReadAloudError("nothing to read")
+        for chunk in chunks:
+            with self._lock:
+                if self._stopped:
+                    return
+            try:
+                player = player_builder(chunk)
+            except ReadAloudError:
+                raise
+            except Exception as exc:
+                raise ReadAloudError(f"speech unavailable: {exc}") from exc
+            with self._lock:
+                if self._stopped:
+                    self._stop_player(player)
+                    return
+                self._player = player
+            try:
+                self._play(player)
+                self._await_end(player, chunk)
+            except Exception:
+                with self._lock:
+                    if self._player is player:
+                        self._player = None
+                self._stop_player(player)
+                raise
 
     def pause(self) -> None:
         with self._lock:
@@ -486,6 +601,73 @@ def build_speaker(text: str, cfg) -> tuple["Speaker", str]:
                 f"{type(exc).__name__} — using the Windows voice instead")
 
     return Speaker(rate=rate, player_factory=lambda: player), ""
+
+
+def build_chunked_speaker(text: str, cfg) -> tuple["Speaker", list[str], Callable[[str], object], str]:
+    """The chunked sibling of `build_speaker`: same tier dispatch and the same
+    fallback-to-Windows-on-any-failure contract, but for a full read instead of
+    the Settings preview's one fixed sentence. Returns the Speaker, its
+    sentence-safe chunks, a per-chunk player builder (called lazily by
+    `Speaker.speak_chunks`), and a fallback reason (empty on success).
+    """
+    tier = (getattr(cfg, "read_aloud_tts", "") or "windows").strip().lower()
+    rate = getattr(cfg, "read_aloud_rate", 1.0)
+
+    if tier == "windows":
+        speaker = Speaker(voice=getattr(cfg, "read_aloud_voice", ""), rate=rate)
+        return speaker, split_into_chunks(text, None), speaker._build_player, ""
+
+    from . import config as _config
+    from . import tts_cloud
+
+    if tier == "deepgram":
+        limit = tts_cloud.DEEPGRAM_MAX_CHARS
+    elif tier == "elevenlabs":
+        limit = tts_cloud.ELEVENLABS_MAX_CHARS
+    else:
+        speaker = Speaker(voice="", rate=rate)
+        return (speaker, split_into_chunks(text, None), speaker._build_player,
+                f"unknown voice engine {tier!r} — using the Windows voice instead")
+
+    def synth(chunk: str) -> tuple[bytes, str]:
+        if tier == "deepgram":
+            return tts_cloud.deepgram_speak(
+                chunk,
+                getattr(cfg, "read_aloud_voice", "") or tts_cloud.DEFAULT_DEEPGRAM_VOICE,
+                getattr(cfg, "read_aloud_deepgram_key", "") or _config.deepgram_key()), "audio/wav"
+        return tts_cloud.elevenlabs_speak(
+            chunk,
+            getattr(cfg, "read_aloud_elevenlabs_voice_id", ""),
+            getattr(cfg, "read_aloud_elevenlabs_key", "") or _config.elevenlabs_key()), "audio/mpeg"
+
+    chunks = split_into_chunks(text, limit)
+    try:
+        # Synthesize the FIRST chunk now, same as build_speaker, so a dead key
+        # or no network is caught before anything plays rather than mid-read.
+        first_audio, content_type = synth(chunks[0])
+        first_player = _winrt_player_from_bytes(first_audio, content_type)
+    except tts_cloud.CloudTTSError as exc:
+        speaker = Speaker(voice="", rate=rate)
+        return (speaker, split_into_chunks(text, None), speaker._build_player,
+                f"{exc} — using the Windows voice instead")
+    except Exception as exc:
+        log.exception("read-aloud: cloud voice failed, falling back")
+        speaker = Speaker(voice="", rate=rate)
+        return (speaker, split_into_chunks(text, None), speaker._build_player,
+                f"{type(exc).__name__} — using the Windows voice instead")
+
+    served = {"player": first_player}
+
+    def player_builder(chunk: str):
+        # speak_chunks calls this once per chunk, in order - the first call is
+        # always chunks[0], already fetched above to detect a dead key early.
+        if served["player"] is not None:
+            player, served["player"] = served["player"], None
+            return player
+        audio, content_type = synth(chunk)
+        return _winrt_player_from_bytes(audio, content_type)
+
+    return Speaker(rate=rate), chunks, player_builder, ""
 
 
 # ---- screen reader detection (informational only — never gates speaking) -----

--- a/wisprlite/tts_cloud.py
+++ b/wisprlite/tts_cloud.py
@@ -33,6 +33,13 @@ DEEPGRAM_VOICES = [
 ]
 DEFAULT_DEEPGRAM_VOICE = "aura-2-draco-en"
 
+# Per-engine input caps, in characters. Deepgram Aura-2 hard-fails (413) above
+# 2000; 1900 leaves headroom. ElevenLabs' own limit varies by plan (free tier
+# is 2,500-5,000 depending on model) - 5000 is the conservative floor so a
+# free-tier key doesn't 400 mid-chunk.
+DEEPGRAM_MAX_CHARS = 1900
+ELEVENLABS_MAX_CHARS = 5000
+
 
 def _post_for_audio(url: str, headers: dict, payload: dict, *, timeout: float, label: str) -> bytes:
     data = json.dumps(payload).encode("utf-8")


### PR DESCRIPTION
James: *"it's kind of like missing out whole sentences. Is it doing some sort of polish?"* — **No.** Nothing in this path summarises. Text was being lost.

### Confirmed bug: no chunking, and the engines have hard caps
Deepgram Aura-2 caps input at **2000 characters** and returns **413 — "the audio file will not be created"**. Nothing chunked, so every long read on Deepgram failed to the Windows voice. Text is now split on sentence boundaries under each engine's own cap and spoken back to back through one Speaker, so Stop and Pause still govern the whole read.

### The review find that mattered more than the feature
**The chunker corrupted words.** An over-long *clause* was hard-cut at the character limit and the pieces rejoined with a space, so `MqXXQagO` came back as `MqXXQ agO` — two words to a voice. A property test over random text failed on **132 of 400** inputs, against a docstring claiming "nothing is cut mid-word".

Now clauses → words, hard-cutting only a single word longer than the entire limit, where a cut is unavoidable. **0 failures in 2000 inputs**, and that property test is in the suite.

### Also
- The pill warns before a long read ("Reading 4,200 characters — about 5 min"), silent under ~1,000 so short reads stay quiet.
- **Summarise as a choice at the pill**, not a setting. **Read all** is the default that Enter and the hotkey take; Summarise is a deliberate click through the existing `cleanup.clean()` with a new style — not a second LLM path. A failed summarise **reads the full text and says so**; a truncated summary passed off as the whole thing would be the reported bug wearing a feature's clothes.

### Does not fix what James saw
This only fires above 1900 characters and garbles words rather than dropping sentences. The clipboard holds exactly what OCR produced, so his paste settles whether OCR is the culprit — deliberately not guessed at.

### Verification
**543 passing under xvfb**, same 15 pre-existing failures. Six sabotages verified red. Jury found no correctness or security issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)