### PR TITLE
fix(screenrec): abort when the encoder dies; traceback; name saved narration (2.49.1)

### DIFF
--- a/tests/test_screenrec.py
+++ b/tests/test_screenrec.py
@@ -827,3 +827,61 @@ def test_two_frames_in_the_same_millisecond_get_distinct_timestamps():
     assert seen == sorted(set(seen)), \
         f"timestamps were not strictly increasing: {seen}"
     assert len(set(seen)) == 3, f"a duplicate PTS was emitted: {seen}"
+
+
+# -- a dead encoder must not masquerade as a live recording -------------------
+
+def test_a_grab_loop_crash_flags_video_failed_and_logs_the_traceback(caplog):
+    import logging
+    import types
+
+    with tempfile.TemporaryDirectory() as tmp:
+        rec = _recording(tmp)
+        def explode():
+            raise RuntimeError("boom at frame 0")
+
+        fake_mss = types.SimpleNamespace(mss=explode)
+        with patch.dict(sys.modules, {"mss": fake_mss}), \
+                caplog.at_level(logging.INFO, logger="wisprlite"):
+            rec._grab_loop()
+        assert rec.video_failed.is_set()
+        assert any("boom at frame 0" in r.message for r in caplog.records)
+        # The traceback names the raising line; the message alone never did.
+        assert any(r.exc_info and r.exc_info[0] is RuntimeError for r in caplog.records)
+
+
+def test_stop_names_the_saved_narration_when_the_mux_fails():
+    with tempfile.TemporaryDirectory() as tmp:
+        rec = _recording(tmp)
+        _feed(rec, _frames(3))
+        _write_wav(rec.audio_path, 0.5)
+        with patch.object(rec, "_mux", return_value=None):
+            assert rec.stop() is None
+        assert rec.audio_path.exists()
+        assert any("narration saved" in e and rec.audio_path.name in e for e in rec.errors)
+
+
+def test_the_pill_tick_aborts_a_recording_whose_video_died():
+    import types
+
+    from uistub import install_platform_stubs
+
+    install_platform_stubs()
+    from wisprlite.app import App
+
+    app = App.__new__(App)
+    rec = types.SimpleNamespace(
+        elapsed=lambda: 3.2, paused=False, video_failed=threading.Event())
+    app._screenrec = rec
+    app._screenrec_ui = types.SimpleNamespace(snapshot=lambda: {"phase": "recording"})
+    calls = []
+    app.toggle_screen_recording = lambda: calls.append("stop")
+
+    app._screenrec_overlay_state()
+    assert calls == []                     # healthy: nothing happens
+    rec.video_failed.set()
+    app._screenrec_overlay_state()
+    assert calls == ["stop"]
+    app._screenrec = None                  # what the finish path does first
+    app._screenrec_overlay_state()
+    assert calls == ["stop"]               # never a second stop

--- a/vault/Architecture/audio-pipeline.md
+++ b/vault/Architecture/audio-pipeline.md
@@ -105,6 +105,26 @@ James's machine.
 
 ## Finishing a screen recording
 
+### A dead encoder must not look like a live recording (v2.49.1)
+
+2026-09-08: an 8-minute narration produced a 3-second clip. The grab loop died
+on frame ~36 with `ArgumentError: Invalid argument ... returned 22` from
+libx264/mp4, the mic kept recording (49 MB wav, intact), and the pill sat on
+"recording" for eight minutes because nothing was watching the grab thread.
+Root cause of the errno 22 is still unknown — the error was logged without a
+traceback. Local repro: only a backwards PTS gives that exact error, and
+`_encode_frame` already clamps PTS strictly increasing.
+
+- `_record_error` logs `exc_info`, so the next failure names the raising line.
+- `ScreenRecording.video_failed` (Event) is set when the grab loop dies. The
+  pill's state provider (`_screenrec_overlay_state`) sees it and runs the
+  normal stop path — same route as the hotkey, so the error, the agent
+  waiter and the saved files are handled in one place.
+- `stop()` appends `narration saved: <wav>` to `errors` when the mux fails
+  but the wav exists. The wav is never deleted on a failed mux; recover with
+  `ffmpeg -i x.wav -af loudnorm -c:a aac x.m4a` and transcribe via Deepgram.
+
+
 The order matters, and it was wrong until v2.42.0.
 
 `_finish_screen_recording` ran **mux → name → transcribe → send → show buttons**

--- a/wisprlite/__init__.py
+++ b/wisprlite/__init__.py
@@ -1,3 +1,3 @@
 """Pipevoice — push-to-talk voice typing for Windows."""
 
-__version__ = "2.49.0"
+__version__ = "2.49.1"

--- a/wisprlite/app.py
+++ b/wisprlite/app.py
@@ -849,7 +849,22 @@ class App:
                 info["paused"] = recording.paused
             except Exception:
                 pass
+            if recording.video_failed.is_set():
+                self._abort_failed_screen_recording(recording)
         return info
+
+    def _abort_failed_screen_recording(self, recording) -> None:
+        """The encoder died mid-recording: stop NOW and say so.
+
+        Called from the pill's redraw, so it runs within a frame of the failure
+        instead of whenever the user next presses Stop. Same finish path as the
+        hotkey, so the error, the saved narration and any waiting agent are all
+        handled in one place.
+        """
+        if self._screenrec is not recording:
+            return
+        log.error("screenrec: video stopped after %.1fs, aborting", recording.elapsed())
+        self.toggle_screen_recording()
 
     def _ask_name_in_pill(self, default: str) -> str:
         """Show the name field IN the pill and wait for Save or Skip.
@@ -998,7 +1013,7 @@ class App:
             self._screenrec_ui.update(phase="working", status="Wrapping up the video\u2026")
             video = recording.stop()
             if video is None:
-                self._fail("screen recording: " + "; ".join(recording.errors[:2]))
+                self._fail("screen recording: " + "; ".join(recording.errors[:3]))
                 return
 
             # Named AFTER the fact: the moment you want to hit record is the

--- a/wisprlite/screenrec.py
+++ b/wisprlite/screenrec.py
@@ -65,6 +65,10 @@ class ScreenRecording:
         self.stem = _stamp()
 
         self._stop = threading.Event()
+        # Set when the grab loop dies. The mic keeps going, so the pill would
+        # otherwise sit on "recording" while nothing is being filmed — that is
+        # how eight minutes of narration once produced a 3-second clip.
+        self.video_failed = threading.Event()
         self._threads: list[threading.Thread] = []
         self._audio_queue: queue.Queue = queue.Queue(maxsize=AUDIO_QUEUE_LIMIT)
         self._wave: wave.Wave_write | None = None
@@ -139,7 +143,11 @@ class ScreenRecording:
         if not self.frames_written:
             self._record_error(RuntimeError("no frames captured"))
             return None
-        return self._mux()
+        video = self._mux()
+        if video is None and self.audio_path.exists():
+            # The narration is intact even when the picture is not; say where.
+            self.errors.append(f"narration saved: {self.audio_path.name}")
+        return video
 
     def rename(self, stem: str) -> None:
         """Give the finished files a new stem, keeping every extension."""
@@ -176,7 +184,9 @@ class ScreenRecording:
     def _record_error(self, exc: Exception) -> None:
         message = f"{type(exc).__name__}: {exc}"
         self.errors.append(message)
-        log.info("screenrec: %s", message)
+        # With the traceback: the message alone ("Invalid argument ... 22")
+        # could not say whether the encoder or the muxer raised it.
+        log.info("screenrec: %s", message, exc_info=exc)
 
     # -- video ---------------------------------------------------------------
 
@@ -276,6 +286,7 @@ class ScreenRecording:
                         next_at = time.monotonic()
         except Exception as exc:
             self._record_error(exc)
+            self.video_failed.set()
             if not self.frames_written:
                 # The container was opened but never took a frame, so stop()
                 # skips the mux and leaves an unplayable stub sitting in the


### PR DESCRIPTION
An 8-minute narration produced a 3-second clip: the grab loop died at ~3s (errno 22 from libx264/mp4), the mic kept recording, and the pill showed "recording" for eight minutes. The error was logged without a traceback, so the raising line is still unknown.

- `_record_error` logs `exc_info` → next failure names the line
- `ScreenRecording.video_failed` set when the grab loop dies; the pill tick runs the normal stop path within a frame
- `stop()` appends `narration saved: <wav>` when the mux fails but the wav is intact

Tests: 3 new, each verified by sabotage (each product line removed → exactly one test fails). Full suite: only the 15 pre-existing failures (test_env_precedence, test_transcribe_window). Jury (MiniMax): no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)