### PR TITLE
feat(read-aloud): keep the last OCR text beside the log (2.49.2)

### DIFF
--- a/tests/test_readaloud_last_text.py
+++ b/tests/test_readaloud_last_text.py
@@ -1,0 +1,11 @@
+
+
+def test_keep_last_text_writes_the_ocr_output_beside_the_log(tmp_path, caplog):
+    import logging
+
+    from wisprlite import readaloud
+
+    with caplog.at_level(logging.INFO, logger="wisprlite"):
+        readaloud.keep_last_text("hello there world", tmp_path / "cfg")
+    assert (tmp_path / "cfg" / "read-aloud-last.txt").read_text(encoding="utf-8") == "hello there world"
+    assert any("17 chars, 3 words" in r.message for r in caplog.records)

--- a/wisprlite/__init__.py
+++ b/wisprlite/__init__.py
@@ -1,3 +1,3 @@
 """Pipevoice — push-to-talk voice typing for Windows."""
 
-__version__ = "2.49.1"
+__version__ = "2.49.2"

--- a/wisprlite/app.py
+++ b/wisprlite/app.py
@@ -407,6 +407,7 @@ class App:
             return
 
         self._read_aloud_last_text = text
+        readaloud.keep_last_text(text, config.config_dir())
         mode = self._ask_read_mode_in_pill(len(text))
         self._read_aloud_speak(text, mode)
 

--- a/wisprlite/readaloud.py
+++ b/wisprlite/readaloud.py
@@ -739,3 +739,20 @@ def main() -> None:
         except Exception as exc:      # never let reporting change the verdict
             print(f"(could not write {out}: {exc})")
     sys.exit(0 if ok else 1)
+
+
+def keep_last_text(text: str, folder) -> None:
+    """Write what OCR produced to read-aloud-last.txt beside the log.
+
+    When a read comes out as nonsense there is no way to tell whether OCR
+    misread the screen or the voice mangled good text. The file answers that;
+    the log line gives the size without the content.
+    """
+    try:
+        from pathlib import Path
+
+        Path(folder).mkdir(parents=True, exist_ok=True)
+        (Path(folder) / "read-aloud-last.txt").write_text(text, encoding="utf-8")
+        log.info("read-aloud: OCR produced %d chars, %d words", len(text), len(text.split()))
+    except Exception as exc:
+        log.info("read-aloud: could not keep the last text: %s", exc)


### PR DESCRIPTION
Read Aloud produced 'random vowels' near the end of a read; nothing recorded what OCR gave the voice. Now writes read-aloud-last.txt next to pipevoice.log and logs char/word counts. One test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)